### PR TITLE
Feature/navigation visual update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,8 +69,7 @@ Markup changes:
 
 - Add new `<script>` tag to load Google Web Font Loader into `<head>`
 
-### 1.0.0 - 2016-06-29
-
+### 1.0.0 - 2016-06-30
 Guide MVP is now live ([1]).
 
 Adds:

--- a/assets/js/ui-kit.js
+++ b/assets/js/ui-kit.js
@@ -4,14 +4,13 @@
 
     /**
      * Initialise the Global Nav collapse behaviour
-     * @param {array} elems - list of collapsible elements
+     * @param {array} elems - array of HTMLCollections representing collapsible elements
      */
     init: function(elems) {
+      console.log(elems);
       for (var i = 0; i < elems.length; i++) {
-        if (elems[i] !== null) {
-          this.initPanel(elems[i]);
-          this.initToggle(elems[i]);
-        }
+        this.initPanel(elems[i]);
+        this.initToggle(elems[i]);
       }
     },
 
@@ -20,8 +19,9 @@
      * @param {object} elem - the containing DOMElement
      */
     initPanel: function(elem) {
-      var panelLabel = elem.dataset.label || elem.className;
+      var panelLabel = elem.dataset ? elem.dataset.label ? elem.dataset.label : elem.className : elem.className;
 
+      console.log(elem);
       elem.id = panelLabel;
       elem.setAttribute('aria-expanded', 'false');
     },
@@ -61,10 +61,7 @@
 
   // Kick of the JavaScript party when the DOM is ready
   document.addEventListener('DOMContentLoaded', function() {
-    CollapsibleNav.init([
-      document.getElementsByClassName('global-nav').item(0),
-      document.getElementsByClassName('local-nav').item(0)
-    ]);
+    CollapsibleNav.init(document.querySelectorAll('.global-nav, .local-nav'));
   });
 
 })(document);

--- a/assets/sass/_colours.scss
+++ b/assets/sass/_colours.scss
@@ -222,6 +222,7 @@ $frame-colour:                  $light-grey;
 $primary-colour:                $light-navy;
 $highlight-colour:              $aqua;
 $focus-colour:                  $light-aqua;
+$nav-focus-colour:              $lighter-aqua;
 $error-colour:                  $red;
 $success-colour:                $green;
 

--- a/assets/sass/_colours.scss
+++ b/assets/sass/_colours.scss
@@ -247,3 +247,4 @@ $controls-bg-colour:            $dark-navy;
 $controls-contrast-bg-colour:   $dark-maroon;
 $header-bg-colour:              $navy;
 $hero-bg-colour:                $aqua;
+$breadcrumbs-bg-colour:         $non-white;

--- a/assets/sass/_colours.scss
+++ b/assets/sass/_colours.scss
@@ -173,7 +173,7 @@ $aqua:          #18788d;
 $dark-aqua:     darken($aqua, 5%);
 $darker-aqua:   darken($aqua, 10%);
 $light-aqua:    lighten($aqua, 30%);
-$lighter-aqua:  #ddf2f8;
+$lighter-aqua:  lighten($aqua, 60%);
 
 $navy:          #224a61;
 $dark-navy:     darken($navy, 10%);

--- a/assets/sass/_colours.scss
+++ b/assets/sass/_colours.scss
@@ -173,6 +173,7 @@ $aqua:          #18788d;
 $dark-aqua:     darken($aqua, 5%);
 $darker-aqua:   darken($aqua, 10%);
 $light-aqua:    lighten($aqua, 30%);
+$lighter-aqua:  #ddf2f8;
 
 $navy:          #224a61;
 $dark-navy:     darken($navy, 10%);

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -259,7 +259,8 @@ Style guide: Navigation.2 Local Navigation
     &:active,
     &.active,
     &.is-active {
-      background-color: $nav-focus-colour;
+      border-color: $border-contrast-colour;
+      background-color: $lighter-aqua;
     }
 
   }

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -253,13 +253,12 @@ Style guide: Navigation.2 Local Navigation
 
     &:hover {
       border-color: $border-contrast-colour;
-      background-color: $nav-focus-colour;
+      background-color: $lighter-aqua;
     }
 
     &:active,
     &.active,
     &.is-active {
-      border-color: $border-contrast-colour;
       background-color: $lighter-aqua;
     }
 

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -259,13 +259,13 @@ Style guide: Navigation.2 Local Navigation
 
     &:hover {
       border-color: $border-contrast-colour;
-      background-color: $lighter-aqua;
+      background-color: $nav-focus-colour;
     }
 
     &:active,
     &.active,
     &.is-active {
-      background-color: $lighter-aqua;
+      background-color: $nav-focus-colour;
     }
 
   }

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -349,7 +349,7 @@ Style guide: Navigation.3 Breadcrumbs
       margin: 0;
       padding: 0;
       color: $white;
-      font-size: rem(14);
+      font-size: rem(16);
 
       a {
         color: $white;

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -341,7 +341,7 @@ Style guide: Navigation.3 Breadcrumbs
       margin: 0;
       padding: 0;
       color: $white;
-      font-size: rem(16);
+      font-size: rem(14);
 
       a {
         color: $white;

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -301,6 +301,11 @@ Style guide: Navigation.2 Local Navigation
       background-color: $dark-aqua;
       color: $white;
       padding: $medium-spacing / 2 $small-spacing;
+
+      &:hover {
+        border-color: $dark-aqua;
+        background-color: $dark-aqua;
+      }
     }
 
   }

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -360,7 +360,7 @@ Style guide: Navigation.3 Breadcrumbs
       a {
         color: $white;
       }
-
+      
       a:hover {
         border-bottom-color: $white;
       }

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -249,7 +249,7 @@ Style guide: Navigation.2 Local Navigation
     background-color: $background-colour;
     text-decoration: none;
     color: $non-black;
-    font-size: rem(14);
+    font-size: rem(16);
 
     &:hover {
       border-color: $border-contrast-colour;
@@ -341,7 +341,7 @@ Style guide: Navigation.3 Breadcrumbs
       margin: 0;
       padding: 0;
       color: $white;
-      font-size: rem(14);
+      font-size: rem(16);
 
       a {
         color: $white;

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -257,10 +257,14 @@ Style guide: Navigation.2 Local Navigation
 
     font-size: rem(14);
 
+    &:hover {
+      border-color: $border-contrast-colour;
+      background-color: $lighter-aqua;
+    }
+
     &:active,
     &.active,
     &.is-active {
-      border-color: $border-contrast-colour;
       background-color: $lighter-aqua;
     }
 

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -245,7 +245,7 @@ Style guide: Navigation.2 Local Navigation
     display: block;
     border: none;
     border-left: 4px solid transparent;
-    padding: $tiny-spacing $small-spacing;
+    padding: $medium-spacing / 2 $small-spacing;
     background-color: $background-colour;
     text-decoration: none;
     color: $non-black;

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -331,7 +331,8 @@ Style guide: Navigation.3 Breadcrumbs
 
   ul {
     margin: 0;
-    padding: $small-spacing 0;
+    padding: .5 * $medium-spacing 0;
+    line-height: $medium-spacing;
     list-style: none;
 
     li {
@@ -340,7 +341,7 @@ Style guide: Navigation.3 Breadcrumbs
       padding: 0;
       color: $white;
       font-size: rem(14);
-      
+
       a {
         color: $white;
       }

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -249,12 +249,13 @@ Style guide: Navigation.2 Local Navigation
     background-color: $background-colour;
     text-decoration: none;
     color: $non-black;
-    font-size: rem(16);
 
     &:hover {
       border-color: $border-contrast-colour;
       background-color: $nav-focus-colour;
     }
+
+    font-size: rem(14);
 
     &:active,
     &.active,

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -331,7 +331,7 @@ Style guide: Navigation.3 Breadcrumbs
 
   ul {
     margin: 0;
-    padding: .5 * $medium-spacing 0;
+    padding: .5 * $medium-spacing 0 .6 * $medium-spacing;
     line-height: $medium-spacing;
     list-style: none;
 

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -253,13 +253,13 @@ Style guide: Navigation.2 Local Navigation
 
     &:hover {
       border-color: $border-contrast-colour;
-      background-color: $lighter-aqua;
+      background-color: $nav-focus-colour;
     }
 
     &:active,
     &.active,
     &.is-active {
-      background-color: $lighter-aqua;
+      background-color: $nav-focus-colour;
     }
 
   }

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -328,6 +328,7 @@ Style guide: Navigation.3 Breadcrumbs
 
 [class^='breadcrumbs'] {
   display: none;
+  width: 100%;
   margin: 0;
   background-color: $aqua;
   color: $body-inverted-text-colour;

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -261,7 +261,7 @@ Style guide: Navigation.2 Local Navigation
     &.active,
     &.is-active {
       border-color: $border-contrast-colour;
-      background-color: $background-contrast-colour;
+      background-color: $lighter-aqua;
     }
 
   }

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -297,7 +297,10 @@ Style guide: Navigation.2 Local Navigation
 
   .nav-heading {
     @include media($tablet) {
-      display: none;
+      display: block;
+      background-color: $dark-aqua;
+      color: $white;
+      padding: $medium-spacing / 2 $small-spacing;
     }
 
   }

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -347,7 +347,7 @@ Style guide: Navigation.3 Breadcrumbs
 
   ul {
     margin: 0;
-    padding: .5 * $medium-spacing 0 .6 * $medium-spacing;
+    padding: .75 * $medium-spacing 0 .8 * $medium-spacing;
     line-height: $medium-spacing;
     list-style: none;
 

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -299,6 +299,7 @@ Style guide: Navigation.2 Local Navigation
     @include media($tablet) {
       display: none;
     }
+
   }
 }
 

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -355,12 +355,12 @@ Style guide: Navigation.3 Breadcrumbs
       margin: 0;
       padding: 0;
       color: $white;
-      font-size: rem(16);
+      font-size: rem(14);
 
       a {
         color: $white;
       }
-      
+
       a:hover {
         border-bottom-color: $white;
       }

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -347,7 +347,7 @@ Style guide: Navigation.3 Breadcrumbs
 
   ul {
     margin: 0;
-    padding: .75 * $medium-spacing 0 .8 * $medium-spacing;
+    padding: $small-spacing 0 .8 * $medium-spacing;
     line-height: $medium-spacing;
     list-style: none;
 

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -302,17 +302,18 @@ Style guide: Navigation.2 Local Navigation
   }
 
   .nav-heading {
-    @include media($tablet) {
-      display: block;
+    display: block;
+    background-color: $dark-aqua;
+    color: $white;
+    padding: $medium-spacing / 2 $small-spacing;
+
+    &:hover {
+      border-color: $dark-aqua;
       background-color: $dark-aqua;
-      color: $white;
-      padding: $medium-spacing / 2 $small-spacing;
+    }
 
-      &:hover {
-        border-color: $dark-aqua;
-        background-color: $dark-aqua;
-      }
-
+    @include media($tablet) {
+      display: none;
     }
   }
 }

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -223,7 +223,7 @@ Style guide: Navigation.2 Local Navigation
           @extend .icon-arrow-right;
           padding-left: $base-spacing + $small-spacing;
           background-repeat: no-repeat;
-          background-position: $base-spacing $small-spacing * 1.15;
+          background-position: $base-spacing $small-spacing * 1.45;
           background-size: $tiny-spacing auto;
         }
       }

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -307,11 +307,12 @@ Style guide: Navigation.2 Local Navigation
       background-color: $dark-aqua;
       color: $white;
       padding: $medium-spacing / 2 $small-spacing;
-
+      
       &:hover {
         border-color: $dark-aqua;
         background-color: $dark-aqua;
       }
+
     }
 
   }

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -322,7 +322,7 @@ Style guide: Navigation.3 Breadcrumbs
 [class^='breadcrumbs'] {
   display: none;
   margin: 0;
-  background-color: $non-white;
+  background-color: $aqua;
   color: $grey;
 
   @include media($tablet) {

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -255,7 +255,7 @@ Style guide: Navigation.2 Local Navigation
       background-color: $nav-focus-colour;
     }
 
-    font-size: rem(14);
+    font-size: rem(16);
 
     &:hover {
       border-color: $border-contrast-colour;
@@ -355,7 +355,7 @@ Style guide: Navigation.3 Breadcrumbs
       margin: 0;
       padding: 0;
       color: $white;
-      font-size: rem(14);
+      font-size: rem(16);
 
       a {
         color: $white;

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -260,7 +260,8 @@ Style guide: Navigation.2 Local Navigation
     &:active,
     &.active,
     &.is-active {
-      background-color: $nav-focus-colour;
+      border-color: $border-contrast-colour;
+      background-color: $lighter-aqua;
     }
 
   }

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -317,9 +317,11 @@ Breadcrumbs
 
 Use breadcrumbs to help the user understand where are in the service and how they got there.
 
-Breadcrumbs appear on an aqua background, and are positioned directly underneath a page header or hero.
+Default breadcrumbs appear on a light grey background, and are positioned directly underneath a page header or hero.
 
 Breadcrumbs are hidden on small screens, and only displayed at `$tablet` breakpoint or bigger.
+
+The inverted style (`.breadcrumbs--inverted`) can be used on a darker coloured background. Make sure you check the [colour contrast guidance](http://gov-au-ui-kit.dev/section-colours.html#kssref-colours-3-colour-contrast) before choosing a colour combination.
 
 Markup: templates/breadcrumbs.hbs
 
@@ -330,8 +332,8 @@ Style guide: Navigation.3 Breadcrumbs
   display: none;
   width: 100%;
   margin: 0;
-  background-color: $aqua;
-  color: $body-inverted-text-colour;
+  background-color: $background-contrast-colour;
+  color: $body-text-colour;
 
   @include media($tablet) {
     display: inline-block;
@@ -341,7 +343,7 @@ Style guide: Navigation.3 Breadcrumbs
   a:visited,
   a:hover,
   a:active {
-    color: $body-inverted-text-colour;
+  color: $body-text-colour;
   }
 
   ul {
@@ -356,12 +358,30 @@ Style guide: Navigation.3 Breadcrumbs
       padding: 0;
 
       &:not(:last-child) {
-        @extend .icon-arrow-right-white;
+        @extend .icon-arrow-right;
         margin-right: $small-spacing;
         padding-right: $medium-spacing;
         background-repeat: no-repeat;
         background-position: right;
         background-size: $tiny-spacing auto;
+      }
+    }
+  }
+  &[class$='--inverted'] {
+    background-color: transparent;
+    color: $body-inverted-text-colour;
+
+    a:link,
+    a:visited,
+    a:hover,
+    a:active {
+      color: $body-inverted-text-colour;
+    }
+
+    ul {
+      li:not(:last-child) {
+        @extend .icon-arrow-right-white;
+        color: $body-inverted-text-colour;
       }
     }
   }

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -251,11 +251,14 @@ Style guide: Navigation.2 Local Navigation
     color: $non-black;
     font-size: rem(14);
 
-    &:hover,
+    &:hover {
+      border-color: $border-contrast-colour;
+      background-color: $lighter-aqua;
+    }
+
     &:active,
     &.active,
     &.is-active {
-      border-color: $border-contrast-colour;
       background-color: $lighter-aqua;
     }
 

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -254,6 +254,7 @@ Style guide: Navigation.2 Local Navigation
     background-color: $background-colour;
     text-decoration: none;
     color: $non-black;
+    font-size: rem(14);
 
     &:hover,
     &:active,

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -255,13 +255,6 @@ Style guide: Navigation.2 Local Navigation
       background-color: $nav-focus-colour;
     }
 
-    font-size: rem(16);
-
-    &:hover {
-      border-color: $border-contrast-colour;
-      background-color: $nav-focus-colour;
-    }
-
     &:active,
     &.active,
     &.is-active {
@@ -324,11 +317,9 @@ Breadcrumbs
 
 Use breadcrumbs to help the user understand where are in the service and how they got there.
 
-Default breadcrumbs appear on a light grey background, and are positioned directly underneath a page header or hero.
+Breadcrumbs appear on an aqua background, and are positioned directly underneath a page header or hero.
 
-The global navigation breadcrumbs (with the attribute `aria-label='breadcrumb'`) are hidden on small screens, and only displayed at `$tablet` breakpoint or bigger.
-
-The inverted style can be used on a darker coloured background. Make sure you check the [colour contrast guidance](http://gov-au-ui-kit.dev/section-colours.html#kssref-colours-3-colour-contrast) before choosing a colour combination.
+Breadcrumbs are hidden on small screens, and only displayed at `$tablet` breakpoint or bigger.
 
 Markup: templates/breadcrumbs.hbs
 
@@ -339,10 +330,17 @@ Style guide: Navigation.3 Breadcrumbs
   display: none;
   margin: 0;
   background-color: $aqua;
-  color: $grey;
+  color: $body-inverted-text-colour;
 
   @include media($tablet) {
     display: inline-block;
+  }
+
+  a:link,
+  a:visited,
+  a:hover,
+  a:active {
+    color: $body-inverted-text-colour;
   }
 
   ul {
@@ -355,44 +353,14 @@ Style guide: Navigation.3 Breadcrumbs
       display: inline-block;
       margin: 0;
       padding: 0;
-      color: $white;
-      font-size: rem(16);
 
-      a {
-        color: $white;
-      }
-
-      a:hover {
-        border-bottom-color: $white;
-      }
-
-    }
-
-    li:not(:last-child) {
-      @extend .icon-arrow-right;
-      margin-right: $small-spacing;
-      padding-right: $medium-spacing;
-      background-repeat: no-repeat;
-      background-position: right;
-      background-size: $tiny-spacing auto;
-    }
-  }
-
-  &[class$='--inverted'] {
-    background-color: transparent;
-    color: $body-inverted-text-colour;
-
-    a:link,
-    a:visited,
-    a:hover,
-    a:active {
-      color: $body-inverted-text-colour;
-    }
-
-    ul {
-      li:not(:last-child) {
+      &:not(:last-child) {
         @extend .icon-arrow-right-white;
-        color: $body-inverted-text-colour;
+        margin-right: $small-spacing;
+        padding-right: $medium-spacing;
+        background-repeat: no-repeat;
+        background-position: right;
+        background-size: $tiny-spacing auto;
       }
     }
   }

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -347,6 +347,10 @@ Style guide: Navigation.3 Breadcrumbs
         color: $white;
       }
 
+      a:hover {
+        border-bottom-color: $white;
+      }
+
     }
 
     li:not(:last-child) {

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -339,7 +339,8 @@ Style guide: Navigation.3 Breadcrumbs
       margin: 0;
       padding: 0;
       color: $white;
-
+      font-size: rem(14);
+      
       a {
         color: $white;
       }

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -215,12 +215,7 @@ Style guide: Navigation.2 Local Navigation
       }
 
       a {
-        border-left: 1px solid transparent;
         padding-left: $base-spacing;
-
-        &:hover {
-          border-left: 1px solid $border-contrast-colour;
-        }
       }
 
       ul {
@@ -249,7 +244,7 @@ Style guide: Navigation.2 Local Navigation
   a {
     display: block;
     border: none;
-    border-left: 2px solid transparent;
+    border-left: 4px solid transparent;
     padding: $tiny-spacing $small-spacing;
     background-color: $background-colour;
     text-decoration: none;

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -338,6 +338,12 @@ Style guide: Navigation.3 Breadcrumbs
       display: inline-block;
       margin: 0;
       padding: 0;
+      color: $white;
+
+      a {
+        color: $white;
+      }
+
     }
 
     li:not(:last-child) {
@@ -347,7 +353,6 @@ Style guide: Navigation.3 Breadcrumbs
       background-repeat: no-repeat;
       background-position: right;
       background-size: $tiny-spacing auto;
-      color: $grey;
     }
   }
 

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -332,7 +332,7 @@ Style guide: Navigation.3 Breadcrumbs
   display: none;
   width: 100%;
   margin: 0;
-  background-color: $background-contrast-colour;
+  background-color: $breadcrumbs-bg-colour;
   color: $body-text-colour;
 
   @include media($tablet) {

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -307,14 +307,13 @@ Style guide: Navigation.2 Local Navigation
       background-color: $dark-aqua;
       color: $white;
       padding: $medium-spacing / 2 $small-spacing;
-      
+
       &:hover {
         border-color: $dark-aqua;
         background-color: $dark-aqua;
       }
 
     }
-
   }
 }
 

--- a/assets/sass/_page-header.scss
+++ b/assets/sass/_page-header.scss
@@ -35,6 +35,7 @@
   }
 
   [class^='breadcrumbs'] {
+    width: auto;
     margin-right: $small-spacing;
     background-color: transparent;
   }

--- a/assets/sass/_page-header.scss
+++ b/assets/sass/_page-header.scss
@@ -36,6 +36,7 @@
 
   [class^='breadcrumbs'] {
     margin-right: $small-spacing;
+    background-color: transparent;
   }
 
   [role='button'] {

--- a/assets/sass/templates/breadcrumbs.hbs
+++ b/assets/sass/templates/breadcrumbs.hbs
@@ -1,25 +1,9 @@
-<div class="bg-non-white">
-  <nav class="breadcrumbs" aria-label="breadcrumb">
-    <div class="wrapper">
-      <ul>
-        <li><a href="#" title="Home">Home</a></li>
-        <li><a href="#" title="Menu1">Menu1</a></li>
-        <li>Menu2</li>
-      </ul>
-    </div>
-  </nav>
-</div>
-
-<hr>
-
-<div class="bg-navy">
-  <nav class="breadcrumbs--inverted" aria-label="breadcrumb">
-    <div class="wrapper">
-      <ul>
-        <li><a href="#" title="Home">Home</a></li>
-        <li><a href="#" title="Menu1">Menu1</a></li>
-        <li>Menu2</li>
-      </ul>
-    </div>
-  </nav>
-</div>
+<nav class="breadcrumbs" aria-label="breadcrumb">
+  <div class="wrapper">
+    <ul>
+      <li><a href="#" title="Home">Home</a></li>
+      <li><a href="#" title="Menu1">Menu1</a></li>
+      <li>Menu2</li>
+    </ul>
+  </div>
+</nav>

--- a/assets/sass/templates/breadcrumbs.hbs
+++ b/assets/sass/templates/breadcrumbs.hbs
@@ -7,3 +7,17 @@
     </ul>
   </div>
 </nav>
+
+<hr>
+
+<div class="bg-dark-navy">
+  <nav class="breadcrumbs--inverted" aria-label="breadcrumb">
+    <div class="wrapper">
+      <ul>
+        <li><a href="#" title="Home">Home</a></li>
+        <li><a href="#" title="Menu1">Menu1</a></li>
+        <li>Menu2</li>
+      </ul>
+    </div>
+  </nav>
+</div>


### PR DESCRIPTION
**For review**

This PR adds some minor visual tweaks to the navigation elements (breadcrumbs and local navigation) to match the current visual design of gov.au. We can revisit the mobile navigation styling once we have a clearer view of how the header and navigation layout will work together on mobile.

**Breadcrumb changes**: change of colour, spacing and font size

**Local nav changes**: new visual active state, new active and hover background colour, reduced font sizes, spacing adjustment

<img width="433" alt="breadcrumb" src="https://cloud.githubusercontent.com/assets/12635736/16478987/a7ab0546-3ee0-11e6-9b2f-8d958f10631a.png">

<img width="328" alt="local-nav" src="https://cloud.githubusercontent.com/assets/12635736/16478993/b574b668-3ee0-11e6-8a1d-f43ba352ab27.png">
