### PR TITLE
Update path to assets in Gulp watch task

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -198,7 +198,7 @@ gulp.task('watch', ['watch.build']);
 
 gulp.task('watch.build', function () {
     gulp.watch([
-      paths.assetsDir,
+      paths.assets,
       paths.examplesDir,
       paths.readme,
       paths.kssBuilderDir,


### PR DESCRIPTION
## Description

Fixes: https://github.com/AusDTO/gov-au-ui-kit/issues/175

The assets path that the `gulp watch` task watches was incorrect.
