### PR TITLE
Misc improvements to the guide documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,23 @@ This way you can access framework's variables and mixins
 @import url('https://gov-au-ui-kit.apps.staging.digital.gov.au/latest/_ui-kit.scss');
 ```
 
-### Features & browser support
+### Features
 
 - [Normalize](https://necolas.github.io/normalize.css/).
-- Bourbon, version 4.2.7.
-- Neat, and settings for a grid framework with some good defaults.
+- [Bourbon](http://bourbon.io/), version 4.2.7.
+- [Neat](http://neat.bourbon.io/), and settings for a grid framework with some good defaults.
 - Basic styling for content with some good typographic coverage.
 - Basic styling for UI elements (eg `input`, `label`, etc).
-- UI components build on solid HTML foundation.
-- Built on a [philosophy of progressive enhancement](https://en.wikipedia.org/wiki/Progressive_enhancement) (as opposed to [graceful degradation](https://en.wikipedia.org/wiki/Fault_tolerance)).
+
+For a full list of features please see the [CHANGELOG](CHANGELOG.md).
+
+### Browser support
+
+Our components are built on a solid HTML foundation, opting on a [philosophy of progressive enhancement](https://en.wikipedia.org/wiki/Progressive_enhancement) (as opposed to [graceful degradation](https://en.wikipedia.org/wiki/Fault_tolerance)).
+
+We intend to support Internet Explorer 8+.
+
+We will provide precise version support information in the future.
 
 ## What this isn't
 

--- a/assets/sass/_grid-settings.scss
+++ b/assets/sass/_grid-settings.scss
@@ -1,7 +1,7 @@
 /*
 Grid
 
-This framework uses [Bourbon](https://github.com/thoughtbot/bourbon) and [Neat](https://github.com/thoughtbot/neat) to create a consistent 16 column responsive grid layout with good defaults.
+This framework uses [Bourbon](http://bourbon.io/) and [Neat](http://neat.bourbon.io/) to create a consistent 16 column responsive grid layout with good defaults.
 
 Bourbon is a [SASS](http://sass-lang.com/) mixin library (it provides little styling). Neat is a flexible grid framework.
 
@@ -102,7 +102,9 @@ Style guide: Grid.5 Layout
 /*
 Wrapper class
 
-There is a wrapper class for escaping the outer (grid) container: `<div class="wrapper">`. This is currently used for the page `header` and `footer`.
+There is a wrapper class (`<div class="wrapper">`) for wrapping the contents of a block within the grid, while allowing its outer container to run the full viewport width.
+
+This is currently used for the page `header` and `footer`, and also for the [breadcrumbs](section-navigation.html#kssref-navigation-2-breadcrumbs).
 
 Style guide: Grid.6 Wrapper class
 */

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -35,6 +35,8 @@ Breadcrumbs
 
 Use breadcrumbs to help the user understand where are in the service and how they got there.
 
+The breadcrumbs do not receive any left padding because they are expected to sit nested inside a block that spans the full viewport width to aligned with the first column.
+
 Markup: templates/breadcrumbs.hbs
 
 Style guide: Navigation.2 Breadcrumbs

--- a/assets/sass/_typography.scss
+++ b/assets/sass/_typography.scss
@@ -1,7 +1,7 @@
 /*
 Typography
 
-This framework uses [Bourbon](https://github.com/thoughtbot/bourbon) and [Neat](https://github.com/thoughtbot/neat) to provide a responsive grid layout with basic content styling and good typographic defaults.
+Basic content styling with good typographic defaults.
 
 The framework aims to meet common government typographic needs:
 

--- a/assets/sass/templates/breadcrumbs.hbs
+++ b/assets/sass/templates/breadcrumbs.hbs
@@ -1,7 +1,9 @@
 <nav class="breadcrumbs" aria-label="breadcrumb">
-  <ul>
-    <li><a href="#" title="Home">Home</a></li>
-    <li><a href="#" title="Menu1">Menu1</a></li>
-    <li>Menu2</li>
-  </ul>
+  <div class="wrapper">
+    <ul>
+      <li><a href="#" title="Home">Home</a></li>
+      <li><a href="#" title="Menu1">Menu1</a></li>
+      <li>Menu2</li>
+    </ul>
+  </div>
 </nav>

--- a/kss-builder/index.hbs
+++ b/kss-builder/index.hbs
@@ -55,7 +55,7 @@
   <section class="govau--header">
     <div class="wrapper">
       <div class="govau--logo">
-        <a href="#" class="logo">gov.au ui-kit</a> <span class="badge--default">draft</span>
+        <a href="/" class="logo">gov.au ui-kit</a> <span class="badge--default">draft</span>
       </div>
       <div class="feedback">
         <a href="https://github.com/AusDTO/gov-au-ui-kit/issues/new" class="button--feedback">Give feedback</a>
@@ -66,7 +66,7 @@
   <section class="hero">
     <div class="wrapper">
       <span class="site-title">{{options.title}}</span>
-      <p class="tagline">A living style guide of gov-au-ui-kit, built using <a href="http://warpspire.com/kss/"><abbr title="Knyle Style Sheets">KSS</abbr></a>.</p>
+      <p class="tagline">A living style guide of the UI-Kit <abbr title="Sassy CSS">SCSS</abbr> framework, built from the source, using <a href="http://warpspire.com/kss/"><abbr title="Knyle Style Sheets">KSS</abbr></a>.</p>
       <p>Last updated: <time datetime="{{moment "" ""}}">{{moment "" "DD MMMM Y"}}</time></p>
     </div>
   </section>


### PR DESCRIPTION
Changes are probably best seen in the diffs, but, in summary:
- Improved the documentation on the wrapper class in the Grid section.
- Improved documentation and confusion re. the wrapper class wrt. breadcrumbs in the Nav section (and why it doesn’t have any left padding).
- Changed Bourbon and Neat anchors to link to their websites (instead of GH repos).
- Made the inner-header “GOV.AU UI-KIT” text link back to `/`
- Changed the site description line in the header on the guide homepage to reference that this is a living style guide of a SCSS framework
- Expand/simplify the browser support section (to actually provide some info on actual browser support).
