### PR TITLE
Corrects which header & footer items custom grid stuff is applied to.

### DIFF
--- a/assets/sass/_grid-settings.scss
+++ b/assets/sass/_grid-settings.scss
@@ -25,8 +25,8 @@ If you need an element not defined here you are probably not the only one&mdash;
 
 We define the grid placement for the following elements in `_block-elements.scss`:
 
-- `header`
-- `footer`
+- `header[role='banner']`
+- `footer[role='contentinfo']`
 - `main`
 - `article`
 - `aside`.
@@ -120,7 +120,7 @@ Style guide: Grid.7 Header & footer
 /*
 Accessibility
 
-Long lines reduce legibility. Lines of text should be no longer than 75 characters. Place text in narrower grid boxes to stop text lines from becoming too wide.
+Long lines reduce legibility. Lines of text should be no longer than 75 characters including spaces. Place text in narrower grid boxes to stop text lines from becoming too wide.
 
 Low-vision users should be able to increase the size of the text by up to 200 per cent without breaking the layout.
 

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -307,7 +307,7 @@ Style guide: Navigation.2 Local Navigation
 /*
 Breadcrumbs
 
-Use breadcrumbs to help the user understand where are in the service and how they got there.
+Use breadcrumbs to help the user understand where they are in the service and how they got there.
 
 Default breadcrumbs appear on a light grey background, and are positioned directly underneath a page header or hero.
 


### PR DESCRIPTION
## Description

Minor correction on specificity of which `header` and `footer` elements receive custom grid styling, and adds missing word in sentence in docs on breadcrumbs. 
## Additional information

Found a few other things I’m leaving for now, probably things @joolswood would be able to help us with in the coming week or two:
- the markdown parser doesn’t turn ‘dumb’ punctation into proper punctuation — we have a mix of html entities hand-written out (eg. for a ‘—’), and not converted punctuation/dumb punctation [tech issue potentially?]
- some things are shortened (eg “can’t”) and sometimes they aren’t
- some of our link anchor text could be improved
