### PR TITLE
Scrolling anchor links

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -14,7 +14,8 @@ var gulp = require('gulp'),
     runSequence = require('run-sequence'),
     inline = require('./lib/gulp-scss-inline.js'),
     connect = require('gulp-connect'),
-    svg2png = require('gulp-svg2png')
+    svg2png = require('gulp-svg2png'),
+    webpack = require('webpack-stream')
     ;
 
 var paths = {
@@ -67,6 +68,11 @@ gulp.task('ui-kit.scss', ['svg2png'], function () {
 
 gulp.task('ui-kit.js', function () {
     return gulp.src(paths.js)
+        .pipe(webpack({
+          output: {
+            filename: 'ui-kit.js',
+          }
+        }))
         .pipe(gitVersion())
         .pipe(gulp.dest(paths.outputAssets));
 });
@@ -95,11 +101,13 @@ gulp.task('ui-kit.min.scss', ['svg2png'], function () {
 
 gulp.task('ui-kit.min.js', function () {
     return gulp.src(paths.js)
+        .pipe(webpack({
+          output: {
+            filename: 'ui-kit.min.js',
+          }
+        }))
         .pipe(uglify())
         .pipe(gitVersion())
-        .pipe(rename({
-            suffix: '.min'
-        }))
         .pipe(gulp.dest(paths.outputAssets));
 });
 

--- a/assets/js/ui-kit.js
+++ b/assets/js/ui-kit.js
@@ -1,3 +1,5 @@
+var smoothScroll = require('smoothscroll');
+
 (function (document) {
 
   var CollapsibleNav = {
@@ -7,7 +9,6 @@
      * @param {array} elems - array of HTMLCollections representing collapsible elements
      */
     init: function(elems) {
-      console.log(elems);
       for (var i = 0; i < elems.length; i++) {
         this.initPanel(elems[i]);
         this.initToggle(elems[i]);
@@ -21,7 +22,6 @@
     initPanel: function(elem) {
       var panelLabel = elem.dataset ? elem.dataset.label ? elem.dataset.label : elem.className : elem.className;
 
-      console.log(elem);
       elem.id = panelLabel;
       elem.setAttribute('aria-expanded', 'false');
     },
@@ -62,6 +62,7 @@
   // Kick of the JavaScript party when the DOM is ready
   document.addEventListener('DOMContentLoaded', function() {
     CollapsibleNav.init(document.querySelectorAll('.global-nav, .local-nav'));
+    ScrollingAnchorLinks.init();
   });
 
 })(document);

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -437,6 +437,12 @@ Used to group a collection of text links, Index links can appear at the beginnin
 
 An optional heading is included in the markup example. Any level leading from `h2` to `h6` can be used. Use a heading level that's appropriate for your document outline.
 
+**Behaviour**
+
+Because these are internal links they trigger a smooth scroll down the page.
+
+This works in Firefox, Chrome, IE10, Opera and Safari. Unsupported browsers would just use the normal internal link behaviour.
+
 Markup: templates/index-links.hbs
 
 Style guide: Navigation.5 Index links

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
   "preferGlobal": true,
   "license": "MIT",
   "dependencies": {
+    "css-select": "^1.2.0",
     "del": "^2.2.0",
+    "dom-serializer": "^0.1.0",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^3.1.0",
     "gulp-connect": "^4.1.0",
@@ -33,16 +35,16 @@
     "gulp-svg2png": "^1.0.2",
     "gulp-uglify": "^1.5.3",
     "gulp-util": "^3.0.7",
-    "node-sass": "^3.8.0",
     "handlebars.moment": "^1.0.4",
+    "htmlparser2": "^3.9.1",
     "kss": "^3.0.0-beta.14",
+    "node-sass": "^3.8.0",
+    "object-assign": "^4.1.0",
     "run-sequence": "^1.2.1",
     "sass-inline-svg": "^0.0.3",
+    "smoothscroll": "^0.2.2",
     "through2": "^2.0.1",
-    "css-select": "^1.2.0",
-    "dom-serializer": "^0.1.0",
-    "htmlparser2": "^3.9.1",
-    "object-assign": "^4.1.0"
+    "webpack-stream": "^3.2.0"
   },
   "devDependencies": {
     "fs": "0.0.2"


### PR DESCRIPTION
## Description

Any links with a `href` attribute starting with `#` are internal links and trigger a smooth scroll down the page.

This works in Firefox, Chrome, IE10, Opera and Safari. Unsupported browsers would just use the normal internal link behaviour.

![image](https://i.gyazo.com/2e02bf316486b66f6e9a33846c13f22c.gif)
