### PR TITLE
First stab at rehashing the homepage and getting started pages

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -137,7 +137,7 @@ gulp.task('styleguide', ['styleguide.scss'], function () {
     var kssresult = kss({
         source: 'assets/sass',
         destination: paths.outputHTML,
-        homepage: '../../README.md',
+        homepage: '../../homepage.md',
         builder: 'kss-builder'
     });
     kssresult.then(function(v) {

--- a/assets/sass/docs/_getting-started.scss
+++ b/assets/sass/docs/_getting-started.scss
@@ -1,0 +1,133 @@
+/*
+
+Getting started
+
+![CircleCI build status](https://circleci.com/gh/AusDTO/gov-au-ui-kit.svg?style=shield)
+
+Start here if you are setting up a page for the first time. This guide provides information for setting the basic foundations to effectively use the CSS/SCSS framework.
+
+Style guide: Getting started
+
+Weight: 100
+*/
+
+/*
+Features being used
+
+- [Normalize](https://necolas.github.io/normalize.css/).
+- [Bourbon](http://bourbon.io/), version 4.2.7.
+- [Neat](http://neat.bourbon.io/), and settings for a grid framework with some good defaults.
+
+For a full list of features please see the [CHANGELOG](CHANGELOG.md).
+
+Style guide: Getting started.1 Features being used
+*/
+
+/*
+Dependencies
+
+We use Bourbon 4.2.7. We include its `.scss` files directly rather than calling it via its node (or gem) package. Bourbon and Neat live under `/assets/sass/vendor`.
+
+Some of the key libraries we use are:
+- `gulp ^3.9.1`
+- `gulp-sass ^2.3.1`
+- `kss ^3.0.0-beta.14`
+- `sass-lint ^1.7.0`
+
+`^` = compatible with version (see [semver](https://docs.npmjs.com/misc/semver#caret-ranges-123-025-004)).
+
+Style guide: Getting started.2 Dependencies
+*/
+
+/*
+Browser support
+
+Our components are built on a solid HTML foundation, opting on a [philosophy of progressive enhancement](https://en.wikipedia.org/wiki/Progressive_enhancement) (as opposed to [graceful degradation](https://en.wikipedia.org/wiki/Fault_tolerance)).
+
+We intend to support Internet Explorer 8+.
+
+We will provide precise version support information in the future.
+
+Style guide: Getting started.3 Browser support
+*/
+
+/*
+Get the framework
+
+You can include the lean and frugal CSS/SCSS framework in your project in one of two ways:
+
+**Link to as a precompiled minified file**
+
+```
+<link rel="stylesheet" type="text/css" href="https://gov-au-ui-kit.apps.staging.digital.gov.au/latest/ui-kit.min.css"/>
+```
+
+**Download and include the complete SCSS framework**
+
+This way you can access framework's variables and mixins
+
+```
+@import url('https://gov-au-ui-kit.apps.staging.digital.gov.au/latest/_ui-kit.scss');
+```
+
+Style guide: Getting started.4 Get the framework
+*/
+
+/*
+Build the Guide yourself
+
+We have a build process for the development of the framework which uses gulp on node.js.
+
+To build it yourself, begin by installing the system dependencies:
+- Node.js v5.0.0
+
+Install node package dependencies:
+
+```
+npm install
+```
+
+Run a build:
+
+```
+gulp
+```
+
+The compiled style guide can be found at `./build/index.html` and the UI Kit CSS
+at `./build/latest/ui-kit.css`.
+
+We have automated the build, with a few additions:
+
+- `sass-lint` for [linting](https://en.wikipedia.org/wiki/Lint_(software)
+- `cssnano` for [CSS compression](http://cssnano.co/)
+- `autoprefixer` for adding [CSS vendor prefixes](https://autoprefixer.github.io/)
+- `AusDTO/gulp-html` for [HTML validation](https://github.com/AusDTO/gulp-html)
+- `kss` for auto-building a [living style guide](http://warpspire.com/kss/)
+
+Our CI build is available as a shell script at `bin/cibuild.sh`.
+
+Style guide: Getting started.5 Build the Guide yourself
+*/
+
+/*
+Releases
+
+See [RELEASING.md](RELEASING.md) and [CHANGELOG.md](CHANGELOG.md).
+
+We aim to provide stable, usable releases at the end of each sprint.
+
+Style guide: Getting started.6 Releases
+*/
+
+/*
+Deprecation
+
+We are wary about breaking changes. We will work to ensure we will gracefully deprecate any changes that cause things to break.
+
+Installer/wrapper
+
+We may create an installer wrapper (likely node-based), or release via git submodules.
+
+Style guide: Getting started.7 Deprecation
+
+*/

--- a/assets/sass/ui-kit.scss
+++ b/assets/sass/ui-kit.scss
@@ -21,3 +21,5 @@
 
 @import 'ie';
 @import 'print';
+
+@import 'docs/getting-started'

--- a/gettingstarted.md
+++ b/gettingstarted.md
@@ -1,0 +1,99 @@
+![CircleCI build status](https://circleci.com/gh/AusDTO/gov-au-ui-kit.svg?style=shield)
+# Getting Started
+
+Start here if you are setting up a page for the first time. This guide provides information for setting the basic foundations to effectively use the CSS/SCSS framework.
+
+### Features being used
+
+- [Normalize](https://necolas.github.io/normalize.css/).
+- [Bourbon](http://bourbon.io/), version 4.2.7.
+- [Neat](http://neat.bourbon.io/), and settings for a grid framework with some good defaults.
+
+For a full list of features please see the [CHANGELOG](CHANGELOG.md).
+
+### Dependencies
+
+We use Bourbon 4.2.7. We include its `.scss` files directly rather than calling it via its node (or gem) package. Bourbon and Neat live under `/assets/sass/vendor`.
+
+Some of the key libraries we use are:
+- `gulp ^3.9.1`
+- `gulp-sass ^2.3.1`
+- `kss ^3.0.0-beta.14`
+- `sass-lint ^1.7.0`
+
+`^` = compatible with version (see [semver](https://docs.npmjs.com/misc/semver#caret-ranges-123-025-004)).
+
+
+### Browser support
+
+Our components are built on a solid HTML foundation, opting on a [philosophy of progressive enhancement](https://en.wikipedia.org/wiki/Progressive_enhancement) (as opposed to [graceful degradation](https://en.wikipedia.org/wiki/Fault_tolerance)).
+
+We intend to support Internet Explorer 8+.
+
+We will provide precise version support information in the future.
+
+### Get the framework
+
+You can include the lean and frugal CSS/SCSS framework in your project in one of two ways:
+
+**Link to as a precompiled minified file**
+
+```
+<link rel="stylesheet" type="text/css" href="https://gov-au-ui-kit.apps.staging.digital.gov.au/latest/ui-kit.min.css"/>
+```
+
+**Download and include the complete SCSS framework**
+
+This way you can access framework's variables and mixins
+
+```
+@import url('https://gov-au-ui-kit.apps.staging.digital.gov.au/latest/_ui-kit.scss');
+```
+
+
+### Build the Guide yourself
+
+We have a build process for the development of the framework which uses gulp on node.js.
+
+To build it yourself, begin by installing the system dependencies:
+- Node.js v5.0.0
+
+Install node package dependencies:
+
+```
+npm install
+```
+
+Run a build:
+
+```
+gulp build
+```
+
+The compiled style guide can be found at `./build/index.html` and the UI Kit CSS
+at `./build/latest/ui-kit.css`.
+
+We have automated the build, with a few additions:
+
+- `sass-lint` for [linting](https://en.wikipedia.org/wiki/Lint_(software)
+- `cssnano` for [CSS compression](http://cssnano.co/)
+- `autoprefixer` for adding [CSS vendor prefixes](https://autoprefixer.github.io/)
+- `AusDTO/gulp-html` for [HTML validation](https://github.com/AusDTO/gulp-html)
+- `kss` for auto-building a [living style guide](http://warpspire.com/kss/)
+
+Our CI build is available as a shell script at `bin/cibuild.sh`.
+
+
+### Releases
+
+See [RELEASING.md](RELEASING.md) and [CHANGELOG.md](CHANGELOG.md).
+
+We aim to provide stable, usable releases at the end of each sprint.
+
+### Deprecation
+
+We are wary about breaking changes. We will work to ensure we will gracefully deprecate any changes that cause things to break.
+
+### Installer/wrapper
+
+We may create an installer wrapper (likely node-based), or release via git submodules.

--- a/homepage.md
+++ b/homepage.md
@@ -1,0 +1,59 @@
+<!-- # `gov-au-ui-kit` -->
+
+## Welcome to the Guide
+
+This is a draft guide for the use of a growing, lean, and frugal CSS/SCSS framework. It is meant to help build an accessible standardised look and feel for GOV.AU projects. We happily welcome use outside of federal government as well.
+
+This is just the beginning; a work and progress that will develop with your help.
+
+## How is this related to the Digital Service Standard?
+
+The [Digital Service Standard](https://www.dto.gov.au/standard/) requires teams to [build services using common design patterns](https://www.dto.gov.au/standard/6-consistent-and-responsive/). This is draft work on the framework and guidance that will eventually become the design patterns for digital content.
+
+You should use this with the [draft **Content Style Guide**](http://content-style-guide.apps.staging.digital.gov.au/) for Digital Transformation Office projects.
+
+## How to contribute
+
+- Create a new [GitHub issue](https://github.com/AusDTO/gov-au-ui-kit/issues/new), or comment on [existing issues](https://github.com/AusDTO/gov-au-ui-kit/issues).
+- Contribute to this repository. Please see the [Contributor Code of Conduct](code_of_conduct.md) and [our code Conventions](conventions.md), (also see [Block Element Modifier](http://getbem.com/)), first.
+- Contact us on slack in `#govau-guide`.
+
+## Roadmap
+
+### Sprint 26 (Last sprint)
+With the release of the MVP, the team took their product into usability testing to find areas to improve and iterate on. Additionally, the framework has expanded to include:
+- list views
+- footers
+- tables
+- type updates
+- “skip to content” for screen readers
+
+
+### Sprint 27 (Current)
+The team has converted feedback and insights from usability testing into the following action points:
+- Creating a separate "Getting Started" page
+- Overall improvements to IA structure within the side navigation and inline anchor links
+
+The framework is also expanding to include
+- global navigation
+- inline navigation
+- layout patterns
+
+
+### Where to learn about UI Kit releases
+
+See [RELEASING.md](RELEASING.md) and [CHANGELOG.md](CHANGELOG.md).
+
+We aim to provide stable, usable releases at the end of each sprint.
+
+
+<hr><p>
+
+Copyright Digital Transformation Office. [Licensed under the MIT license](https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE).
+
+This repository includes [Bourbon](http://bourbon.io/), [Neat](http://neat.bourbon.io/) and [Normalize.css](https://necolas.github.io/normalize.css/). All also use the MIT license.
+
+![](https://www.dto.gov.au/images/govt-crest.png "logo of the DTO")
+
+gov-au-ui-kit is maintained and funded by the [Digital Transformation Office](https://www.dto.gov.au/).
+</p>

--- a/kss-builder/index.hbs
+++ b/kss-builder/index.hbs
@@ -88,7 +88,7 @@
     <nav class="local-nav" aria-label="main navigation">
       <ul>
         <li>
-          <a href="/" {{# if homepage}}class="is-active"{{/if}}>Getting started</a>
+          <a href="/" {{# if homepage}}class="is-active"{{/if}}>Home</a>
         </li>
         {{#each menu}}
           <li>


### PR DESCRIPTION
## Description

[Issue #157 in Jira]
This is the first draft of the splitting of the readme file into a
homepage and a getting started page. A majority of the content is the
same, with a bit of rearranging and slight rewording where sections
were consolidated.

<img width="713" alt="screen shot 2016-07-12 at 2 21 56 pm" src="https://cloud.githubusercontent.com/assets/19661064/16755075/16fc0a12-483c-11e6-93d0-7887bb23afbe.png">
## Additional information

What this still needs:
- content review (Jools, Petch,  Pascal)
- Revisit what we want to include in the “Roadmap” (to be updated each
  sprint?)
- Getting the "gettinstarted.md" page into the side navigation
