### PR TITLE
Removes pairings from typography docs and guide heading change.

### DIFF
--- a/assets/sass/_typography.scss
+++ b/assets/sass/_typography.scss
@@ -65,26 +65,6 @@ Style guide: Typography.1 Typeface.1 Font stacks
 */
 
 /*
-Pairing style examples
-
-#### Open Sans regular 400
-
-<p class='abstract'>ABCDEFGHIJKLMNOPQRSTUVWXYZ<br />
-abcdefghijklmnopqrstuvwxyz<br />
-1234567890(!@#s%g.,?:;)</p>
-
-#### Open Sans bold 400
-
-<p class='abstract'><strong>ABCDEFGHIJKLMNOPQRSTUVWXYZ<br />
-abcdefghijklmnopqrstuvwxyz<br />
-1234567890(!@#s%g.,?:;)</strong></p>
-
-We will provide a full HTML test page showing all possible pairings.
-
-Style guide: Typography.1 Typeface.2 Pairing style examples
-*/
-
-/*
 Breakpoints
 
 - Mobile (extra small devices): 4 columns, 420px maximum

--- a/kss-builder/index.hbs
+++ b/kss-builder/index.hbs
@@ -45,7 +45,7 @@
   <section class="govau--header">
     <div class="wrapper">
       <div class="govau--logo">
-        <a href="#" class="logo">gov.au</a> <span class="badge--alpha">alpha</span>
+        <a href="#" class="logo">gov.au ui-kit</a> <span class="badge--default">draft</span>
       </div>
       <div class="feedback">
         <a href="https://github.com/AusDTO/gov-au-ui-kit/issues" class="button--feedback">Give feedback</a>


### PR DESCRIPTION
Out of QA review work between @joolswood and myself.
