### PR TITLE
Refactor of colours

### DIFF
--- a/assets/sass/_colours.scss
+++ b/assets/sass/_colours.scss
@@ -13,7 +13,7 @@ Style guide: Colours
 /*
 Palette
 
-The framework uses semantic names. This includes lighter and darker versions that are percentage variations of the original colours.
+The framework uses colours for decoration and to distinguish different types of information on a page. This includes lighter and darker versions that are percentage variations of the original colours.
 
 The Sass variables are also provided below, for reference.
 
@@ -43,6 +43,12 @@ The Sass variables are also provided below, for reference.
   </div>
 
   <div class="guide-colour">
+    <div class="swatch bg-non-white"></div>
+    <p class="text"> <strong>Non-white</strong><br/>
+      <small>$non-white<br/> #F0F3F5</small></p>
+  </div>
+
+  <div class="guide-colour">
     <div class="swatch bg-darker-aqua"></div>
     <p class="text"> <strong>Darker-aqua</strong><br/>
       <small>$darker-aqua<br/> #115361</small></p>
@@ -67,6 +73,12 @@ The Sass variables are also provided below, for reference.
   </div>
 
   <div class="guide-colour">
+    <div class="swatch bg-lighter-aqua"></div>
+    <p class="text"> <strong>Lighter-aqua</strong><br/>
+      <small>$lighter-aqua<br/> #5BCBE3</small></p>
+  </div>
+
+  <div class="guide-colour">
     <div class="swatch bg-dark-navy"></div>
     <p class="text"> <strong>Dark-navy</strong><br/>
       <small>$dark-navy<br/> #152D3B</small></p>
@@ -79,30 +91,45 @@ The Sass variables are also provided below, for reference.
   </div>
 
   <div class="guide-colour">
-    <div class="swatch bg-light-navy"></div>
-    <p class="text"> <strong>Light-navy</strong><br/>
-      <small>$light-navy<br/> #327DA9</small></p>
-  </div>
-
-  <div class="guide-colour">
-    <div class="swatch bg-non-white"></div>
-    <p class="text"> <strong>Non-white</strong><br/>
-      <small>$non-white<br/> #F0F3F5</small></p>
+    <div class="swatch bg-maroon"></div>
+    <p class="text"> <strong>Maroon</strong><br/>
+      <small>$maroon<br/> #880E48</small></p>
   </div>
 </div>
 
+
 Style guide: Colours.1 Palette
 */
+
+// Colour constants
+
+$black:         #000;
+$non-black:     #222;
+$grey:          #6e6e6e;
+$dark-grey:     darken($grey, 25%);
+$light-grey:    lighten($grey, 30%);
+$non-white:     #f0f3f5;
+$white:         #fff;
+
+$aqua:          #18788d;
+$dark-aqua:     darken($aqua, 5%);
+$darker-aqua:   darken($aqua, 10%);
+$light-aqua:    lighten($aqua, 30%);
+$lighter-aqua:  lighten($aqua, 60%);
+
+$navy:          #224a61;
+$dark-navy:     darken($navy, 10%);
+
+$maroon:        #880e48;
 
 /*
 Contextual colours palette
 
 These colours are reserved to help show specific changes in status.
 
- <div class="guide-colour-examples">
-
+<div class="guide-colour-examples">
   <div class="guide-colour">
-    <div class="swatch bg-success"></div>
+    <div class="swatch bg-success-green"></div>
     <p class="text"> <strong>Success-green</strong><br/>
       <small>$success-colour<br/> #007554</small></p>
   </div>
@@ -110,24 +137,60 @@ These colours are reserved to help show specific changes in status.
   <div class="guide-colour">
     <div class="swatch bg-light-green"></div>
     <p class="text"> <strong>Light-green</strong><br/>
-      <small>$light-green<br/> #E6EFC2</small></p>
+      <small>$light-green<br/> #e6efc2</small></p>
   </div>
 
   <div class="guide-colour">
-    <div class="swatch bg-error"></div>
+    <div class="swatch bg-error-red"></div>
     <p class="text"> <strong>Error-red</strong><br/>
-      <small>$error-colour<br/> #CC0000</small></p>
+      <small>$error-colour<br/> #cc0000</small></p>
   </div>
 
   <div class="guide-colour">
     <div class="swatch bg-light-red"></div>
     <p class="text"> <strong>Light-red</strong><br/>
-      <small>$light-red<br/> #F9DEDE</small></p>
+      <small>$light-red<br/> #f9dede</small></p>
+  </div>
+
+  <div class="guide-colour">
+    <div class="swatch bg-warning-yellow"></div>
+    <p class="text"> <strong>Warning-yellow</strong><br/>
+      <small>$warning-colour<br/> #f9c642</small></p>
+  </div>
+
+  <div class="guide-colour">
+    <div class="swatch bg-light-yellow"></div>
+    <p class="text"> <strong>Light-yellow</strong><br/>
+      <small>$light-yellow<br/> #fdf7dc</small></p>
+  </div>
+
+  <div class="guide-colour">
+    <div class="swatch bg-info-blue"></div>
+    <p class="text"> <strong>Info-blue</strong><br/>
+      <small>$info-colour<br/> #00Bfe9</small></p>
+  </div>
+
+  <div class="guide-colour">
+    <div class="swatch bg-light-blue"></div>
+    <p class="text"> <strong>Light-blue</strong><br/>
+      <small>$light-blue<br/> #e8f5fa</small></p>
   </div>
 </div>
 
 Style guide: Colours.2 Contextual colours palette
 */
+
+$green:         #007554;
+$light-green:   #e6efc2;
+
+$red:           #c00;
+$light-red:     #f9dede;
+
+$yellow:        #f9c642;
+$light-yellow:  #fdf7dc;
+
+$blue:          #00bfe9;
+$light-blue:    #e8f5fa;
 
 /*
 Colour contrast
@@ -140,7 +203,6 @@ The colour contrast ratio for text and interactive elements should be at least 4
 <p class="guide-colour-block bg-dark-grey">non-white on dark-grey<span class="invert">AAA</span></p>
 <p class="guide-colour-block bg-grey">white on grey <span class="invert">AA</span></p>
 <p class="guide-colour-block bg-light-grey">non-black on light-grey <span class="invert">AAA</span></p>
-<p class="guide-colour-block bg-lighter-grey">non-black on lighter-grey <span class="invert">AAA</span></p>
 <p class="guide-colour-block bg-non-white">non-black on non-white <span class="invert">AAA</span></p>
 <p class="guide-colour-block bg-white">non-black on white <span class="invert">AAA</span></p>
 <p class="guide-colour-block bg-darker-aqua">non-white on darker-aqua <span class="invert">AAA</span></p>
@@ -149,85 +211,43 @@ The colour contrast ratio for text and interactive elements should be at least 4
 <p class="guide-colour-block bg-light-aqua">non-black on light-aqua <span class="invert">AAA</span></p>
 <p class="guide-colour-block bg-dark-navy">non-white on dark-navy <span class="invert">AAA</span></p>
 <p class="guide-colour-block bg-navy">non-white on navy <span class="invert">AAA</span></p>
-<p class="guide-colour-block bg-light-navy">white on light-navy <span class="invert">AA</span></p>
-<p class="guide-colour-block bg-error">white on error-red  <span class="invert">AA</span></p>
+<p class="guide-colour-block bg-maroon">white on maroon <span class="invert">AAA</span></p>
+<p class="guide-colour-block bg-error-red">white on error-red  <span class="invert">AA</span></p>
 <p class="guide-colour-block bg-light-red">error-red on light-red <span class="invert">AA</span></p>
-<p class="guide-colour-block bg-success">white on success-green <span class="invert">AA</span></p>
-<p class="guide-colour-block bg-light-green">success-green on light-green <span class="invert">AA</span></p>
+<p class="guide-colour-block bg-success-green">white on success-green <span class="invert">AA</span></p>
+<p class="guide-colour-block bg-light-green">success-green on light-green <span class="invert">AAA</span></p>
+<p class="guide-colour-block bg-light-yellow">non-black on light-yellow <span class="invert">AA</span></p>
+<p class="guide-colour-block bg-light-blue">non-black on light-blue <span class="invert">AA</span></p>
 
 Style guide: Colours.3 Colour contrast
 */
 
-// Colour constants
-
-$black:         #000;
-$non-black:     #222;
-$grey:          #6e6e6e;
-$dark-grey:     darken($grey, 25%);
-$light-grey:    lighten($grey, 30%);
-$lighter-grey:  lighten($grey, 45%);
-$non-white:     #f0f3f5;
-$white:         #fff;
-
-$aqua:          #18788d;
-$dark-aqua:     darken($aqua, 5%);
-$darker-aqua:   darken($aqua, 10%);
-$light-aqua:    lighten($aqua, 30%);
-$lighter-aqua:  lighten($aqua, 58%);
-
-$navy:          #224a61;
-$dark-navy:     darken($navy, 10%);
-$light-navy:    #327da9; //lighten($navy, 30%); Changed for WCAG:AA
-
-$red:           #c00;
-$light-red:     #f9dede;
-
-$green:         #007554;
-$light-green:   #e6efc2;
-
-$yellow:        #f9c642;  //Warning from Alpha
-$light-yellow:  #fdf7dc;  //Warning from Alpha
-
-$blue:          #fff;     //Info from Alpha
-$light-blue:    #e8f5fa;  //Info from Alpha
-
-$orange:        #fbb03b;
-
-$maroon:        #880e48;
-$dark-maroon:   darken($maroon, 5%);
-$darker-maroon: darken($maroon, 10%);
-
 // Colour variables
 
 $background-colour:             $white;
-$background-contrast-colour:    $lighter-grey;
+$background-secondary-colour:   $light-grey;
 
 $link-colour:                   $non-black;
+$link-hover-colour:             $aqua;
 
 $button-colour:                 $aqua;
 $button-colour--hover:          $darker-aqua;
 $button-colour--active:         $dark-aqua;
 $button-colour--disabled:       $light-grey;
 
-$button-contrast-colour:         $maroon;
-$button-contrast-colour--hover:  $darker-maroon;
-$button-contrast-colour--active: $dark-maroon;
-
 $button-inverted-colour:        $white;
 
 $button-text-colour:            $white;
 $button-inverted-text-colour:   $navy;
 
-$frame-colour:                  $light-grey;
-$primary-colour:                $light-navy;
-$highlight-colour:              $aqua;
-$focus-colour:                  $light-aqua;
-$nav-focus-colour:              $lighter-aqua;
+$focus-colour:                  $lighter-aqua;
+
 $error-colour:                  $red;
 $success-colour:                $green;
+$warning-colour:                $yellow;
+$info-colour:                   $blue;
 
 $border-colour:                 $light-grey;
-$border-secondary-colour:       $lighter-grey;
 $border-soft-colour:            rgba($light-grey, 0.5);
 $border-contrast-colour:        $navy;
 
@@ -244,7 +264,7 @@ $badge-colour-error:            $error-colour;
 $badge-colour-success:          $green;
 
 $controls-bg-colour:            $dark-navy;
-$controls-contrast-bg-colour:   $dark-maroon;
+$controls-contrast-bg-colour:   $maroon;
 $header-bg-colour:              $navy;
 $hero-bg-colour:                $aqua;
 $breadcrumbs-bg-colour:         $non-white;

--- a/assets/sass/_colours.scss
+++ b/assets/sass/_colours.scss
@@ -191,7 +191,6 @@ Colour contrast
 The colour contrast ratio for text and interactive elements should be at least 4.5:1 as [recommended by the W3C](http://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html).
 
 ### Accessible combinations
-<p class="guide-colour-block bg-black">white on black <span class="invert">AAA</span></p>
 <p class="guide-colour-block bg-non-black">non-white on non-black<span class="invert">AAA</span></p>
 <p class="guide-colour-block bg-grey">white on grey <span class="invert">AA</span></p>
 <p class="guide-colour-block bg-light-grey">non-black on light-grey <span class="invert">AAA</span></p>

--- a/assets/sass/_colours.scss
+++ b/assets/sass/_colours.scss
@@ -216,7 +216,7 @@ Style guide: Colours.3 Colour contrast
 // Colour variables
 
 $background-colour:             $white;
-$background-secondary-colour:   $light-grey;
+$background-secondary-colour:   $non-white;
 
 $link-colour:                   $non-black;
 $link-hover-colour:             $aqua;

--- a/assets/sass/_colours.scss
+++ b/assets/sass/_colours.scss
@@ -11,7 +11,7 @@ Style guide: Colours
 */
 
 /*
-Palette
+Colours palette
 
 The framework uses colours for decoration and to distinguish different types of information on a page. This includes lighter and darker versions that are percentage variations of the original colours.
 
@@ -21,13 +21,7 @@ The Sass variables are also provided below, for reference.
   <div class="guide-colour">
     <div class="swatch bg-non-black"></div>
     <p class="text"> <strong>Non-black</strong><br/>
-      <small>$non-black<br/>#CC0000</small></p>
-  </div>
-
-  <div class="guide-colour">
-    <div class="swatch bg-dark-grey"></div>
-    <p class="text"> <strong>Dark-grey</strong><br/>
-      <small>$dark-grey<br/>#313131</small></p>
+      <small>$non-black<br/>#313131</small></p>
   </div>
 
   <div class="guide-colour">
@@ -98,15 +92,14 @@ The Sass variables are also provided below, for reference.
 </div>
 
 
-Style guide: Colours.1 Palette
+Style guide: Colours.1 Colours palette
 */
 
 // Colour constants
 
 $black:         #000;
-$non-black:     #222;
+$non-black:     #313131;
 $grey:          #6e6e6e;
-$dark-grey:     darken($grey, 25%);
 $light-grey:    lighten($grey, 30%);
 $non-white:     #f0f3f5;
 $white:         #fff;
@@ -200,7 +193,6 @@ The colour contrast ratio for text and interactive elements should be at least 4
 ### Accessible combinations
 <p class="guide-colour-block bg-black">white on black <span class="invert">AAA</span></p>
 <p class="guide-colour-block bg-non-black">non-white on non-black<span class="invert">AAA</span></p>
-<p class="guide-colour-block bg-dark-grey">non-white on dark-grey<span class="invert">AAA</span></p>
 <p class="guide-colour-block bg-grey">white on grey <span class="invert">AA</span></p>
 <p class="guide-colour-block bg-light-grey">non-black on light-grey <span class="invert">AAA</span></p>
 <p class="guide-colour-block bg-non-white">non-black on non-white <span class="invert">AAA</span></p>
@@ -253,8 +245,7 @@ $border-contrast-colour:        $navy;
 
 $box-shadow-colour:             rgba($non-black, 0.5);
 
-$body-text-colour:              $dark-grey;
-$body-secondary-text-colour:    $dark-grey;
+$body-text-colour:              $non-black;
 $body-inverted-text-colour:     $white;
 
 $badge-colour-default:          $grey;

--- a/assets/sass/_forms.scss
+++ b/assets/sass/_forms.scss
@@ -144,7 +144,7 @@ form {
 
   .hint {
     display: block;
-    color: $body-secondary-text-colour;
+    color: $body-text-colour;
     font-size: rem(14);
   }
 

--- a/assets/sass/_lists.scss
+++ b/assets/sass/_lists.scss
@@ -35,7 +35,15 @@ Style guide: List styles
     }
 
     a {
-      color: $aqua;
+      color: $link-hover-colour;
+      padding: 2px $tiny-spacing;
+      border: 1px solid $link-hover-colour;
+      border-radius: 2px;
+
+      &:hover {
+        color: $white;
+        background-color: $link-hover-colour;
+      }
     }
   }
 

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -153,7 +153,7 @@ Style guide: Navigation.2 Local Navigation
 
   &,
   &:hover {
-    background-color: $lighter-grey;
+    background-color: $background-secondary-colour;
     color: $darker-aqua;
   }
 
@@ -234,10 +234,10 @@ Style guide: Navigation.2 Local Navigation
   li {
     margin: 0;
     padding: 0;
-    border-bottom: 1px solid $border-secondary-colour;
+    border-bottom: 1px solid $border-colour;
 
     &:first-child {
-      border-top: 1px solid $border-secondary-colour;
+      border-top: 1px solid $border-colour;
     }
   }
 
@@ -252,13 +252,13 @@ Style guide: Navigation.2 Local Navigation
 
     &:hover {
       border-color: $border-contrast-colour;
-      background-color: $nav-focus-colour;
+      background-color: $focus-colour;
     }
 
     &:active,
     &.active,
     &.is-active {
-      background-color: $nav-focus-colour;
+      background-color: $focus-colour;
     }
 
   }
@@ -271,7 +271,7 @@ Style guide: Navigation.2 Local Navigation
 .primary-nav {
   .nav-heading {
     color: $darker-aqua;
-    background: $lighter-grey;
+    background: $background-secondary-colour;
     margin: $base-spacing 0;
 
     .chevron {

--- a/assets/sass/_typography.scss
+++ b/assets/sass/_typography.scss
@@ -284,7 +284,7 @@ a {
 
   &:hover,
   &:active {
-    color: $highlight-colour;
+    color: $link-hover-colour;
   }
 
 }
@@ -347,7 +347,7 @@ strong {
 }
 
 hr {
-  border-color: $border-secondary-colour;
+  border-color: $border-colour;
   border-style: solid;
   border-bottom: none;
 }
@@ -495,7 +495,7 @@ Style guide: Typography.8 Quotations
 blockquote {
   margin: $medium-spacing 0;
   padding: $small-spacing ($base-spacing + ($small-spacing * 0.75));
-  background-color: $non-white;
+  background-color: $background-secondary-colour;
   font-family: $base-serif;
   quotes: '\201C''\201D''\2018''\2019';
 

--- a/assets/sass/_typography.scss
+++ b/assets/sass/_typography.scss
@@ -561,7 +561,7 @@ blockquote {
       text-transform: lowercase;
       font-variant: small-caps;
       letter-spacing: 1px;
-      color: $dark-grey;
+      color: $body-text-colour;
     }
   }
 

--- a/kss-builder/kss-assets/kss.scss
+++ b/kss-builder/kss-assets/kss.scss
@@ -115,15 +115,6 @@ code {
 }
 
 // Colour background classes
-.bg-black {
-  background-color: $black;
-  color: $white;
-
-  .invert {
-    background-color: $white;
-    color: $black;
-  }
-}
 
 .bg-non-black {
   background-color: $non-black;

--- a/kss-builder/kss-assets/kss.scss
+++ b/kss-builder/kss-assets/kss.scss
@@ -145,16 +145,6 @@ code {
   }
 }
 
-.bg-dark-grey {
-  background-color: $dark-grey;
-  color: $non-white;
-
-  .invert {
-    background-color: $non-white;
-    color: $dark-grey;
-  }
-}
-
 .bg-light-grey {
   background-color: $light-grey;
   color: $non-black;

--- a/kss-builder/kss-assets/kss.scss
+++ b/kss-builder/kss-assets/kss.scss
@@ -165,16 +165,6 @@ code {
   }
 }
 
-.bg-lighter-grey {
-  background-color: $lighter-grey;
-  color: $non-black;
-
-  .invert {
-    background-color: $non-black;
-    color: $lighter-grey;
-  }
-}
-
 .bg-non-white {
   background-color: $non-white;
   color: $non-black;
@@ -235,6 +225,16 @@ code {
   }
 }
 
+.bg-lighter-aqua {
+  background-color: $lighter-aqua;
+  color: $non-black;
+
+  .invert {
+    background-color: $non-black;
+    color: $lighter-aqua;
+  }
+}
+
 .bg-navy {
   background-color: $navy;
   color: $non-white;
@@ -255,17 +255,17 @@ code {
   }
 }
 
-.bg-light-navy {
-  background-color: $light-navy;
+.bg-maroon {
+  background-color: $maroon;
   color: $white;
 
   .invert {
     background-color: $white;
-    color: $light-navy;
+    color: $maroon;
   }
 }
 
-.bg-error {
+.bg-error-red {
   background-color: $red;
   color: $white;
 
@@ -285,7 +285,7 @@ code {
   }
 }
 
-.bg-success {
+.bg-success-green {
   background-color: $green;
   color: $white;
 
@@ -305,12 +305,30 @@ code {
   }
 }
 
-.bg-yellow {
+.bg-warning-yellow {
   background-color: $yellow;
-  color: $white;
 }
 
 .bg-light-yellow {
   background-color: $light-yellow;
-  color: $white;
+  color: $non-black;
+
+  .invert {
+    background-color: $non-black;
+    color: $light-yellow;
+  }
+}
+
+.bg-info-blue {
+  background-color: $blue;
+}
+
+.bg-light-blue {
+  background-color: $light-blue;
+  color: $non-black;
+
+  .invert {
+    background-color: $non-black;
+    color: $light-blue;
+  }
 }


### PR DESCRIPTION
## Description

This code refactor aims to bring more clarity to the guide around colour usage by:
- Removing unused colour variables
- Removing duplicate or very similar colour variable declarations (e.g. `$light-grey` & `$lighter-grey`)
- Updating 'Colour palette' swatches so that all colours are demonstrated
- Updating 'Contextual colours palette' swatches to include $warning-yellow & $info-blue
- Updating 'Colour contrast' swatches to include accessible combinations for light-yellow & light-blue
- Changing link hover colour from `$teal` to `$aqua` to meet an acceptable level of contrast
- Renaming `$dark-grey` to `$non-black` and removing the old `$non-black`
## Additional information
### Colours palette

![image](https://cloud.githubusercontent.com/assets/5482613/16907144/33d4b2fc-4d04-11e6-9e55-0d54c3b0481b.png)
### Contextual colours palette

![image](https://cloud.githubusercontent.com/assets/5482613/16906953/4c4c1444-4d02-11e6-85eb-2ee6ade580fd.png)
### Accessible combinations for contextual colours

![image](https://cloud.githubusercontent.com/assets/5482613/16906973/7491a4fa-4d02-11e6-9b50-ced1d1e2e606.png)
