### PR TITLE
Use Google Fonts via JS webfont loader

### DIFF
--- a/assets/sass/_typography.scss
+++ b/assets/sass/_typography.scss
@@ -69,8 +69,6 @@ Currently you will need to `link` to Open Sans via the HTML `head` to support In
 Style guide: Typography.1 Typeface.1 Font stacks
 */
 
-@import url('https://fonts.googleapis.com/css?family=Open+Sans:400italic,600,700,400&subset=latin,latin-ext');
-
 $base-serif: 'Book Antiqua', Georgia, 'Bitstream Vera Serif', serif;
 $base-sans-serif: 'Open Sans', Verdana, 'Bitstream Vera Sans', sans-serif;
 $base-monospace: 'Lucida Sans Typewriter', 'Lucida Console', Monaco, 'Bitstream Vera Sans Mono', monospace;

--- a/examples/index.html
+++ b/examples/index.html
@@ -19,14 +19,25 @@
     h.className = h.className.replace('no-js', 'js')
   })(document.documentElement)</script>
   <title>Example Pages</title>
+
+  <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.16/webfont.js"></script>
+  <script>
+    WebFont.load({
+      google: {
+        families: ['Open+Sans:400italic,600,700,400:latin,latin-ext']
+      }
+    });
+  </script>
+
   <!-- in production use <link rel="stylesheet" type="text/css" href="https://gov-au-ui-kit.apps.staging.digital.gov.au/latest/ui-kit.min.css"/> instead of next 2 lines-->
   <link rel="stylesheet" type="text/css" href="../latest/ui-kit.css"/>
   <link rel="stylesheet" type="text/css" href="../build/latest/ui-kit.css"/>
 
-  <!--[if (gte IE 9) | (!IE)]>
+
+  <!--[if (gte IE 9) | (!IE)]> <!-->
   <script src="//code.jquery.com/jquery-3.0.0.min.js" integrity="sha256-JmvOoLtYsmqlsWxa7mDSLMwa6dZ9rrIdtrrVYRnDRH0="
           crossorigin="anonymous"></script>
-  <![endif]-->
+  <!--<![endif]-->
   <!--[if lt IE 9]>
   <script src="//code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ="
           crossorigin="anonymous"></script>

--- a/kss-builder/index.hbs
+++ b/kss-builder/index.hbs
@@ -14,6 +14,15 @@
   })(document.documentElement)
   </script>
 
+  <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.16/webfont.js"></script>
+  <script>
+    WebFont.load({
+      google: {
+        families: ['Open+Sans:400italic,600,700,400:latin,latin-ext']
+      }
+    });
+  </script>
+
   <link rel="stylesheet" href="kss-assets/kss.css">
   {{{styles}}}
 


### PR DESCRIPTION
(and fix end of html comment appearing on screen in IE9 in example page)

Time to page ready on a good connection is the same if not better, time to page ready on a slow connection vastly improved by using fallback fonts first.

<img width="719" alt="screen shot 2016-07-04 at 3 24 30 pm" src="https://cloud.githubusercontent.com/assets/81432/16558345/6ee39d36-4228-11e6-886f-91d008b09c83.png">
