### PR TITLE
Removing mention of Geneva in the sans-serif font stack -- not used.

### DIFF
--- a/assets/sass/_typography.scss
+++ b/assets/sass/_typography.scss
@@ -38,7 +38,7 @@ We aim to spend a spike in the future to properly test and optimise any usage of
 
 ```
 $base-serif: 'Book Antiqua', Georgia, 'Bitstream Vera Serif', serif;
-$base-sans-serif: 'Open Sans', Geneva, Verdana, 'Bitstream Vera Sans', sans-serif;
+$base-sans-serif: 'Open Sans', Verdana, 'Bitstream Vera Sans', sans-serif;
 $base-monospace: 'Lucida Sans Typewriter', 'Lucida Console', Monaco, 'Bitstream Vera Sans Mono', monospace;
 ```
 


### PR DESCRIPTION
Just a content change in the KSS — removes mention of Geneva, which is unused.
