### PR TITLE
make focussed elements stand out with yellow highlighting

### DIFF
--- a/assets/sass/_typography.scss
+++ b/assets/sass/_typography.scss
@@ -291,6 +291,10 @@ a {
     color: $highlight-colour;
   }
 
+  &:focus {
+    background-color: #ffbf47;
+    outline: 3px solid #ffbf47;
+  }
 }
 
 code,


### PR DESCRIPTION
:information_source: This is just exploratory. I'm aware you might not want to use this, e.g. if it's not consistent with the rest of your work, so feel free to reject.
# Vivid yellow highlight when links are focussed on

Might make it easier for keyboard-only users to see where the focus is, when using TAB/SHIFT-TAB to navigate a page.

As seen on [GOV.UK](https://gov.uk). See also: [Form elements focus state](https://govuk-elements.herokuapp.com/form-elements/#form-focus-states)

Screenshot:
![image](https://cloud.githubusercontent.com/assets/310330/16731858/b3a095b0-47bd-11e6-8e58-6c4a2f777ecc.png)
