### PR TITLE
Bugfix/build refactor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Finally, if you're unsure about anything, just ask — or submit your issue or p
 
 ### <a name="submitting-a-pr">Submitting a pull request</a>
 
-To help us get a better understanding of the issue you're submitting, follow our ISSUE TEMPLATE and the guidelines it describes.
+To help us get a better understanding of the issue you're submitting, follow our [ISSUE TEMPLATE](https://github.com/AusDTO/gov-au-ui-kit/blob/develop/.github/ISSUE_TEMPLATE.md) and the guidelines it describes.
 
 ### Submitting a pull request
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ To build it yourself, begin by installing the system dependencies:
 Install node package dependencies:
 
 ```
+npm -g install gulp
 npm install
 ```
 

--- a/bin/cideploy.sh
+++ b/bin/cideploy.sh
@@ -4,4 +4,10 @@
 set -e
 # Output the commands we run
 set -x
+# download cf-cli and use to push
+curl -v -L -o cf-cli_amd64.deb 'https://cli.run.pivotal.io/stable?release=debian64&source=github'
+sudo dpkg -i cf-cli_amd64.deb
+cf -v
+cf login -a https://api.system.staging.digital.gov.au -o dto -u $CF_USER_STAGING -p $CF_PASSWORD_STAGING
+cf target -o dto -s dtomisc
 cf push gov-au-ui-kit$1 -b staticfile_buildpack -p ./build -i 1

--- a/circle.yml
+++ b/circle.yml
@@ -2,18 +2,10 @@
 general:
   artifacts:
     - "build"
-dependencies:
-  pre:
-    - "curl -v -L -o cf-cli_amd64.deb 'https://cli.run.pivotal.io/stable?release=debian64&version=6.17.0&source=github'"
-    - sudo dpkg -i cf-cli_amd64.deb
-    - cf -v
 
 test:
   override:
     - ./bin/cibuild.sh
-  post:
-    - cf login -a https://api.system.staging.digital.gov.au -o dto -u $CF_USER_STAGING -p $CF_PASSWORD_STAGING
-    - cf target -o dto -s dtomisc
 
 deployment:
   development:

--- a/package.json
+++ b/package.json
@@ -16,9 +16,6 @@
     "scss",
     "js"
   ],
-  "scripts": {
-    "preinstall": "npm install -g gulp"
-  },
   "sasslintConfig": "./sass-lint.yml",
   "preferGlobal": true,
   "license": "MIT",


### PR DESCRIPTION
Running CF commands as dependencies is bad if you want people to make PRs because they need secret credentials. So I've taken them out.

This PR seems to still be building so let's see if it deploys...
