### PR TITLE
Improves readme -- cleans up, extends a bit, improv. syntax, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,12 @@ You should use this with the [draft **Content Style Guide**](http://content-styl
 
 ## <a name="building"></a>Build the scss yourself
 
-Install system dependencies:
+We have a build process for the development of the framework which uses gulp on node.js.
+
+To build it yourself, begin by installing the system dependencies:
 - Node.js v5.0.0
 
-Install dependencies:
+Install node package dependencies:
 
 ```
 npm install
@@ -86,10 +88,10 @@ Some of the key libraries we use are:
 ## Make gov-au-ui-kit better
 
 - Create a new [**GitHub issue**](https://github.com/AusDTO/gov-au-ui-kit/issues/new), or comment on [existing issues](https://github.com/AusDTO/gov-au-ui-kit/issues)
-- Contribute to this repository. You should understand the [*Contributor Code of Conduct*](https://github.com/AusDTO/gov-au-ui-kit/blob/master/code_of_conduct.md) and [our *Conventions*](conventions.md), including [Block Element Modifier](http://getbem.com/), first
-- Contact us on slack in #govau-uikit.
+- Contribute to this repository. Please see the [**Contributor Code of Conduct**](https://github.com/AusDTO/gov-au-ui-kit/blob/master/code_of_conduct.md) and [our code **Conventions**](conventions.md), (also see [Block Element Modifier](http://getbem.com/)), first
+- Contact us on slack in `#govau-uikit`.
 
-## Roadmap
+## Project goal
 
 This framework is in active development.
 
@@ -99,21 +101,25 @@ Goal: build a lean and frugal CSS/SCSS framework to make building GOV.AU easier.
 - allow for easier rapid prototyping directly in the browser
 - shouldn't get in the way of customised design needs.
 
-**Releases:** see [RELEASING.md](RELEASING.md) and [CHANGELOG.md](CHANGELOG.md)
+### Releases
+
+See [RELEASING.md](RELEASING.md) and [CHANGELOG.md](CHANGELOG.md).
 
 We aim to provide stable, usable releases at the end of each sprint.
 
+### Deprecation
+
 We are wary about breaking changes. We will work to ensure we will gracefully deprecate any changes that cause things to break.
 
-We may create an installer wrapper, or release via git submodules.
+### Installer/wrapper
 
-We have a build process for the development of the framework which uses gulp on node.js (see [Build the scss yourself](#building))
+We may create an installer wrapper (likely node-based), or release via git submodules.
 
 ## Milestones
 
 ### 1st general goal
 
-Meet the general look and feel of the gov.au alpha.
+Meet the general look and feel of the [gov.au alpha](http://gov.au/alpha), with room for some improvements.
 
 This will allow us to establish the basics of the framework while meeting a relatively easily met static target.
 

--- a/README.md
+++ b/README.md
@@ -6,30 +6,27 @@
 
 UI Kit (`gov-au-ui-kit`) is 3 things:
 
-1. a design guide to build an accessible standardised look and feel for GOV.AU projects: [gov-au-ui-kit.apps.staging.digital.gov.au](http://gov-au-ui-kit.apps.staging.digital.gov.au/)
+1. a draft design guide to build an accessible standardised look and feel for GOV.AU projects: [gov-au-ui-kit.apps.staging.digital.gov.au](http://gov-au-ui-kit.apps.staging.digital.gov.au/)
 2. common-use templates (to come)
 3. a lean and frugal CSS/SCSS framework (found in `assets/sass/`) that you can
   - link to as a precompiled minified file:
   ```
   <link rel="stylesheet" type="text/css" href="//gov-au-ui-kit.apps.staging.digital.gov.au/latest/ui-kit.min.css"/>
   ```
-  - download & include the complete SCSS framework in your asset pipeline to use the inbuilt mixins/extends for prototyping & building:
+  - download and include the complete SCSS framework in your asset pipeline to use the inbuilt mixins/extends for prototyping and building:
   ```
   https://gov-au-ui-kit.apps.staging.digital.gov.au/latest/_ui-kit.scss
   ```
 
-We have [an example page showing the full framework](https://gov-au-ui-kit.apps.staging.digital.gov.au/) for staging.
-
 ### Features & browser support
 
-- [Normalize](https://necolas.github.io/normalize.css/) (to make browsers render all elements more consistently).
-- Bourbon 4.2.7
-- Neat
-- a grid framework with some good defaults
-- basic styling for content with some good typographic coverage
-- basic styling for UI elements (eg `input`, `label`, etc.)
-- UI components build on solid HTML foundation. If JavaScript fails users will still get a robust HTML foundation.
-- Progressively enhanced to provide core experiences across browsers. All users get critical information and an accessible site. Users with newer browsers get a better looking site.
+- [Normalize](https://necolas.github.io/normalize.css/).
+- Bourbon, version 4.2.7.
+- Neat, and settings for a grid framework with some good defaults.
+- Basic styling for content with some good typographic coverage.
+- Basic styling for UI elements (eg `input`, `label`, etc.).
+- UI components build on solid HTML foundation.
+- Built on a [philosophy of progressive enhancement](https://en.wikipedia.org/wiki/Progressive_enhancement) (as opposed to [graceful degradation](https://en.wikipedia.org/wiki/Fault_tolerance)).
 
 ## What this isn't
 
@@ -45,7 +42,7 @@ The [Digital Service Standard](https://www.dto.gov.au/standard/) requires teams 
 
 You should use this with the [draft **Content Style Guide**](http://content-style-guide.apps.staging.digital.gov.au/) for Digital Transformation Office projects.
 
-## <a name="building"></a>Build the scss yourself
+## Build the SCSS yourself
 
 We have a build process for the development of the framework which uses gulp on node.js.
 
@@ -87,8 +84,8 @@ Some of the key libraries we use are:
 
 ## Make gov-au-ui-kit better
 
-- Create a new [**GitHub issue**](https://github.com/AusDTO/gov-au-ui-kit/issues/new), or comment on [existing issues](https://github.com/AusDTO/gov-au-ui-kit/issues)
-- Contribute to this repository. Please see the [**Contributor Code of Conduct**](https://github.com/AusDTO/gov-au-ui-kit/blob/master/code_of_conduct.md) and [our code **Conventions**](conventions.md), (also see [Block Element Modifier](http://getbem.com/)), first
+- Create a new [**GitHub issue**](https://github.com/AusDTO/gov-au-ui-kit/issues/new), or comment on [existing issues](https://github.com/AusDTO/gov-au-ui-kit/issues).
+- Contribute to this repository. Please see the [**Contributor Code of Conduct**](https://github.com/AusDTO/gov-au-ui-kit/blob/master/code_of_conduct.md) and [our code **Conventions**](conventions.md), (also see [Block Element Modifier](http://getbem.com/)), first.
 - Contact us on slack in `#govau-uikit`.
 
 ## Project goal

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gov-au-ui-kit
+# `gov-au-ui-kit`
 
 [![CircleCI](https://circleci.com/gh/AusDTO/gov-au-ui-kit.svg?style=svg)](https://circleci.com/gh/AusDTO/gov-au-ui-kit)
 

--- a/README.md
+++ b/README.md
@@ -4,31 +4,36 @@
 
 ## What is this?
 
-gov-au-ui-kit is 3 things:
+UI Kit (`gov-au-ui-kit`) is 3 things:
 
-- draft design guide to build an accessible standardised look and feel for GOV.AU projects: http://gov-au-ui-kit.apps.staging.digital.gov.au/
-- templates (to come)
-- a lean and frugal CSS/SCSS framework (`assets/sass`) that you can
+1. a design guide to build an accessible standardised look and feel for GOV.AU projects: [gov-au-ui-kit.apps.staging.digital.gov.au](http://gov-au-ui-kit.apps.staging.digital.gov.au/)
+2. common-use templates (to come)
+3. a lean and frugal CSS/SCSS framework (found in `assets/sass/`) that you can
   - link to as a precompiled minified file:
   ```
   <link rel="stylesheet" type="text/css" href="//gov-au-ui-kit.apps.staging.digital.gov.au/latest/ui-kit.min.css"/>
   ```
-  - download from https://gov-au-ui-kit.apps.staging.digital.gov.au/latest/_ui-kit.scss to use in your asset pipeline (this includes [Normalize](https://necolas.github.io/normalize.css/), [Bourbon](https://github.com/thoughtbot/bourbon) sass mixin library and the [Neat](https://github.com/thoughtbot/neat) lightweight grid framework).
+  - download & include the complete SCSS framework in your asset pipeline to use the inbuilt mixins/extends for prototyping & building:
+  ```
+  https://gov-au-ui-kit.apps.staging.digital.gov.au/latest/_ui-kit.scss
+  ```
 
-Look at an [example page showing the full framework](https://gov-au-ui-kit.apps.staging.digital.gov.au/).
+We have [an example page showing the full framework](https://gov-au-ui-kit.apps.staging.digital.gov.au/) for staging.
 
 ### Features & browser support
 
-- Normalize (to make browsers render all elements more consistently).
-- Lightweight extensible grid framework with some good defaults.
-- Basic styling for content with some typographic defaults.
-- Basic styling for UI elements (e.g. `input`).
+- [Normalize](https://necolas.github.io/normalize.css/) (to make browsers render all elements more consistently).
+- Bourbon 4.2.7
+- Neat
+- a grid framework with some good defaults
+- basic styling for content with some good typographic coverage
+- basic styling for UI elements (eg `input`, `label`, etc.)
 - UI components build on solid HTML foundation. If JavaScript fails users will still get a robust HTML foundation.
 - Progressively enhanced to provide core experiences across browsers. All users get critical information and an accessible site. Users with newer browsers get a better looking site.
 
 ## What this isn't
 
-This is not yet a complete design system. This is the starting point that will develop with your help.
+This is not yet a complete design or design system. This is the starting point that will develop with your help.
 
 ## Who is this for?
 
@@ -38,7 +43,7 @@ Teams building Australian Government sites. This was designed for GOV.AU teams, 
 
 The [Digital Service Standard](https://www.dto.gov.au/standard/) requires teams to [build services using common design patterns](https://www.dto.gov.au/standard/6-consistent-and-responsive/). This is draft work on the framework and guidance that will eventually become the design patterns for digital content.
 
-You should use this with the [draft Content Style Guide](http://content-style-guide.apps.staging.digital.gov.au/) for Digital Transformation Office projects.
+You should use this with the [draft **Content Style Guide**](http://content-style-guide.apps.staging.digital.gov.au/) for Digital Transformation Office projects.
 
 ## <a name="building"></a>Build the scss yourself
 
@@ -68,20 +73,20 @@ This is available as a shell script at `bin/cibuild.sh`.
 
 ### Dependencies
 
-We use Bourbon 4.2.7. We include its scss files directly rather than calling it via its node package. Bourbon and Neat live under `/assets/sass/vendor`.
+We use Bourbon 4.2.7. We include its `.scss` files directly rather than calling it via its node (or gem) package. Bourbon and Neat live under `/assets/sass/vendor`.
 
 Some of the key libraries we use are:
-- "gulp": "^3.9.1",
-- "gulp-sass": "^2.3.1",
-- "kss": "^3.0.0-beta.14",
-- "sass-lint": "^1.7.0"
+- `gulp ^3.9.1`
+- `gulp-sass ^2.3.1`
+- `kss ^3.0.0-beta.14`
+- `sass-lint ^1.7.0`
 
 `^` = compatible with version (see [semver](https://docs.npmjs.com/misc/semver#caret-ranges-123-025-004)).
 
 ## Make gov-au-ui-kit better
 
-- Create a new [GitHub issue](https://github.com/AusDTO/gov-au-ui-kit/issues/new), or comment on [existing issues](https://github.com/AusDTO/gov-au-ui-kit/issues).
-- Contribute to this repository. You should understand the [Contributor Code of Conduct](https://github.com/AusDTO/gov-au-ui-kit/blob/master/code_of_conduct.md) and [our conventions](conventions.md), including [Block Element Modifier](http://getbem.com/), first.
+- Create a new [**GitHub issue**](https://github.com/AusDTO/gov-au-ui-kit/issues/new), or comment on [existing issues](https://github.com/AusDTO/gov-au-ui-kit/issues)
+- Contribute to this repository. You should understand the [*Contributor Code of Conduct*](https://github.com/AusDTO/gov-au-ui-kit/blob/master/code_of_conduct.md) and [our *Conventions*](conventions.md), including [Block Element Modifier](http://getbem.com/), first
 - Contact us on slack in #govau-uikit.
 
 ## Roadmap
@@ -106,24 +111,30 @@ We have a build process for the development of the framework which uses gulp on 
 
 ## Milestones
 
-### 1st milestone
+### 1st general goal
 
-Meet the general look and feel of the gov.au alpha. This will allow us to establish the basics of the framework while meeting a relatively easily met static target.
+Meet the general look and feel of the gov.au alpha.
+
+This will allow us to establish the basics of the framework while meeting a relatively easily met static target.
 
 We are focused on:
 
+- establishing the basic framework
 - provide UI styling for `input`, `label`, etc.
 - styling for other buttons, next/previous, etc.
 - some sane basics for high level block elements inc. `main`, `article`, `header`, and `footer`
-- styling for primary and secondary `nav`
-- styling for calendars.
+- styling for primary and secondary `nav`.
 
-### 2nd milestone
+### Future… (coming roadmap)
 
 Iterate in 2 ways:
 
 - look and feel under the direction of the designers from the GOV.AU Guides team
-- styling for commonly used and requested things that builders from other Digital Transformation Office teams need.
+- styling for commonly used and requested things that builders from other Digital Transformation Office teams need, including:
+  - styling for calendars
+  - styling for common web application elements
+  - extensive testing
+  - templates.
 
 ## Copyright & license
 

--- a/kss-builder/index.hbs
+++ b/kss-builder/index.hbs
@@ -56,7 +56,7 @@
   <section class="hero">
     <div class="wrapper">
       <a href="/" class="site-title">{{options.title}}</a>
-      <p class="tagline">A living style guide of <code>gov-au-ui-kit</code>, built using <a href="http://warpspire.com/kss/"><abbr title="Knyle Style Sheets">KSS</abbr>.</p>
+      <p class="tagline">A living style guide of <code>gov-au-ui-kit</code>, built using <a href="http://warpspire.com/kss/"><abbr title="Knyle Style Sheets">KSS</abbr></a>.</p>
       <p>Last updated: <time datetime="{{moment "" ""}}">{{moment "" "DD MMMM Y"}}</time></p>
     </div>
   </section>

--- a/kss-builder/index.hbs
+++ b/kss-builder/index.hbs
@@ -56,7 +56,7 @@
   <section class="hero">
     <div class="wrapper">
       <a href="/" class="site-title">{{options.title}}</a>
-      <p class="tagline">A living style guide of the ui-kit, built using KSS.</p>
+      <p class="tagline">A living style guide of <code>gov-au-ui-kit</code>, built using <a href="http://warpspire.com/kss/"><abbr title="Knyle Style Sheets">KSS</abbr>.</p>
       <p>Last updated: <time datetime="{{moment "" ""}}">{{moment "" "DD MMMM Y"}}</time></p>
     </div>
   </section>

--- a/kss-builder/index.hbs
+++ b/kss-builder/index.hbs
@@ -68,7 +68,7 @@
     <nav class="primary-nav" aria-label="main navigation">
       <ul>
         <li>
-          <a href="/">Welcome</a>
+          <a href="/">Getting started</a>
         </li>
         {{#each menu}}
           <li>


### PR DESCRIPTION
@hannah-ustwo Hey. I had a quick pass over this and improved a few things. Happy to simplify this radically if we need to for the web site homepage — we can do the same to the `README.md` (currently pulled in as the homepage), which is the main doc page on GitHub.
