### PR TITLE
Bugfix #136 (DESIGN-168) — apply .is-active to / in sidebar nav in KSS

### DIFF
--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -196,7 +196,7 @@ Style guide: Navigation.2 Local Navigation
 
     @include media($tablet) {
       height: auto;
-      padding: 0 0 $base-spacing;
+      padding: $base-spacing 0;
     }
   }
 

--- a/kss-builder/index.hbs
+++ b/kss-builder/index.hbs
@@ -87,7 +87,7 @@
     <nav class="local-nav" aria-label="main navigation">
       <ul>
         <li>
-          <a href="/">Getting started</a>
+          <a href="/" {{# if homepage}}class="is-active"{{/if}}>Getting started</a>
         </li>
         {{#each menu}}
           <li>


### PR DESCRIPTION
## Description

Adds `.is-active` class if on the homepage to the homepage (“Getting started”) link in the sidebar nav.

Also fixes a padding jump issue changing between pages for `$desktop`.
## Additional information

Fixes #136.
