### PR TITLE
Use pre-release sass-lint to allow SASS linter exemptions

### DIFF
--- a/assets/sass/_typography.scss
+++ b/assets/sass/_typography.scss
@@ -79,9 +79,11 @@ Breakpoints
 You should think about this in parallel with the [grid breakpoints](section-grid.html#kssref-grid-3-breakpoints).
 
 Style guide: Typography.2 Headings & body copy.1 Breakpoints
+
+
 */
 
-@import url('https://fonts.googleapis.com/css?family=Open+Sans:400italic,600,700,400&subset=latin,latin-ext');
+@import url('//fonts.googleapis.com/css?family=Open+Sans:400italic,600,700,400&subset=latin,latin-ext'); //sass-lint:disable-line  no-url-protocols
 
 $base-serif: 'Book Antiqua', Georgia, 'Bitstream Vera Serif', serif;
 $base-sans-serif: 'Open Sans', Verdana, 'Bitstream Vera Sans', sans-serif;
@@ -321,6 +323,7 @@ kbd {
 
 strong {
   font-weight: $bold-font-weight;
+
   &.very-bold {
     font-weight: $heading-font-weight;
   }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,14 @@
+{
+  "dependencies": {
+    "gulp-sass-lint": {
+      "version": "1.2.0",
+      "from": "gulp-sass-lint@1.2.0",
+      "dependencies": {
+        "sass-lint": {
+          "from": "git+https://github.com/sasstools/sass-lint#feature/disable-linters",
+          "version": "1.7.0"
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,9 +16,6 @@
     "scss",
     "js"
   ],
-  "scripts": {
-    "preinstall": "npm install -g gulp"
-  },
   "sasslintConfig": "./sass-lint.yml",
   "preferGlobal": true,
   "license": "MIT",


### PR DESCRIPTION
We have some good exceptions-to-the-rule but where keeping the rule as a whole enabled make sense - we want to use google fonts but we need to look out for other hard coded URLs, we want to use double columns for psuedo-element selectors but when doing very IE specific work they only support single etc.

sass-lint is pretty close to enabling case-by-case exemptions but not quite yet https://github.com/sasstools/sass-lint/pull/677

This PR overrides the dependencies of gulp-sass-lint using npm shrinkwrap to test out that code.

FYI the various exemption syntax types (whole file, selector and children, line only) are detailed in https://github.com/sasstools/sass-lint/blob/c9a3b658aa7b2f06915a108e68c397d24b6451aa/docs/options/toggle-rules-in-src.md
