### PR TITLE
.abstract now extends h4, and set back to base-font-weight

### DIFF
--- a/assets/sass/_typography.scss
+++ b/assets/sass/_typography.scss
@@ -261,7 +261,9 @@ dt {
 //
 // For abstracts or page introductory paragraphs.
 .abstract {
-  font-size: rem(24);
+  @extend h4;
+
+  font-weight: $base-font-weight;
 }
 
 // Quotations


### PR DESCRIPTION
tl;dr: `.abstract` class (which is used in a few places, eg page `header` `.tagline`) was previously set to a `rem(24)`, and out of sync with the type scale. I set it to extend `h4`, and then undid the bolding.

I noticed this while going through the type sizing table with @joolswood. We have updated the documentation in his branch to reflect this PR.
