### PR TITLE
Legibility + design improvs to jump-to link section inside main article

### DIFF
--- a/assets/sass/_block-elements.scss
+++ b/assets/sass/_block-elements.scss
@@ -42,7 +42,7 @@ main {
   flex: 1 0 auto;
 
   @include media($tablet) {
-    @include pad($base-spacing 0 0 0);
+    @include pad(($base-spacing * 2) 0 0 0);
   }
 
   .content-main {

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -216,47 +216,47 @@ Style guide: Navigation.3 Skip Links
   }
 }
 
-// Document me please! :)
-//
-// Card ID for the doc work: DESIGN-153
-article {
-  header {
-    margin-bottom: $base-spacing * 2;
 
-    // Jump to link heading, inside the article header
-    h2 {
-      @extend h6;
+/*
+Index links
 
-      margin: ($base-spacing * 2) 0 0 $small-spacing;
-      padding: 0 0 $tiny-spacing ($base-spacing - $tiny-spacing);
-      border-left: $tiny-spacing solid $light-grey;
-      color: $grey;
-      font-weight: $base-font-weight;
-    }
+Used to group a collection of text links, Index links can appear at the beginning of an article page as a table of contents, or as a group of links to related content.
 
-    .jump-links {
-      margin: 0 0 0 $small-spacing;
-      padding: $medium-spacing 0 $medium-spacing ($base-spacing - $tiny-spacing);
-      border-left: $tiny-spacing solid $light-grey;
+An optional heading is included in the markup example. Any level leading from `h2` to `h6` can be used. Use a heading level that's appropriate for your document outline.
 
-      @include media ($tablet) {
-        column-count: 2;
-        column-width: 40%;
-        column-gap: $gutter * 4;
-      }
+Markup: templates/index-links.hbs
 
-      li {
-        margin-bottom: $medium-spacing;
-        font-weight: $bold-font-weight;
+Style guide: Navigation.4 Index links
+*/
 
-        &:last-child {
-          margin-bottom: 0;
-        }
-      }
-    }
+.index-links {
+  margin: ($base-spacing * 2) 0 $base-spacing $small-spacing;
+  border-left: $tiny-spacing solid $non-white;
+  padding: 0 0 $medium-spacing ($base-spacing - $tiny-spacing);
 
-    ul {
-      list-style-type: none;
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    @extend h6;
+    margin: 0 0 $tiny-spacing;
+    color: $grey;
+    font-weight: $base-font-weight;
+  }
+
+  ul {
+    list-style-type: none;
+    margin: $base-spacing 0 0;
+    padding: 0;
+  }
+
+  li {
+    margin-bottom: $medium-spacing;
+    font-weight: $bold-font-weight;
+
+    &:last-child {
+      margin-bottom: 0;
     }
   }
 }

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -215,3 +215,48 @@ Style guide: Navigation.3 Skip Links
     }
   }
 }
+
+// Document me please! :)
+//
+// Card ID for the doc work: DESIGN-153
+article {
+  header {
+    margin-bottom: $base-spacing * 2;
+
+    // Jump to link heading, inside the article header
+    h2 {
+      @extend h6;
+
+      margin: ($base-spacing * 2) 0 0 $small-spacing;
+      padding: 0 0 $tiny-spacing ($base-spacing - $tiny-spacing);
+      border-left: $tiny-spacing solid $light-grey;
+      color: $grey;
+      font-weight: $base-font-weight;
+    }
+
+    .jump-links {
+      margin: 0 0 0 $small-spacing;
+      padding: $medium-spacing 0 $medium-spacing ($base-spacing - $tiny-spacing);
+      border-left: $tiny-spacing solid $light-grey;
+
+      @include media ($tablet) {
+        column-count: 2;
+        column-width: 40%;
+        column-gap: $gutter * 4;
+      }
+
+      li {
+        margin-bottom: $medium-spacing;
+        font-weight: $bold-font-weight;
+
+        &:last-child {
+          margin-bottom: 0;
+        }
+      }
+    }
+
+    ul {
+      list-style-type: none;
+    }
+  }
+}

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -46,7 +46,7 @@ Style guide: Navigation.2 Breadcrumbs
   .nav-heading {
     color: $darker-aqua;
     background: $lighter-grey;
-    margin-top: $base-spacing;
+    margin: $base-spacing 0;
 
     .chevron {
       float: right;

--- a/assets/sass/_typography.scss
+++ b/assets/sass/_typography.scss
@@ -562,3 +562,9 @@ q {
 cite {
   font-style: $base-font-style;
 }
+
+article {
+  h1:first-of-type {
+    margin-top: 0;
+  }
+}

--- a/assets/sass/templates/index-links.hbs
+++ b/assets/sass/templates/index-links.hbs
@@ -1,0 +1,8 @@
+<nav class="index-links">
+  <h2>In this section</h2>
+  <ul>
+    <li><a href="#">In the news</a></li>
+    <li><a href="#">Social feed</a></li>
+    <li><a href="#">Blog</a></li>
+  </ul>
+</nav>

--- a/kss-builder/index.hbs
+++ b/kss-builder/index.hbs
@@ -75,7 +75,7 @@
 
 <main>
   <aside class="sidebar" id="nav">
-    <nav class="primary-nav" aria-label="main navigation">
+    <nav class="primary-nav guide-section-nav" aria-label="main navigation">
       <a id="primary-nav-heading" href="javascript:void(0)" class="js-accordion-trigger nav-heading"
          aria-expanded="true" aria-controls="primary-nav-panel"><span>Show menu</span><i class="chevron bottom"></i></a>
       <ul id="primary-nav-panel" aria-labelledby="primary-nav-heading">
@@ -85,17 +85,6 @@
         {{#each menu}}
           <li>
             <a href="section-{{referenceURI}}.html" {{#if isActive}}class="is-active"{{/if}}>{{header}}</a>
-            {{#if isActive}}
-              {{#if children}}
-                <ul>
-                  {{#each children}}
-                    <li>
-                      <a href="section-{{../referenceURI}}.html#kssref-{{referenceURI}}">{{header}}</a>
-                    </li>
-                  {{/each}}
-                </ul>
-              {{/if}}
-            {{/if}}
           </li>
         {{/each}}
       </ul>
@@ -118,7 +107,7 @@
       <header>
         <h1 id="#kssref-{{sections.0.referenceURI}}">{{sections.0.header}}</h1>
         <h2>Contents</h2>
-        <ul class="guide-jump-links">
+        <ul class="jump-links">
           {{#each sections}}
             {{#unless @first}}
             <li><a href="#kssref-{{referenceURI}}">{{header}}</a></li>

--- a/kss-builder/index.hbs
+++ b/kss-builder/index.hbs
@@ -118,13 +118,13 @@
       <header>
         <h1 id="#kssref-{{sections.0.referenceURI}}">{{sections.0.header}}</h1>
         <h2>Contents</h2>
-        <ol class="guide-jump-links">
+        <ul class="guide-jump-links">
           {{#each sections}}
             {{#unless @first}}
             <li><a href="#kssref-{{referenceURI}}">{{header}}</a></li>
             {{/unless}}
           {{/each}}
-        </ol>
+        </ul>
       </header>
       {{#each sections}}
         <{{#if @first}}div{{else}}section{{/if}} id="kssref-{{referenceURI}}"

--- a/kss-builder/index.hbs
+++ b/kss-builder/index.hbs
@@ -92,36 +92,35 @@
   </aside>
 
   <article role="main" id="content" class="content-main">
+
     {{#if homepage}}
-      <div id="kssref-0" class="guide-section guide-section--depth-0 kss-overview">
+      <div id="guide-0" class="guide-section guide-section--depth-0 kss-overview">
         {{{homepage}}}
       </div>
     {{else}}
 
-    {{!
-      Display each section, in order.
+    <header class="guide-section-header">
+      <h1>{{sections.0.header}}</h1>
 
-      The "root" element comes first in this loop, and can be detected using
-      the "#if @first" block as seen below.
-    }}
-      <header>
-        <h1 id="#kssref-{{sections.0.referenceURI}}">{{sections.0.header}}</h1>
+      <nav class="index-links">
         <h2>Contents</h2>
-        <ul class="jump-links">
+        <ul>
           {{#each sections}}
             {{#unless @first}}
-            <li><a href="#kssref-{{referenceURI}}">{{header}}</a></li>
+            <li><a href="#guide-{{referenceURI}}">{{header}}</a></li>
             {{/unless}}
           {{/each}}
         </ul>
-      </header>
+      </nav>
+    </header>
+
       {{#each sections}}
-        <{{#if @first}}div{{else}}section{{/if}} id="kssref-{{referenceURI}}"
+        <{{#if @first}}div{{else}}section{{/if}} id="guide-{{referenceURI}}"
                                                  class="guide-section guide-section--depth-{{depth}}">
 
           <div>
             {{#unless @first}}
-            <h{{depth}} id="#kssref-{{referenceURI}}">
+            <h{{depth}} id="#guide-{{referenceURI}}">
               {{header}}
             </h{{depth}}>
             {{/unless}}

--- a/kss-builder/index.hbs
+++ b/kss-builder/index.hbs
@@ -115,16 +115,17 @@
       The "root" element comes first in this loop, and can be detected using
       the "#if @first" block as seen below.
     }}
-
-      <h1 id="#kssref-{{sections.0.referenceURI}}">{{sections.0.header}}</h1>
-      <h2>Jump to</h2>
-      <ul class="guide-jump-links">
-        {{#each sections}}
-          {{#unless @first}}
-          <li><a href="#kssref-{{referenceURI}}">{{header}}</a></li>
-          {{/unless}}
-        {{/each}}
-      </ul>
+      <header>
+        <h1 id="#kssref-{{sections.0.referenceURI}}">{{sections.0.header}}</h1>
+        <h2>Contents</h2>
+        <ol class="guide-jump-links">
+          {{#each sections}}
+            {{#unless @first}}
+            <li><a href="#kssref-{{referenceURI}}">{{header}}</a></li>
+            {{/unless}}
+          {{/each}}
+        </ol>
+      </header>
       {{#each sections}}
         <{{#if @first}}div{{else}}section{{/if}} id="kssref-{{referenceURI}}"
                                                  class="guide-section guide-section--depth-{{depth}}">

--- a/kss-builder/kss-assets/kss.scss
+++ b/kss-builder/kss-assets/kss.scss
@@ -1,5 +1,9 @@
 @import './../../assets/sass/ui-kit';
 
+.guide-section-nav {
+  margin-top: ($base-spacing * 4);
+}
+
 %scrolling-example {
   width: 17em;
 
@@ -13,53 +17,6 @@
 
   @include media($desktop) {
     width: 45em;
-  }
-}
-
-article {
-  header {
-    margin-bottom: $base-spacing * 2;
-
-    // Jump to link heading, inside the article header
-    h2 {
-      @extend h6;
-
-      margin-top: $base-spacing * 2;
-      margin-bottom: 0;
-      padding-bottom: $tiny-spacing;
-      margin-left: $small-spacing;
-      padding-left: ($base-spacing - $tiny-spacing);
-      border-left: $tiny-spacing solid $light-grey;
-      color: $grey;
-      font-weight: $base-font-weight;
-    }
-
-    ul,
-    ol {
-      margin-top: 0;
-      margin-left: $small-spacing;
-      padding: $medium-spacing 0 $medium-spacing ($base-spacing - $tiny-spacing);
-      border-left: $tiny-spacing solid $light-grey;
-
-      @include media ($tablet) {
-        column-count: 2;
-        column-width: 40%;
-        column-gap: $gutter * 4;
-      }
-
-      li {
-        margin-bottom: $medium-spacing;
-        font-weight: $bold-font-weight;
-
-        &:last-child {
-          margin-bottom: 0;
-        }
-      }
-    }
-
-    ul {
-      list-style-type: none;
-    }
   }
 }
 

--- a/kss-builder/kss-assets/kss.scss
+++ b/kss-builder/kss-assets/kss.scss
@@ -17,7 +17,9 @@
 }
 
 .guide-section-nav {
-  margin-top: ($base-spacing * 4);
+  @include media($tablet) {
+    margin-top: ($base-spacing * 4);
+  }
 }
 
 .guide-section-header {

--- a/kss-builder/kss-assets/kss.scss
+++ b/kss-builder/kss-assets/kss.scss
@@ -16,16 +16,31 @@
   }
 }
 
+article {
+  header {
+    margin-bottom: $base-spacing * 2;
+
+    // Jump to link heading, inside the article header
+    h2 {
+      @extend h6;
+
+      margin-top: $base-spacing * 2;
+      color: $grey;
+      font-weight: $base-font-weight;
+    }
+  }
+}
+
 .guide-jump-links {
 
   @include media ($tablet) {
-    display: flex;
-    flex-wrap: wrap;
+    column-count: 2;
+    column-width: 40%;
+    column-gap: $gutter * 4;
+  }
 
-    li {
-      flex-basis: 50%;
-    }
-
+  li {
+    margin-bottom: $small-spacing;
   }
 }
 

--- a/kss-builder/kss-assets/kss.scss
+++ b/kss-builder/kss-assets/kss.scss
@@ -25,27 +25,41 @@ article {
       @extend h6;
 
       margin-top: $base-spacing * 2;
+      margin-bottom: 0;
+      padding-bottom: $tiny-spacing;
+      margin-left: $small-spacing;
+      padding-left: ($base-spacing - $tiny-spacing);
+      border-left: $tiny-spacing solid $light-grey;
       color: $grey;
       font-weight: $base-font-weight;
     }
-  }
-}
 
-.guide-jump-links {
-  margin-bottom: $base-spacing;
-  margin-left: $small-spacing;
-  padding: $small-spacing 0 $small-spacing ($base-spacing * 1.5);
-  border-left: 3px solid $light-grey;
+    ul,
+    ol {
+      margin-top: 0;
+      margin-left: $small-spacing;
+      padding: $medium-spacing 0 $medium-spacing ($base-spacing - $tiny-spacing);
+      border-left: $tiny-spacing solid $light-grey;
 
-  @include media ($tablet) {
-    column-count: 2;
-    column-width: 40%;
-    column-gap: $gutter * 4;
-  }
+      @include media ($tablet) {
+        column-count: 2;
+        column-width: 40%;
+        column-gap: $gutter * 4;
+      }
 
-  li {
-    margin-bottom: $medium-spacing;
-    font-weight: $bold-font-weight;
+      li {
+        margin-bottom: $medium-spacing;
+        font-weight: $bold-font-weight;
+
+        &:last-child {
+          margin-bottom: 0;
+        }
+      }
+    }
+
+    ul {
+      list-style-type: none;
+    }
   }
 }
 

--- a/kss-builder/kss-assets/kss.scss
+++ b/kss-builder/kss-assets/kss.scss
@@ -32,6 +32,10 @@ article {
 }
 
 .guide-jump-links {
+  margin-bottom: $base-spacing;
+  margin-left: $small-spacing;
+  padding: $small-spacing 0 $small-spacing ($base-spacing * 1.5);
+  border-left: 3px solid $light-grey;
 
   @include media ($tablet) {
     column-count: 2;
@@ -40,7 +44,8 @@ article {
   }
 
   li {
-    margin-bottom: $small-spacing;
+    margin-bottom: $medium-spacing;
+    font-weight: $bold-font-weight;
   }
 }
 

--- a/kss-builder/kss-assets/kss.scss
+++ b/kss-builder/kss-assets/kss.scss
@@ -1,9 +1,5 @@
 @import './../../assets/sass/ui-kit';
 
-.guide-section-nav {
-  margin-top: ($base-spacing * 4);
-}
-
 %scrolling-example {
   width: 17em;
 
@@ -18,6 +14,14 @@
   @include media($desktop) {
     width: 45em;
   }
+}
+
+.guide-section-nav {
+  margin-top: ($base-spacing * 4);
+}
+
+.guide-section-header {
+  margin-bottom: $base-spacing * 2;
 }
 
 .guide-example {


### PR DESCRIPTION
## Description
- wrapped the `article`’s `h1` and jumpto link section in a `header`
- padded the new `article` page header from the `article` content
- padded the jump to list items from each other
- switched from flex boxes to CSS columns
- switched from `ul` to `ol`
## Additional information

Screengrabs from before–after:

![before-desktop-jumpto](https://cloud.githubusercontent.com/assets/52766/16642228/3c023c94-444c-11e6-916e-7e2f37b83861.png)

![before-mbl-jumpto](https://cloud.githubusercontent.com/assets/52766/16642237/4883aef8-444c-11e6-8c54-b54d1b02ee05.png)

![after-desktop-jumpto](https://cloud.githubusercontent.com/assets/52766/16642238/4c5314a6-444c-11e6-9107-1093be11a494.png)

![after-mbl-jumpto](https://cloud.githubusercontent.com/assets/52766/16642243/525f2f2e-444c-11e6-9747-348d44b589a8.png)
## Questions/discussion

The styling for this currently sits inside `kss.scss`; we should lift out generic jumpto/ToC styling into the ui-kit. Any thoughts?
