### PR TITLE
Switches Lato to Open Sans

### DIFF
--- a/assets/sass/_typography.scss
+++ b/assets/sass/_typography.scss
@@ -28,7 +28,7 @@ The framework is currently testing the open source [Open Sans font family](https
 
 - regular 400
 - regular 400 italic
-- regular bold
+- regular 600 bold
 
 The framework is likely to change to a different primary typeface. We are currently testing the use of webfonts generally.
 
@@ -44,16 +44,16 @@ $base-monospace: 'Lucida Sans Typewriter', 'Lucida Console', Monaco, 'Bitstream 
 
 Despite not having decided on a webfont the font stacks should achieve a high degree of coverage across a range of browsers and operating systems using the fall-backs (roughly 95% coverage).
 
-Currently you will need to `link` to Work Sans via the HTML `head` to support Internet Explorer.
+Currently you will need to `link` to Open Sans via the HTML `head` to support Internet Explorer.
 
 ### Pairing style examples
-#### Work Sans regular 400
+#### Open Sans regular 400
 
 <p class="abstract">ABCDEFGHIJKLMNOPQRSTUVWXYZ<br />
 abcdefghijklmnopqrstuvwxyz<br />
 1234567890(!@#s%g.,?:;)</p>
 
-#### Work Sans bold 400
+#### Open Sans bold 400
 
 <p class="abstract"><strong>ABCDEFGHIJKLMNOPQRSTUVWXYZ<br />
 abcdefghijklmnopqrstuvwxyz<br />

--- a/assets/sass/_typography.scss
+++ b/assets/sass/_typography.scss
@@ -24,36 +24,36 @@ Style guide: Typography
 /*
 Typeface
 
-The framework is currently testing the open source [Lato font family](http://www.latofonts.com/) in 3 styles:
+The framework is currently testing the open source [Open Sans font family](https://www.google.com/fonts/specimen/Open+Sans) in 3 styles:
 
 - regular 400
-- italic 400
-- regular 700.
+- regular 400 italic
+- regular bold
 
 The framework is likely to change to a different primary typeface. We are currently testing the use of webfonts generally.
 
-If we choose to use webfonts we provide optimisation.
+We aim to spend a spike in the future to properly test and optimise any usage of webfonts.
 
 ### Font stacks
 
 ```
 $base-serif: 'Book Antiqua', Georgia, 'Bitstream Vera Serif', serif;
-$base-sans-serif: 'Lato', Geneva, Verdana, 'Bitstream Vera Sans', sans-serif;
+$base-sans-serif: 'Open Sans', Geneva, Verdana, 'Bitstream Vera Sans', sans-serif;
 $base-monospace: 'Lucida Sans Typewriter', 'Lucida Console', Monaco, 'Bitstream Vera Sans Mono', monospace;
 ```
 
 Despite not having decided on a webfont the font stacks should achieve a high degree of coverage across a range of browsers and operating systems using the fall-backs (roughly 95% coverage).
 
-Currently you will need to `link` to Lato via the HTML `head` to support Internet Explorer.
+Currently you will need to `link` to Work Sans via the HTML `head` to support Internet Explorer.
 
 ### Pairing style examples
-#### Lato regular
+#### Work Sans regular 400
 
 <p class="abstract">ABCDEFGHIJKLMNOPQRSTUVWXYZ<br />
 abcdefghijklmnopqrstuvwxyz<br />
 1234567890(!@#s%g.,?:;)</p>
 
-#### Lato bold
+#### Work Sans bold 400
 
 <p class="abstract"><strong>ABCDEFGHIJKLMNOPQRSTUVWXYZ<br />
 abcdefghijklmnopqrstuvwxyz<br />
@@ -61,20 +61,19 @@ abcdefghijklmnopqrstuvwxyz<br />
 
 We will provide a full HTML test page showing all possible pairings.
 
-Style guide: Typography.1 Lato typeface
+Style guide: Typography.1 Open Sans typeface
 */
 
-@import url('https://fonts.googleapis.com/css?family=Lato:700,400italic,400&subset=latin,latin-ext');
+@import url('https://fonts.googleapis.com/css?family=Open+Sans:400italic,600,400&subset=latin,latin-ext');
 
 $base-serif: 'Book Antiqua', Georgia, 'Bitstream Vera Serif', serif;
-$base-sans-serif: 'Lato', Verdana, 'Bitstream Vera Sans', sans-serif;
+$base-sans-serif: 'Open Sans', Verdana, 'Bitstream Vera Sans', sans-serif;
 $base-monospace: 'Lucida Sans Typewriter', 'Lucida Console', Monaco, 'Bitstream Vera Sans Mono', monospace;
 
 $base-font-family: $base-sans-serif;
 
-// Not actually sure if Lato 700 is being applied...
 strong {
-  font-weight: 700;
+  font-weight: 600;
 }
 
 /*

--- a/examples/index.html
+++ b/examples/index.html
@@ -34,9 +34,9 @@
           src="//cdnjs.cloudflare.com/ajax/libs/corysimmons-selectivizr2/1.0.8/selectivizr2.min.js"></script>
   <script type="text/javascript"
           src="//cdnjs.cloudflare.com/ajax/libs/livingston-css3-mediaqueries-js/1.0.0/css3-mediaqueries.js"></script>
-  <link href="//fonts.googleapis.com/css?family=Lato:700" rel="stylesheet">
-  <link href="//fonts.googleapis.com/css?family=Lato:400italic" rel="stylesheet">
-  <link href="//fonts.googleapis.com/css?family=Lato:400" rel="stylesheet">
+  <link href="//fonts.googleapis.com/css?family=Open+Sans:400&subset=latin,latin-ext" rel='stylesheet'>
+  <link href="//fonts.googleapis.com/css?family=Open+Sans:400italic&subset=latin,latin-ext" rel='stylesheet'>
+  <link href="//fonts.googleapis.com/css?family=Open+Sans:600&subset=latin,latin-ext" rel='stylesheet'>
   <![endif]-->
   <!--[if lte IE 9]>
   <script type='text/javascript' src='//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js'></script>

--- a/kss-builder/index.hbs
+++ b/kss-builder/index.hbs
@@ -10,6 +10,28 @@
 
   <link rel="stylesheet" href="kss-assets/kss.css">
   {{{styles}}}
+
+  <!--[if (gte IE 9) | (!IE)]>-->
+  <script src="//code.jquery.com/jquery-3.0.0.min.js" integrity="sha256-JmvOoLtYsmqlsWxa7mDSLMwa6dZ9rrIdtrrVYRnDRH0="
+          crossorigin="anonymous"></script>
+  <!--<![endif]-->
+  <!--[if lt IE 9]>
+  <script src="//code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ="
+          crossorigin="anonymous"></script>
+  <script type="text/javascript"
+          src="//cdnjs.cloudflare.com/ajax/libs/corysimmons-selectivizr2/1.0.8/selectivizr2.min.js"></script>
+  <script type="text/javascript"
+          src="//cdnjs.cloudflare.com/ajax/libs/livingston-css3-mediaqueries-js/1.0.0/css3-mediaqueries.js"></script>
+  <link href="//fonts.googleapis.com/css?family=Open+Sans:400&subset=latin,latin-ext" rel='stylesheet'>
+  <link href="//fonts.googleapis.com/css?family=Open+Sans:400italic&subset=latin,latin-ext" rel='stylesheet'>
+  <link href="//fonts.googleapis.com/css?family=Open+Sans:600&subset=latin,latin-ext" rel='stylesheet'>
+  <![endif]-->
+  <!--[if lte IE 9]>
+  <script type='text/javascript' src='//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js'></script>
+  <script type='text/javascript'
+          src='//cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.3/jquery.xdomainrequest.min.js'></script>
+  <![endif]-->
+  
 </head>
 <body id="kss-node">
 


### PR DESCRIPTION
Reasons:
- tested Work Sans (nice x-height; poor kerning; too monospace-y; large asset size)
- tested Source Sans Pro and Lato against the webfont used in the gov.au alpha (Open Sans)

Results from that test:
- optically larger than Lato, and less dense than Source Sans Pro
- smallest asset file size of the three

Decided to go with Open Sans until we do a proper spike on typography and webfont testing. 
