### PR TITLE
Fix mobile layout to remove horizontal scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,21 @@ UI Kit (`gov-au-ui-kit`) is 3 things:
 1. a draft design guide to build an accessible standardised look and feel for GOV.AU projects: [gov-au-ui-kit.apps.staging.digital.gov.au](http://gov-au-ui-kit.apps.staging.digital.gov.au/)
 2. common-use templates (to come)
 3. a lean and frugal CSS/SCSS framework (found in `assets/sass/`) that you can
-  - link to as a precompiled minified file:
-  ```
-  <link rel="stylesheet" type="text/css" href="//gov-au-ui-kit.apps.staging.digital.gov.au/latest/ui-kit.min.css"/>
-  ```
-  - download and include the complete SCSS framework in your asset pipeline to use the inbuilt mixins/extends for prototyping and building:
-  ```
-  https://gov-au-ui-kit.apps.staging.digital.gov.au/latest/_ui-kit.scss
-  ```
+include in your project in one of two ways:
+
+**Link to as a precompiled minified file**
+
+```
+<link rel="stylesheet" type="text/css" href="https://gov-au-ui-kit.apps.staging.digital.gov.au/latest/ui-kit.min.css"/>
+```
+
+**Download and include the complete SCSS framework**
+
+This way you can access framework's variables and mixins
+
+```
+@import url('https://gov-au-ui-kit.apps.staging.digital.gov.au/latest/_ui-kit.scss');
+```
 
 ### Features & browser support
 

--- a/assets/sass/_tables.scss
+++ b/assets/sass/_tables.scss
@@ -36,8 +36,14 @@ Style guide: Tables.Content Tables
   td,
   th {
     border-bottom: solid 1px $light-grey;
-    padding: $small-spacing;
+    padding: $tiny-spacing;
+    font-size: $small-font-size;
     text-align: left;
+
+    @include media($tablet) {
+      padding: $small-spacing;
+      font-size: initial;
+    }
   }
 
   thead {

--- a/assets/sass/_typography.scss
+++ b/assets/sass/_typography.scss
@@ -161,46 +161,46 @@ Use relative units to allow for variety across users' browsers and device screen
     <th>Desktop</th>
   </tr>
   <tr>
-    <td>h1 / .display </td>
-    <td>32 / 2em</td>
-    <td>44 / 2.75em<br></td>
-    <td>40 / 2.5em</td>
+    <td>h1</td>
+    <td>32px</td>
+    <td>44px<br></td>
+    <td>40px</td>
   </tr>
   <tr>
     <td>h2</td>
-    <td>28 / 1.75em</td>
-    <td>32 / 2em</td>
-    <td>32 / 2em</td>
+    <td>28px</td>
+    <td>32px</td>
+    <td>32px</td>
   </tr>
   <tr>
     <td>h3</td>
-    <td>24 / 1.5em</td>
-    <td>26 / 1.625em</td>
-    <td>26 / 1.625em</td>
+    <td>24px</td>
+    <td>26px</td>
+    <td>26px</td>
   </tr>
   <tr>
-    <td>h4 / .abstract</td>
-    <td>19 / 1.1875em</td>
-    <td>22 / 1.375em</td>
-    <td>22 / 1.275em</td>
+    <td>h4</td>
+    <td>19px</td>
+    <td>22px</td>
+    <td>22px</td>
   </tr>
   <tr>
     <td>h5</td>
-    <td>16 / 1em</td>
-    <td>16 / 1em</td>
-    <td>16 / 1em</td>
+    <td>16px</td>
+    <td>16px</td>
+    <td>16px</td>
   </tr>
   <tr>
     <td>h6</td>
-    <td>16 / 1em</td>
-    <td>16 / 1em</td>
-    <td>16 / 1em</td>
+    <td>16px</td>
+    <td>16px</td>
+    <td>16px</td>
   </tr>
   <tr>
-    <td>Body copy</td>
-    <td>16 / 1em</td>
-    <td>16 / 1em</td>
-    <td>16 / 1em</td>
+    <td>p</td>
+    <td>16px</td>
+    <td>16px</td>
+    <td>16px</td>
   </tr>
 </table>
 

--- a/kss-builder/kss-assets/kss.scss
+++ b/kss-builder/kss-assets/kss.scss
@@ -1,11 +1,31 @@
 @import './../../assets/sass/ui-kit';
 
-.guide-jump-links {
-  display: flex;
-  flex-wrap: wrap;
+%scrolling-example {
+  width: 17em;
 
-  li {
-    flex-basis: 50%;
+  @include media($mobile) {
+    width: 25em;
+  }
+
+  @include media($tablet) {
+    width: 35em;
+  }
+
+  @include media($desktop) {
+    width: 45em;
+  }
+}
+
+.guide-jump-links {
+
+  @include media ($tablet) {
+    display: flex;
+    flex-wrap: wrap;
+
+    li {
+      flex-basis: 50%;
+    }
+
   }
 }
 
@@ -17,6 +37,7 @@
 }
 
 .guide-example--type {
+  @extend %scrolling-example;
   background-color: $non-white;
   border-radius: $base-border-radius;
   color: $dark-aqua;
@@ -38,23 +59,32 @@
 }
 
 pre {
-  background-color: $background-contrast-colour;
-  color: $navy;
+  @extend %scrolling-example;
   margin: 0 0 $base-spacing;
+  white-space: pre;
   overflow: scroll;
+  background-color: $non-white;
   padding: $small-spacing;
-  white-space: normal;
 }
 
+pre,
 code {
   color: $navy;
 }
 
 .guide-colour {
-  @include span-columns(3);
-  @include omega(4n);
+  float: left;
+  width: 43%;
+  margin-right: 3%;
   margin-bottom: $gutter;
   border: solid 1px $light-grey;
+
+  @include media($tablet) {
+    float: none;
+    margin-right: 0;
+    @include span-columns(3 of 12);
+    @include omega(4n);
+  }
 
   .swatch {
     padding: 50% 0;


### PR DESCRIPTION
Fixes: https://github.com/AusDTO/gov-au-ui-kit/issues/122

I've made changes across a few guide elements to improve the small screen view & prevent content pushing out the page width:
- Put a fixed width on code snippets & type samples. Doing this means that we can have a scroll-bar and text-wrapping.
- Included a 2x layout for colour swatches below the $tablet breakpoint
- Bumped down the font size and padding in tables below the $tablet breakpoint
- Made Jump links display in two columns above the $tablet breakpoint
- Removed the equivalent em sizes from the Type sizes table
