### PR TITLE
README now includes Browser Support detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Temporary compiled CSS URL: http://content-style-guide.apps.staging.digital.gov.
 
 This version of the CSS has not yet been cleaned up fully. It also needs to be abstracted out of the content guide.
 
+## Browser Support
+
+The UI components are built on a solid HTML foundation, progressively enhanced to provide core experiences across browsers. All users get critical information and experiences. New browsers get the prettiest experiences, while older browsers get less pretty, but usable ones. If JavaScript fails, users will still get a robust HTML foundation.
+
 ### Future
 
 You will be able to the framework in one of two ways:


### PR DESCRIPTION
I've borrowed directly from the (public domain) 18F Web Design Standards, and I propose we revisit to add more detail as we carry out testing:

https://standards.usa.gov/getting-started/
