### PR TITLE
Make HTML validator optional

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -8,7 +8,7 @@ var gulp = require('gulp'),
     gitVersion = require('gulp-gitversion'),
     scssMerge = require('./lib/gulp-scss-merge.js'),
     uglify = require('gulp-uglify'),
-    del = require('del')
+    del = require('del'),
     runSequence = require('run-sequence')
     ;
 
@@ -101,10 +101,21 @@ gulp.task('nginx', function () {
         .pipe(gulp.dest(paths.outputHTML));
 });
 
-gulp.task('htmlvalidate', ['examples','styleguide'], function () {
-    validator = require('gulp-html')
-    return gulp.src(['build/*.html', 'build/**/*.html'])
-        .pipe(validator({'verbose': true}));
+gulp.task('htmlvalidate', ['examples','styleguide'], function (cb) {
+    try {
+        validator = require('gulp-html')
+        return gulp.src(['build/*.html', 'build/**/*.html'])
+            .pipe(validator({'verbose': true}));
+    } catch (err) {
+        if (err.code == 'MODULE_NOT_FOUND') {
+            console.log("WARNING: optional HTML validator not installed, to resolve run:");
+            console.log("> npm install AusDTO/gulp-html");
+            return cb;
+        }
+        else {
+            throw err
+        }
+    }
 });
 
 gulp.task('styleguide', function () {

--- a/bin/cibuild.sh
+++ b/bin/cibuild.sh
@@ -4,6 +4,7 @@
 set -eo pipefail
 
 gem install scss_lint scss_lint_reporter_checkstyle
+npm install AusDTO/gulp-html
 npm install
 # do linting, build scss into css, minify and generate styleguide
-./node_modules/.bin/gulp ui-kit build.prod
+./node_modules/.bin/gulp build.prod

--- a/package.json
+++ b/package.json
@@ -1,25 +1,20 @@
 {
   "name": "gov-au-ui-kit",
-  "version": "1.0.0",
-  "description": "An example module to illustrate the usage of a package.json",
-  "author": "Your Name <you.name@example.org>",
-  "contributors": [
-    {
-      "name": "Foo Bar",
-      "email": "foo.bar@example.com"
-    }
-  ],
+  "version": "0.1.2",
+  "description": "GOV.AU UI framework, using Bourbon and Neat",
+  "author": "GOV.AU UI Kit team <ui-kit-announce@digital.gov.au>",
+  "homepage": "https://gov-au-ui-kit.apps.staging.digital.gov.au/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/nodejitsu/browsenpm.org"
+    "url": "https://github.com/AusDTO/gov-au-ui-kit"
   },
   "bugs": {
-    "url": "https://github.com/nodejitsu/browsenpm.org/issues"
+    "url": "https://github.com/AusDTO/gov-au-ui-kit/issues"
   },
   "keywords": [
-    "nodejitsu",
-    "example",
-    "browsenpm"
+    "ui",
+    "scss",
+    "js"
   ],
   "preferGlobal": true,
   "license": "MIT",
@@ -28,7 +23,6 @@
     "gulp-autoprefixer": "^3.1.0",
     "gulp-cssnano": "^2.1.2",
     "gulp-gitversion": "^0.0.8",
-    "gulp-html": "AusDTO/gulp-html",
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.3.1",
     "gulp-scss-lint": "^0.4.0",


### PR DESCRIPTION
For the integration of jQuery, I added [Subresource integrity attributes](https://www.w3.org/TR/SRI/) which are valid HTML5 but aren't detected by gulp-html because they were [only added to the validator relatively recently](https://github.com/validator/validator/issues/151). So I forked gulp-html to update the validator but now it can take ages/fail to complete npm install because it's having to download 20MB from github. Even using Github tarballs didn't seem to speed it up that much. 
I revisited https://www.npmjs.com/package/gulp-htmltidy and https://www.npmjs.com/package/gulp-html-validator but they have their own problems (former isn't actually validation, latter just uses API which pushes network problems to build stage).

So... HTML validation is now optional for local production builds. Real production builds will have the HTML validator so we're still checking that but a little later in the workflow.

Fixes #34
