### PR TITLE
Wrapping forms documentation examples in form tags.

### DIFF
--- a/assets/sass/_forms.scss
+++ b/assets/sass/_forms.scss
@@ -66,7 +66,7 @@ form {
   Markup:
   <form>
     <label for="name">Enter your name</label>
-    <span class="hint">Your name is on your birth certificate</span>
+    <span class="hint" id="name-hint">Your name is on your birth certificate</span>
     <input type="text" id="name" aria-describedby="name-hint" />
   </form>
 
@@ -92,11 +92,11 @@ form {
     </p>
     <p>
       <label>An invalid field:</label>
-      <input type="text" class="invalid"/>
+      <input type="text" class="invalid" />
     </p>
     <p>
       <label>A disabled field:</label>
-      <input type="text" disabled/>
+      <input type="text" disabled />
     </p>
   </form>
 

--- a/assets/sass/_forms.scss
+++ b/assets/sass/_forms.scss
@@ -43,9 +43,12 @@ form {
   /*
   Label
 
-  Used to tell the user what to enter into the field
+  Used to tell the user what to enter into the field.
 
-  Markup: <label>Enter your name</label>
+  Markup:
+  <form>
+    <label>Enter your name</label>
+  </form>
 
   Style guide: Forms.Label
   */
@@ -57,11 +60,13 @@ form {
   /*
   Hint text
 
-  An optional extra descriptor for the input field
+  An optional extra descriptor for the input field.
 
   Markup:
-  <span class="hint" id="name-hint">Your name is on your birth certificate</span>
-  <input type="text" id="name" aria-describedby="name-hint" />
+  <form>
+    <label class="hint" for="name" id="name-hint">Your name is on your birth certificate</label>
+    <input type="text" id="name" aria-describedby="name-hint" />
+  </form>
 
   Style guide: Forms.HintText
   */
@@ -75,13 +80,17 @@ form {
   /*
   Text input
 
-  A single line text input
+  A single line text input.
 
-  Markup: <input type="text" />
+  Markup:
+  <form>
+    <input type="text" />
+    <input type="text" disabled/>
+  </form>
 
   :focus - When a user has entered the field with the cursor or mouse
-  :invalid  - When a form is submitted with an invalid value
-  :disabled - When an input has the `disabled` attribute
+  .invalid  - When a form is submitted with an invalid value
+  disabled - When an input has the `disabled` attribute
 
   Style guide: Forms.TextInput
   */
@@ -95,13 +104,16 @@ form {
   /*
   Textarea input
 
-  A multi-line text input
+  A multi-line text input.
 
-  Markup: <textarea></textarea>
+  Markup:
+  <form>
+    <textarea></textarea>
+  </form>
 
   :focus - When a user has entered the field with the cursor or mouse
-  :invalid  - When a form is submitted with an invalid value
-  :disabled - When an input has the `disabled` attribute
+  .invalid  - When a form is submitted with an invalid value
+  disabled - When an input has the `disabled` attribute
 
   Style guide: Forms.TextAreaInput
   */

--- a/assets/sass/_forms.scss
+++ b/assets/sass/_forms.scss
@@ -64,7 +64,8 @@ form {
 
   Markup:
   <form>
-    <label class="hint" for="name" id="name-hint">Your name is on your birth certificate</label>
+    <label for="name">Enter your name</label>
+    <span class="hint">Your name is on your birth certificate</span>
     <input type="text" id="name" aria-describedby="name-hint" />
   </form>
 
@@ -84,13 +85,15 @@ form {
 
   Markup:
   <form>
-    <input type="text" />
-    <input type="text" disabled/>
+    <p>
+      <label>A text input field:</label>
+      <input type="text" />
+    </p>
+    <p>
+      <label>A disabled field:</label>
+      <input type="text" disabled/>
+    </p>
   </form>
-
-  :focus - When a user has entered the field with the cursor or mouse
-  .invalid  - When a form is submitted with an invalid value
-  disabled - When an input has the `disabled` attribute
 
   Style guide: Forms.TextInput
   */
@@ -104,22 +107,20 @@ form {
   /*
   Textarea input
 
-  A multi-line text input.
+  A multi-line text input that can be resised vertically by the user.
 
   Markup:
   <form>
+    <label>An input for longer responses:</label>
     <textarea></textarea>
   </form>
-
-  :focus - When a user has entered the field with the cursor or mouse
-  .invalid  - When a form is submitted with an invalid value
-  disabled - When an input has the `disabled` attribute
 
   Style guide: Forms.TextAreaInput
   */
 
   textarea {
     @extend %base-text-input;
+    resize: vertical;
   }
 
 }

--- a/assets/sass/_forms.scss
+++ b/assets/sass/_forms.scss
@@ -16,7 +16,8 @@ Style guide: Forms
   background-color: $background-colour;
   padding: $tiny-spacing;
 
-  &:invalid {
+  &:invalid,
+  &.invalid {
     outline: 2px solid $error-colour;
   }
 
@@ -88,6 +89,10 @@ form {
     <p>
       <label>A text input field:</label>
       <input type="text" />
+    </p>
+    <p>
+      <label>An invalid field:</label>
+      <input type="text" class="invalid"/>
     </p>
     <p>
       <label>A disabled field:</label>


### PR DESCRIPTION
@maxious @petronbot I wrapped these in `<form>` to make them render mostly right, but I haven’t wrangled with them fully to make all the various states work automatically via KSS (notably `:focus`, `.invalid` (?), and `disabled`).
