### PR TITLE
Typography update + refactor w/ .gov-speak [DESIGN-220]

### DIFF
--- a/assets/sass/_accordions.scss
+++ b/assets/sass/_accordions.scss
@@ -102,7 +102,7 @@ summary {
   top: 0;
   height: auto;
   overflow: hidden;
-  padding: $small-spacing $base-spacing;
+  padding: $medium-spacing $base-spacing $small-spacing;
   border: solid $small-spacing $lighter-aqua;
   border-top: none;
   border-bottom-right-radius: $tiny-border-radius;

--- a/assets/sass/_accordions.scss
+++ b/assets/sass/_accordions.scss
@@ -102,7 +102,7 @@ summary {
   top: 0;
   height: auto;
   overflow: hidden;
-  padding: $medium-spacing $base-spacing $small-spacing;
+  padding: $base-spacing $base-spacing $small-spacing;
   border: solid $small-spacing $lighter-aqua;
   border-top: none;
   border-bottom-right-radius: $tiny-border-radius;

--- a/assets/sass/_images.scss
+++ b/assets/sass/_images.scss
@@ -1,3 +1,9 @@
+figure {
+  img {
+    display: block;
+  }
+}
+
 img {
   max-width: 100%;
 }

--- a/assets/sass/_lists.scss
+++ b/assets/sass/_lists.scss
@@ -24,6 +24,7 @@ Style guide: List styles
     dt,
     dd {
       display: inline-block;
+      line-height: $double-leading;
       margin: 0;
       padding: 0;
     }

--- a/assets/sass/_lists.scss
+++ b/assets/sass/_lists.scss
@@ -46,12 +46,6 @@ Style guide: List styles
         background-color: $link-hover-colour;
       }
     }
-
-    figure {
-      img {
-        display: block;
-      }
-    }
   }
 
   .meta {

--- a/assets/sass/_lists.scss
+++ b/assets/sass/_lists.scss
@@ -45,11 +45,17 @@ Style guide: List styles
         background-color: $link-hover-colour;
       }
     }
+
+    figure {
+      img {
+        display: block;
+      }
+    }
   }
 
   .meta {
     font-size: $small-font-size;
-    margin-top: $small-spacing;
+    //margin-top: $small-spacing;
     margin-bottom: $small-spacing;
 
     time {
@@ -58,7 +64,7 @@ Style guide: List styles
   }
 
   > li {
-    padding: ($base-spacing * 1.5) 0;
+    padding: $base-spacing 0;
     border-bottom: solid 1px $border-colour;
     margin-bottom: 0;
   }
@@ -74,6 +80,10 @@ Style guide: List styles
 
   h3 {
     @extend h4;
+  }
+
+  img {
+    display: block;
   }
 }
 
@@ -153,7 +163,6 @@ Style guide: List styles.2 Vertical list
 */
 
 .list-vertical {
-
   @extend %base-list;
 
   &.no-border {
@@ -169,7 +178,7 @@ Style guide: List styles.2 Vertical list
 
   > li {
 
-    border-top: 1px solid $border-colour;
+    border-top: 4px solid $border-colour;
     border-bottom: none;
     flex: 0 0 100%;
 

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -480,8 +480,7 @@ Style guide: Navigation.5 Index links
   h4,
   h5,
   h6 {
-    @extend p;
-
+    font-size: rem(17);
     margin-top: $base-spacing;
     color: $grey;
     font-weight: $base-font-weight;

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -182,10 +182,20 @@ Style guide: Navigation.2 Local Navigation
   }
 }
 
+.local-nav {
+  padding-top: 0;
+  @include media($tablet) {
+    padding: $base-spacing 0;
+  }
+}
+
+.primary-nav {
+  padding: $base-spacing 0;
+}
+
 .primary-nav,
 .local-nav {
   margin: 0 0 $base-spacing;
-  padding: $base-spacing 0;
   overflow: hidden;
   transition: padding ($transition-timing * 2) ease;
 
@@ -199,6 +209,15 @@ Style guide: Navigation.2 Local Navigation
       padding: $base-spacing 0;
     }
   }
+
+  h1 {
+    font-size: 1em;
+    font-weight: $base-font-weight;
+    text-transform: uppercase;
+    margin: 0;
+    line-height: $base-leading;
+  }
+
 
   ul {
     margin: 0;
@@ -255,9 +274,12 @@ Style guide: Navigation.2 Local Navigation
       background-color: $focus-colour;
     }
 
-    &:active,
     &.active,
     &.is-active {
+      font-weight: $bold-font-weight;
+    }
+
+    &.current {
       background-color: $focus-colour;
     }
 

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -189,10 +189,6 @@ Style guide: Navigation.2 Local Navigation
   }
 }
 
-.primary-nav {
-  padding: $base-spacing 0;
-}
-
 .primary-nav,
 .local-nav {
   margin: 0 0 $base-spacing;
@@ -291,6 +287,8 @@ Style guide: Navigation.2 Local Navigation
 // This class is legacy as of v1.2
 // Marked for removal at 2.0
 .primary-nav {
+  padding: $base-spacing 0;
+
   .nav-heading {
     color: $darker-aqua;
     background: $background-secondary-colour;

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -458,8 +458,9 @@ Style guide: Navigation.5 Index links
   h4,
   h5,
   h6 {
-    @extend h6;
-    margin: 0 0 $tiny-spacing;
+    @extend p;
+
+    margin-top: $base-spacing;
     color: $grey;
     font-weight: $base-font-weight;
   }

--- a/assets/sass/_page-footer.scss
+++ b/assets/sass/_page-footer.scss
@@ -1,6 +1,6 @@
 footer[role='contentinfo'] {
 
-  @include pad($base-spacing 0);
+  @include pad(( $base-spacing * 2 ) 0);
   background-color: $non-white;
   border-top: 6px solid $border-contrast-colour;
 
@@ -13,7 +13,7 @@ footer[role='contentinfo'] {
   }
 
   .footer-logo {
-    margin: 0 0 $base-spacing;
+    //margin: 0 0 $base-spacing;
 
     @include media($tablet) {
       @include span-columns(3 of 12);
@@ -27,7 +27,7 @@ footer[role='contentinfo'] {
   .footer-links {
 
     @include media($mobile) {
-      @include span-columns(9 of 12);
+      @include span-columns(12 of 12);
     }
 
     ul {
@@ -40,7 +40,7 @@ footer[role='contentinfo'] {
       margin-right: $small-spacing;
 
       @include media($mobile) {
-        display: inline-block;
+        display: block;
       }
     }
 

--- a/assets/sass/_page-footer.scss
+++ b/assets/sass/_page-footer.scss
@@ -26,8 +26,8 @@ footer[role='contentinfo'] {
 
   .footer-links {
 
-    @include media($mobile) {
-      @include span-columns(12 of 12);
+    @include media($tablet) {
+      @include span-columns(9 of 12);
     }
 
     ul {
@@ -38,9 +38,10 @@ footer[role='contentinfo'] {
 
     li {
       margin-right: $small-spacing;
+      display: block;
 
-      @include media($mobile) {
-        display: block;
+      @include media($tablet) {
+        display: inline-block;
       }
     }
 

--- a/assets/sass/_page-header.scss
+++ b/assets/sass/_page-header.scss
@@ -59,6 +59,7 @@
   position: relative;
   padding: $medium-spacing 0 ($base-spacing * 3);
   padding-bottom: $medium-spacing;
+  margin-bottom: 0;
   background-color: $header-bg-colour;
   color: $body-inverted-text-colour;
 
@@ -121,6 +122,7 @@
 
 .hero {
   padding: ($base-spacing * 2) 0;
+  margin-bottom: 0;
   background-color: $hero-bg-colour;
   color: $body-inverted-text-colour;
 

--- a/assets/sass/_typography.scss
+++ b/assets/sass/_typography.scss
@@ -104,6 +104,7 @@ Style guide: Typography.3 Spacing
 $base-leading: 1.6;
 $base-heading-leading: 1.4;
 $small-leading: 1.2;
+$double-leading: 2;
 
 // Base spacing, relative to leading.
 $base-spacing: $base-leading * 1em;
@@ -496,8 +497,8 @@ Style guide: Typography.6 Callouts & warnings
 .callout--warning {
   @extend .callout;
 
-  border-left: ($small-spacing / 2) solid $red;
-  padding-left: $base-spacing - ($small-spacing / 2);
+  border-left: $tiny-spacing solid $red;
+  padding-left: $base-spacing - $tiny-spacing;
 }
 
 
@@ -606,7 +607,7 @@ blockquote {
 
   footer {
     margin-top: $medium-spacing;
-    padding-top: ($small-spacing / 2);
+    padding-top: $tiny-spacing;
     border-top: 1px solid $light-grey;
   }
 
@@ -633,7 +634,7 @@ blockquote {
 }
 
 q {
-  // Investigate: switching to html entitites?
+  // Investigate: switching to html entities?
   quotes: '“' '”' '‘' '’' '“' '”' '‘' '’';
 }
 

--- a/assets/sass/_typography.scss
+++ b/assets/sass/_typography.scss
@@ -461,14 +461,15 @@ li {
 
   ul,
   ol {
-    margin-top: ($small-spacing / 2);
+    margin-top: $tiny-spacing;
     margin-bottom: 0;
   }
 }
 
 dt {
+  display: inline-block;
   font-weight: $bold-font-weight;
-  margin-top: $medium-spacing;
+  margin-top: $tiny-spacing;
 
   &:first-of-type {
     margin-top: 0;

--- a/assets/sass/_typography.scss
+++ b/assets/sass/_typography.scss
@@ -377,6 +377,7 @@ kbd {
   background-color: $non-white;
   color: $dark-aqua;
   text-align: center;
+  font-size: $small-font-size;
   padding: 0 $small-spacing;
   margin: 0 $tiny-spacing;
 }
@@ -449,7 +450,7 @@ dt,
 dd {
   font-size: rem(17);
   margin-top: 0; // Check up on where margin-top is coming from...
-  margin-bottom: $small-spacing;
+  margin-bottom: $medium-spacing;
   line-height: $base-spacing;
 }
 
@@ -577,10 +578,6 @@ blockquote {
       text-align: center;
       margin: 0;
     }
-
-    &::after {
-      margin-top: -($tiny-spacing);
-    }
   }
 
   &::before,
@@ -594,6 +591,7 @@ blockquote {
 
   &::before {
     margin-left: -($small-spacing * 0.75);
+    padding-bottom: $tiny-spacing;
     content: open-quote;
   }
 

--- a/assets/sass/_typography.scss
+++ b/assets/sass/_typography.scss
@@ -275,7 +275,7 @@ h4 {
   h6 {
     line-height: $base-heading-leading;
     font-weight: $heading-font-weight;
-    margin-bottom: $small-spacing * .5;
+    margin-bottom: $tiny-spacing;
     margin-top: $base-spacing;
   }
 

--- a/assets/sass/_typography.scss
+++ b/assets/sass/_typography.scss
@@ -325,12 +325,13 @@ h4 {
   }
 
   h5 {
-    font-size: rem(16);
+    font-size: rem(17);
     font-weight: $heading-font-weight;
   }
 
   h6 {
-    @extend h5;
+    font-size: rem(17);
+    font-weight: $heading-font-weight;
   }
 }
 

--- a/assets/sass/_typography.scss
+++ b/assets/sass/_typography.scss
@@ -208,28 +208,31 @@ Markup: templates/heading-body-styles.hbs
 Style guide: Typography.2 Headings & body copy
 */
 
+// Styling for headings
+//
+// Note that we don't style h5 and h6.
+
 h1,
 h2,
 h3,
-h4,
-h5,
-h6 {
+h4 {
   line-height: $base-heading-leading;
-  font-weight: $heading-font-weight;
-  margin-bottom: $small-spacing * .5;
+  font-weight: $base-font-weight;
+  margin-bottom: $tiny-spacing;
   margin-top: $base-spacing;
 }
 
 h1 {
-  font-size: rem(32);
-  line-height: $small-leading;
+  // This needs to be changed to live in the 'header', where the breadcrumbs currently are (grey bar).
+  font-size: rem(24);
+  //line-height: $small-leading;
 
   @include media($tablet) {
-    font-size: rem(44);
+    font-size: rem(26);
   }
 
   @include media($desktop) {
-    font-size: rem(40);
+    font-size: rem(32);
   }
 
   &:first-of-type {
@@ -238,11 +241,12 @@ h1 {
 }
 
 h2 {
-  font-size: rem(28);
+  font-size: rem(32);
   line-height: $small-leading;
+  margin-top: $base-spacing;
 
   @include media($tablet) {
-    font-size: rem(32);
+    font-size: rem(44);
   }
 }
 
@@ -256,21 +260,77 @@ h3 {
 }
 
 h4 {
-  font-size: rem(19);
+  font-size: rem(18);
   font-weight: $heading-font-weight;
+}
 
-  @include media($tablet) {
-    font-size: rem(22);
+
+// Document this later.
+.gov-speak {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    line-height: $base-heading-leading;
+    font-weight: $heading-font-weight;
+    margin-bottom: $small-spacing * .5;
+    margin-top: $base-spacing;
   }
-}
 
-h5 {
-  font-size: rem(16);
-  font-weight: $heading-font-weight;
-}
+  h1 {
+    font-size: rem(32);
+    line-height: $small-leading;
 
-h6 {
-  @extend h5;
+    @include media($tablet) {
+      font-size: rem(44);
+    }
+
+    @include media($desktop) {
+      font-size: rem(40);
+    }
+
+    &:first-of-type {
+      margin-top: $tiny-spacing;
+    }
+  }
+
+  h2 {
+    font-size: rem(28);
+    line-height: $small-leading;
+
+    @include media($tablet) {
+      font-size: rem(32);
+    }
+  }
+
+  h3 {
+    font-size: rem(24);
+    font-weight: $heading-font-weight;
+
+    @include media($tablet) {
+      font-size: rem(26);
+    }
+  }
+
+  h4 {
+    font-size: rem(19);
+    font-weight: $heading-font-weight;
+
+    @include media($tablet) {
+      font-size: rem(22);
+    }
+  }
+
+  h5 {
+    font-size: rem(16);
+    font-weight: $heading-font-weight;
+  }
+
+  h6 {
+    @extend h5;
+  }
 }
 
 a {
@@ -331,19 +391,17 @@ strong {
 
 // For display font sizing.
 .display {
-  @extend h1;
+  @extend h2;
 }
 
 // More specialised typography.
 //
 // For abstracts or page introductory paragraphs.
 .abstract {
-  @extend h4;
-
+  font-size: rem(24);
   font-weight: $base-font-weight;
-  border-bottom: 1px solid;
-  padding-bottom: 1.3 * $base-spacing;
-  margin-bottom: 2 * $base-spacing;
+  border-bottom: 1px solid $border-colour;
+  padding-bottom: $medium-spacing;
 }
 
 hr {
@@ -389,8 +447,9 @@ dl,
 p,
 dt,
 dd {
+  font-size: rem(17);
+  margin-top: 0; // Check up on where margin-top is coming from...
   margin-bottom: $small-spacing;
-  font-size: rem(16);
   line-height: $base-spacing;
 }
 

--- a/assets/sass/_variables.scss
+++ b/assets/sass/_variables.scss
@@ -1,6 +1,6 @@
 $base-z-index: 0;
 $base-border-radius: 3px;
-$tiny-border-radius: ($base-border-radius / 3);
+$tiny-border-radius: 1px;
 $large-border-radius: ($base-border-radius * 4);
 
 $transition-timing: .2s;

--- a/assets/sass/_video.scss
+++ b/assets/sass/_video.scss
@@ -1,7 +1,7 @@
 // Shameless nicked from http://refills.bourbon.io/components/#er-toc-id-17
 
 .video {
-  margin-bottom: $medium-spacing;
+  margin-bottom: $base-spacing;
 
   .video-wrapper {
     height: 0;

--- a/assets/sass/_video.scss
+++ b/assets/sass/_video.scss
@@ -1,17 +1,21 @@
 // Shameless nicked from http://refills.bourbon.io/components/#er-toc-id-17
 
-.video-wrapper {
-  height: 0;
-  overflow: hidden;
-  padding-bottom: 56.25%; // For ratio 16:9. 75% if ratio is 4:3
-  position: relative;
+.video {
+  margin-bottom: $medium-spacing;
 
-  embed,
-  object,
-  iframe {
-    @include position(absolute, 0 null null 0);
-    @include size(100%);
+  .video-wrapper {
+    height: 0;
+    overflow: hidden;
+    padding-bottom: 56.25%; // For ratio 16:9. 75% if ratio is 4:3
+    position: relative;
 
-    border: none;
+    embed,
+    object,
+    iframe {
+      @include position(absolute, 0 null null 0);
+      @include size(100%);
+
+      border: none;
+    }
   }
 }

--- a/assets/sass/templates/local-navigation.hbs
+++ b/assets/sass/templates/local-navigation.hbs
@@ -1,19 +1,22 @@
 <nav class="local-nav" aria-label="main navigation">
+
+  <h1><a href="#" class="active">Department of Communications and the Arts</a></h1>
+
   <ul>
-    <li><a href="#">Parent link</a></li>
     <li>
-      <a href="#">Parent link</a>
+      <a href="#" class="active">People and structure</a>
       <ul>
-        <li><a href="#" class="active">Current page</a></li>
+        <li><a href="#">Division name</a></li>
         <li>
-          <a href="#">Child link</a>
+          <a href="#" class="active">Division name</a>
           <ul>
-            <li><a href="#">Grandchild link</a></li>
-            <li><a href="#">Grandchild link</a></li>
+            <li><a href="#" class="active current">Branch name</a></li>
+            <li><a href="#">Branch name</a></li>
           </ul>
         </li>
-        <li><a href="#">Parent link</a></li>
+        <li><a href="#">Division name</a></li>
       </ul>
     </li>
+    <li><a href="#">People and structure</a></li>
   </ul>
 </nav>

--- a/examples/index.html
+++ b/examples/index.html
@@ -489,8 +489,8 @@
             <label for="message">Your message</label>
             <textarea id="message"></textarea>
           </p>
-          <input type="submit" value="Submit"/>
-          <input type="reset" value="Reset"/>
+          <input role="button" type="submit" value="Submit"/>
+          <input role="button" type="reset" value="Reset"/>
         </form>
 
       </section>

--- a/examples/type-contact.html
+++ b/examples/type-contact.html
@@ -170,7 +170,7 @@
       <p>If you have a hearing or speech impairment, use the <a href="http://relayservice.gov.au/">National Relay Service</a> to access any of our listed phone numbers.<br>
       Telephone: <a href="tel:1300555727">1300 555 727</a></p>
 
-      <h3 id="media-enquiries">Media enquiries</h3>
+      <h3>Media enquiries</h3>
 
       <p><a href="tel:+61262711777">02 6271 1777</a>
       9am – 5pm AEDST<br>

--- a/examples/type-contact.html
+++ b/examples/type-contact.html
@@ -1,0 +1,290 @@
+<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<!--[if lt IE 7 ]>
+<html lang="en" class="ie6 no-js">    <![endif]-->
+<!--[if IE 7 ]>
+<html lang="en" class="ie7 no-js">    <![endif]-->
+<!--[if IE 8 ]>
+<html lang="en" class="ie8 no-js">    <![endif]-->
+<!--[if IE 9 ]>
+<html lang="en" class="ie9 no-js">    <![endif]-->
+<!--[if (gt IE 9)|!(IE)]><!-->
+<html lang="en" class="no-js"><!--<![endif]-->
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="x-ua-compatible" content="ie=edge">
+  <!-- viewport declaration must be included in <head> for media queries to work correctly on real devices -->
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Example Pages</title>
+
+  <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.16/webfont.js"></script>
+  <script>
+    WebFont.load({
+      google: {
+        families: ['Open+Sans:400italic,700,400:latin,latin-ext']
+      }
+    });
+  </script>
+
+  <link rel="stylesheet" type="text/css" href="../latest/ui-kit.css"/>
+
+  <!--[if lt IE 9]>
+  <script src="//code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ="
+          crossorigin="anonymous"></script>
+  <script type="text/javascript"
+          src="//cdnjs.cloudflare.com/ajax/libs/corysimmons-selectivizr2/1.0.8/selectivizr2.min.js"></script>
+  <![endif]-->
+  <!--[if lte IE 9]>
+  <script type='text/javascript' src='//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js'></script>
+  <script type='text/javascript'
+          src='//cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.3/jquery.xdomainrequest.min.js'></script>
+  <![endif]-->
+
+  <script type="text/javascript" src="../latest/ui-kit.js"></script>
+
+</head>
+<body>
+
+  <div class="skip-to">
+    <a href="#content">Skip to main content</a>
+    <a href="#nav">Skip to section navigation</a>
+  </div>
+
+  <header role="banner">
+
+    <section class="controls--contrast">
+      <div class="wrapper">
+        <section>
+          <nav class="breadcrumbs--inverted" aria-label="controls-breadcrumb">
+            <ul>
+              <li><a href="#" title="Home">Editorial</a></li>
+              <li><a href="#" title="Menu1">PMC</a></li>
+              <li>Menu2</li>
+            </ul>
+          </nav>
+          <a href="#" role="button">Edit</a>
+        </section>
+        <section class="right">
+          <ul class="inline-links--inverted">
+            <li><a href="#">Help</a></li>
+            <li><a href="#">Sign Out</a></li>
+          </ul>
+        </section>
+      </div>
+    </section>
+    <section class="govau--header">
+      <div class="wrapper">
+        <div class="govau--logo">
+          <a href="#" class="logo">gov.au</a> <span class="badge--default">draft</span>
+        </div>
+        <div class="feedback" tabindex="1">
+          <a href="#" class="button--feedback">Give feedback</a>
+        </div>
+        <nav class="global-nav" aria-label="global navigation" tabindex="2">
+          <ul>
+            <li><a href="#">About us</a></li>
+            <li><a href="#">Information and services</a></li>
+            <li><a href="#">Ministers</a></li>
+            <li><a href="#">News</a></li>
+            <li><a href="#">Departments & Agencies</a></li>
+            <li><a href="#">Contact us</a></li>
+          </ul>
+          <div class="feedback">
+            <a href="#" class="button--feedback">Give feedback</a>
+          </div>
+        </nav>
+      </div>
+    </section>
+    <section class="hero">
+      <div class="wrapper">
+        <span class="site-title">Department of Intertubes</span>
+        <p class="tagline">Calibration of intertube serialisation will be a real game-changer.</p>
+      </div>
+    </section>
+  </header>
+
+  <nav class="breadcrumbs" aria-label="breadcrumb">
+    <div class="wrapper">
+      <ul>
+        <li><a href="#" title="Home">Home</a></li>
+        <li><a href="#" title="Menu1">Menu1</a></li>
+        <li>Menu2</li>
+      </ul>
+    </div>
+  </nav>
+
+  <main>
+    <aside class="sidebar" id="nav">
+      <nav class="local-nav" aria-label="main navigation">
+        <ul>
+          <li><a href="#">Overview</a></li>
+          <li><a href="#">Purpose</a></li>
+          <li>
+            <a href="#">Foundations</a>
+            <ul class="sub-nav-list">
+              <li><a href="#">Overview</a></li>
+              <li><a href="#">Design principles</a></li>
+              <li><a href="#">Grid</a></li>
+              <li>
+                <a href="#">Typography</a>
+                <ul class="sub-sub-nav-list">
+                  <li><a href="#">Line height and spacing</a></li>
+                  <li><a href="#">Typesetting</a></li>
+                </ul>
+              </li>
+              <li><a href="#">Text accessibility</a></li>
+              <li><a href="#">Links</a></li>
+              <li><a href="#">Lists</a></li>
+            </ul>
+          </li>
+        </ul>
+      </nav>
+    </aside>
+
+    <article class="content-main" id="content">
+      <h1>
+      Contact us
+      </h1>
+
+      <p>
+      </p>
+      <p class="abstract">You can contact us in a number of ways.</p>
+
+      <h2 id="email">Email</h2>
+
+      <h3 id="copyright">Copyright</h3>
+
+      <p><a href="mailto:copyright@communications.gov.au">copyright@communications.gov.au</a></p>
+
+      <h3 id="media-enquiries">Media enquiries</h3>
+
+      <p><a href="mailto:media@communications.gov.au">media@communications.gov.au</a></p>
+
+      <h2 id="phone">Phone</h2>
+
+      <p><a href="tel:+61262711000">02 6271 1000</a><br>
+      Free call: <a href="tel:1800254649">1800 254 649</a><br>
+      9am – 5pm AEDST<br>
+      Monday to Friday excluding ACT public holidays  </p>
+
+      <p>If you have a hearing or speech impairment, use the <a href="http://relayservice.gov.au/">National Relay Service</a> to access any of our listed phone numbers.<br>
+      Telephone: <a href="tel:1300555727">1300 555 727</a></p>
+
+      <h3 id="media-enquiries">Media enquiries</h3>
+
+      <p><a href="tel:+61262711777">02 6271 1777</a>
+      9am – 5pm AEDST<br>
+      Monday to Friday excluding ACT public holidays</p>
+
+      <h2 id="locations-and-opening-hours">Locations and opening hours</h2>
+
+      <p>38 Sydney Avenue<br>
+      Forrest ACT 2608<br>
+      9am – 5pm AEDST<br>
+      Monday to Friday excluding ACT public holidays  </p>
+
+      <h2 id="post">Post</h2>
+
+      <p>Department of Communications and the Arts<br>
+      GPO Box 2154<br>
+      Canberra ACT 2601<br>
+      Australia</p>
+
+      <h2 id="social-media">Social media</h2>
+
+      <p>Linkedin: <a href="https://www.linkedin.com/company/commsau">Department of Communications and the Arts</a><br>
+      Twitter: <a href="https://twitter.com/CommsAu">@CommsAu</a><br>
+      Youtube: <a href="https://www.youtube.com/user/DeptCommsAu">Department of Communications and the Arts</a>  </p>
+
+      <h3 id="arts">Arts</h3>
+
+      <p>Twitter: <a href="https://twitter.com/ArtsCultureGov">@ArtsCultureGov</a>  </p>
+
+      <h2 id="how-we-handle-enquiries">How we handle enquiries</h2>
+
+      <h3 id="client-service-charter"><a>Client Service Charter</a></h3>
+
+      <p>We aim to provide you with a high level of service.  </p>
+
+      <h3 id="complaints-handling-policy"><a>Complaints Handling Policy</a></h3>
+
+      <p>How to complain about us and have your concerns addressed.</p>
+
+      <h3 id="privacy-policy"><a>Privacy Policy</a></h3>
+
+      <p>How we handle personal and sensitive information.  </p>
+
+      <h3 id="reporting-fraud-policy"><a>Reporting Fraud Policy</a></h3>
+
+      <p>You are strongly encouraged to report any suspected fraud incidents against us.  </p>
+
+      <h3 id="public-interest-disclosure"><a>Public Interest Disclosure</a></h3>
+
+      <p>How to report serious wrongdoing in the Commonwealth public sector.  </p>
+
+      <h3 id="freedom-of-information-foi-requests"><a>Freedom of information (FOI) requests</a></h3>
+
+      <p>Learn more about our FOI obligations and how to make a request.  </p>
+
+      <p></p>
+
+    </article>
+  </main>
+
+  <footer role="contentinfo">
+    <div class="wrapper">
+      <section class="footer-top">
+        <nav>
+          <ul>
+            <li><h3>Title header</h3></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+          </ul>
+          <ul>
+            <li><h3>Title header</h3></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+          </ul>
+          <ul>
+            <li><h3>Title header</h3></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+          </ul>
+          <ul>
+            <li><h3>Title header</h3></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+          </ul>
+        </nav>
+      </section>
+      <section>
+        <div class="footer-logo">
+          <img alt="Australian Government Coat of Arms" src="/latest/img/coat-of-arms.png">
+        </div>
+        <div class="footer-links">
+          <nav>
+            <ul>
+              <li><a href="javascript:void(0)">Example global link</a></li>
+              <li><a href="javascript:void(0)">Example global link</a></li>
+              <li><a href="javascript:void(0)">Example global link</a></li>
+              <li><a href="javascript:void(0)">Example global link</a></li>
+              <li><a href="javascript:void(0)">Example global link</a></li>
+            </ul>
+          </nav>
+          <p>&copy; Commonwealth of Australia <br>
+          <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE.md">Licensed under the MIT License.</a></p>
+        </div>
+      </section>
+      </div>
+    </footer>
+
+  </body>
+</html>

--- a/examples/type-role.html
+++ b/examples/type-role.html
@@ -192,11 +192,6 @@
           <li><a href="#">Content classification</a></li>
         </ul>
 
-        <p>As cunning as a brick sh*t house where gutful of slacker. Get a dog up ya cobber to she'll be right chuck a sickie. yobbo where come a freo. He's got a massive back of bourke shazza got us some thongs.</p>
-
-        <h4>Lorem ipsum dolor sit amet</h4>
-        <p>Get a dog up ya corker to come a christmas. Lets throw a <strong>piker bloody</strong> as dry as a grundies. jumbuck heaps come a icy pole. She'll be right back of bourke also she'll be right cream.</p>
-
         <h3 id="post">Post</h3>
 
         <p>Advising the Australian Government on how the postal industry can best serve the public.</p>

--- a/examples/type-role.html
+++ b/examples/type-role.html
@@ -146,8 +146,7 @@
         Our role
         </h1>
 
-        <p>
-        </p><p class="abstract">Through our analysis, advice and programs we aim to make the arts and communications sectors better for everyone.</p>
+        <p class="abstract">Through our analysis, advice and programs we aim to make the arts and communications sectors better for everyone.</p>
 
         <h2 id="responsibilities">Responsibilities</h2>
 
@@ -180,8 +179,8 @@
         <p>Ensuring everyone has reasonable access to reliable phone services.</p>
 
         <ul>
-        <li><a href="#">Mobile phone black spots</a></li>
-        <li><a href="#">Accessible phone services</a></li>
+          <li><a href="#">Mobile phone black spots</a></li>
+          <li><a href="#">Accessible phone services</a></li>
         </ul>
 
         <h3 id="radio">Radio</h3>
@@ -189,16 +188,21 @@
         <p>Giving everyone access to radio and assisting in the roll-out of digital radio.</p>
 
         <ul>
-        <li><a href="#">Digital radio</a></li>
-        <li><a href="#">Content classification</a></li>
+          <li><a href="#">Digital radio</a></li>
+          <li><a href="#">Content classification</a></li>
         </ul>
+
+        <p>As cunning as a brick sh*t house where gutful of slacker. Get a dog up ya cobber to she'll be right chuck a sickie. yobbo where come a freo. He's got a massive back of bourke shazza got us some thongs.</p>
+
+        <h4>Lorem ipsum dolor sit amet</h4>
+        <p>Get a dog up ya corker to come a christmas. Lets throw a <strong>piker bloody</strong> as dry as a grundies. jumbuck heaps come a icy pole. She'll be right back of bourke also she'll be right cream.</p>
 
         <h3 id="post">Post</h3>
 
         <p>Advising the Australian Government on how the postal industry can best serve the public.</p>
 
         <ul>
-        <li><a href="#">Posting in Australia and overseas</a></li>
+          <li><a href="#">Posting in Australia and overseas</a></li>
         </ul>
 
         <h3 id="spectrum">Spectrum</h3>

--- a/examples/type-role.html
+++ b/examples/type-role.html
@@ -1,0 +1,380 @@
+<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<!--[if lt IE 7 ]>
+<html lang="en" class="ie6 no-js">    <![endif]-->
+<!--[if IE 7 ]>
+<html lang="en" class="ie7 no-js">    <![endif]-->
+<!--[if IE 8 ]>
+<html lang="en" class="ie8 no-js">    <![endif]-->
+<!--[if IE 9 ]>
+<html lang="en" class="ie9 no-js">    <![endif]-->
+<!--[if (gt IE 9)|!(IE)]><!-->
+<html lang="en" class="no-js"><!--<![endif]-->
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="x-ua-compatible" content="ie=edge">
+  <!-- viewport declaration must be included in <head> for media queries to work correctly on real devices -->
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Example Pages</title>
+
+  <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.16/webfont.js"></script>
+  <script>
+    WebFont.load({
+      google: {
+        families: ['Open+Sans:400italic,700,400:latin,latin-ext']
+      }
+    });
+  </script>
+
+  <link rel="stylesheet" type="text/css" href="../latest/ui-kit.css"/>
+
+  <!--[if lt IE 9]>
+  <script src="//code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ="
+          crossorigin="anonymous"></script>
+  <script type="text/javascript"
+          src="//cdnjs.cloudflare.com/ajax/libs/corysimmons-selectivizr2/1.0.8/selectivizr2.min.js"></script>
+  <![endif]-->
+  <!--[if lte IE 9]>
+  <script type='text/javascript' src='//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js'></script>
+  <script type='text/javascript'
+          src='//cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.3/jquery.xdomainrequest.min.js'></script>
+  <![endif]-->
+
+  <script type="text/javascript" src="../latest/ui-kit.js"></script>
+
+</head>
+<body>
+
+  <div class="skip-to">
+    <a href="#content">Skip to main content</a>
+    <a href="#nav">Skip to section navigation</a>
+  </div>
+
+  <header role="banner">
+
+    <section class="controls--contrast">
+      <div class="wrapper">
+        <section>
+          <nav class="breadcrumbs--inverted" aria-label="controls-breadcrumb">
+            <ul>
+              <li><a href="#" title="Home">Editorial</a></li>
+              <li><a href="#" title="Menu1">PMC</a></li>
+              <li>Menu2</li>
+            </ul>
+          </nav>
+          <a href="#" role="button">Edit</a>
+        </section>
+        <section class="right">
+          <ul class="inline-links--inverted">
+            <li><a href="#">Help</a></li>
+            <li><a href="#">Sign Out</a></li>
+          </ul>
+        </section>
+      </div>
+    </section>
+    <section class="govau--header">
+      <div class="wrapper">
+        <div class="govau--logo">
+          <a href="#" class="logo">gov.au</a> <span class="badge--default">draft</span>
+        </div>
+        <div class="feedback" tabindex="1">
+          <a href="#" class="button--feedback">Give feedback</a>
+        </div>
+        <nav class="global-nav" aria-label="global navigation" tabindex="2">
+          <ul>
+            <li><a href="#">About us</a></li>
+            <li><a href="#">Information and services</a></li>
+            <li><a href="#">Ministers</a></li>
+            <li><a href="#">News</a></li>
+            <li><a href="#">Departments & Agencies</a></li>
+            <li><a href="#">Contact us</a></li>
+          </ul>
+          <div class="feedback">
+            <a href="#" class="button--feedback">Give feedback</a>
+          </div>
+        </nav>
+      </div>
+    </section>
+    <section class="hero">
+      <div class="wrapper">
+        <span class="site-title">Department of Intertubes</span>
+        <p class="tagline">Calibration of intertube serialisation will be a real game-changer.</p>
+      </div>
+    </section>
+  </header>
+
+  <nav class="breadcrumbs" aria-label="breadcrumb">
+    <div class="wrapper">
+      <ul>
+        <li><a href="#" title="Home">Home</a></li>
+        <li><a href="#" title="Menu1">Menu1</a></li>
+        <li>Menu2</li>
+      </ul>
+    </div>
+  </nav>
+
+  <main>
+    <aside class="sidebar" id="nav">
+      <nav class="local-nav" aria-label="main navigation">
+        <ul>
+          <li><a href="#">Overview</a></li>
+          <li><a href="#">Purpose</a></li>
+          <li>
+            <a href="#">Foundations</a>
+            <ul class="sub-nav-list">
+              <li><a href="#">Overview</a></li>
+              <li><a href="#">Design principles</a></li>
+              <li><a href="#">Grid</a></li>
+              <li>
+                <a href="#">Typography</a>
+                <ul class="sub-sub-nav-list">
+                  <li><a href="#">Line height and spacing</a></li>
+                  <li><a href="#">Typesetting</a></li>
+                </ul>
+              </li>
+              <li><a href="#">Text accessibility</a></li>
+              <li><a href="#">Links</a></li>
+              <li><a href="#">Lists</a></li>
+            </ul>
+          </li>
+        </ul>
+      </nav>
+    </aside>
+
+    <article class="content-main" id="content">
+        <h1>
+        Our role
+        </h1>
+
+        <p>
+        </p><p class="abstract">Through our analysis, advice and programs we aim to make the arts and communications sectors better for everyone.</p>
+
+        <h2 id="responsibilities">Responsibilities</h2>
+
+        <p>We help the communications sector stay competitive and innovative by providing advice, delivering programs and conducting research.</p>
+
+        <p>We also manage programs that encourage artists, support Australia's cultural heritage and help the public to experience arts and culture.</p>
+
+        <h2 id="information-and-services">Information and services</h2>
+
+        <h3 id="internet">Internet</h3>
+
+        <p>Providing access to high-quality, reliable and affordable internet services.</p>
+
+        <ul>
+        <li><a href="#">Internet speeds</a></li>
+        <li><a href="#">Internet safety</a></li>
+        </ul>
+
+        <h3 id="television">Television</h3>
+
+        <p>Regulating the TV industry and its services.</p>
+
+        <ul>
+        <li><a href="#">Television reception</a></li>
+        <li><a href="#">Television content rules</a></li>
+        </ul>
+
+        <h3 id="phone">Phone</h3>
+
+        <p>Ensuring everyone has reasonable access to reliable phone services.</p>
+
+        <ul>
+        <li><a href="#">Mobile phone black spots</a></li>
+        <li><a href="#">Accessible phone services</a></li>
+        </ul>
+
+        <h3 id="radio">Radio</h3>
+
+        <p>Giving everyone access to radio and assisting in the roll-out of digital radio.</p>
+
+        <ul>
+        <li><a href="#">Digital radio</a></li>
+        <li><a href="#">Content classification</a></li>
+        </ul>
+
+        <h3 id="post">Post</h3>
+
+        <p>Advising the Australian Government on how the postal industry can best serve the public.</p>
+
+        <ul>
+        <li><a href="#">Posting in Australia and overseas</a></li>
+        </ul>
+
+        <h3 id="spectrum">Spectrum</h3>
+
+        <p>Ensuring the electromagnetic spectrum can be used with current electronic devices.</p>
+
+        <ul>
+        <li><a href="#">Spectrum licences</a></li>
+        <li><a href="#">Emergency services</a></li>
+        <li><a href="#">Digital dividend spectrum</a></li>
+        </ul>
+
+        <h3 id="copyright">Copyright</h3>
+
+        <p>Providing legal protection for people who express ideas and information in certain forms.</p>
+
+        <ul>
+        <li><a href="#">Copyright</a></li>
+        <li><a href="#">Intellectual property (IP)</a></li>
+        </ul>
+
+        <h3 id="classification">Classification</h3>
+
+        <p>Helping the Classification Board to make decisions about the classification of films, television, books and music.</p>
+
+        <ul>
+        <li><a href="#">The classification code</a></li>
+        </ul>
+
+        <h3 id="arts">Arts</h3>
+
+        <p>Encouraging excellence in art, support for cultural heritage and public access to arts and culture.</p>
+
+        <ul>
+        <li><a href="#">Prime Minister's Literary Awards</a></li>
+        <li><a href="#">Lending rights</a></li>
+        <li><a href="#">Arts funding</a></li>
+        </ul>
+
+        <h2 id="portfolio-agencies-we-work-with">Portfolio agencies we work with</h2>
+
+        <p>We work closely with other Government agencies within the Communications portfolio to provide all Australians with information and services.</p>
+
+        <p>A portolio is an area of responsibility for how Australia is run. The Communications portfolio is led by the <a href="link">Minister for Communications</a>.</p>
+
+        <h3 id="australia-council-for-the-arts"><a href="http://www.australiacouncil.gov.au/">Australia Council for the Arts</a></h3>
+
+        <p>The Australian Government's arts funding and advisory body.</p>
+
+        <h3 id="australia-post"><a href="http://auspost.com.au/">Australia Post</a></h3>
+
+        <p>Providing reliable and affordable postal, retail, financial and travel services.</p>
+
+        <h3 id="australian-broadcasting-corporation-abc"><a href="http://www.abc.net.au/">Australian Broadcasting corporation (ABC)</a></h3>
+
+        <p>Australia’s public broadcaster, including national and local television and radio programs.</p>
+
+        <h3 id="australian-communications-and-media-authority-acma"><a href="http://www.acma.gov.au/">Australian Communications and Media Authority (ACMA)</a></h3>
+
+        <p>Responsible for the regulation of broadcasting, the internet, radiocommunications and telecommunications.</p>
+
+        <h3 id="australian-film-television-and-radio-school-aftrs"><a href="https://www.aftrs.edu.au/">Australian Film Television and Radio School (AFTRS)</a></h3>
+
+        <p>The leading institution for the education and training of creative talent.</p>
+
+        <h3 id="australian-national-maritime-museum"><a href="http://www.anmm.gov.au/">Australian National Maritime Museum</a></h3>
+
+        <p>Australia’s national centre for maritime collections, exhibitions, research and archaeology.</p>
+
+        <h3 id="bundanon-trust"><a href="https://bundanon.com.au/">Bundanon Trust</a></h3>
+
+        <p>Supporting arts practice and engagement through education, exhibition and performance programs.</p>
+
+        <h3 id="australia-business-arts-foundation-operating-as-creative-partnerships-australia"><a href="https://www.creativepartnershipsaustralia.org.au/">Australia Business Arts Foundation (operating as Creative Partnerships Australia)</a></h3>
+
+        <p>Bringing artists, donors, businesses and arts organisations together to promote a more sustainable and vibrant arts sector.</p>
+
+        <h3 id="the-museum-of-australian-democracy"><a href="http://moadoph.gov.au/">The Museum of Australian Democracy</a></h3>
+
+        <p>Helping people to understand Australia’s social and political history by interpreting the past and present and exploring the future.</p>
+
+        <h3 id="national-film-and-sound-archive"><a href="http://www.nfsa.gov.au/">National Film and Sound Archive</a></h3>
+
+        <p>The nation’s living archive – collecting, preserving and sharing our rich audiovisual heritage.</p>
+
+        <h3 id="national-gallery-of-australia-nga"><a href="http://nga.gov.au/">National Gallery of Australia (NGA)</a></h3>
+
+        <p>Australia's national cultural institution for the visual arts.</p>
+
+        <h3 id="national-library-of-australia-nla"><a href="https://www.nla.gov.au/">National Library of Australia (NLA)</a></h3>
+
+        <p>Ensuring that important documentary resources are collected, preserved and made accessible to the public.</p>
+
+        <h3 id="national-museum-of-australia"><a href="http://www.nma.gov.au/">National Museum of Australia</a></h3>
+
+        <p>A social history museum exploring the land, nation and people of Australia.</p>
+
+        <h3 id="national-portrait-gallery-australia-npga"><a href="http://www.portrait.gov.au/">National Portrait Gallery Australia (NPGA)</a></h3>
+
+        <p>The national collection of portraits of Australians reflects the breadth and energy of Australian culture and endeavour.</p>
+
+        <h3 id="nbn-co-limited"><a href="http://www.nbnco.com.au/">NBN Co Limited</a></h3>
+
+        <p>Delivering Australia’s first national, open access broadband network to all Australians.</p>
+
+        <h3 id="office-of-the-children-s-e-safety-commissioner"><a href="https://www.esafety.gov.au/">Office of the Children’s e-Safety Commissioner</a></h3>
+
+        <p>Committed to helping young people have safe, positive experiences online.</p>
+
+        <h3 id="screen-australia"><a href="http://www.screenaustralia.gov.au/">Screen Australia</a></h3>
+
+        <p>Funding the production of everything from feature films to documentaries, television drama, children’s programs and online web series.</p>
+
+        <h3 id="special-broadcasting-service-sbs"><a href="http://www.sbs.com.au/">Special broadcasting service (SBS)</a></h3>
+
+        <p>Australia’s multicultural and multilingual broadcaster.</p>
+
+        <p></p>
+
+    </article>
+  </main>
+
+  <footer role="contentinfo">
+    <div class="wrapper">
+      <section class="footer-top">
+        <nav>
+          <ul>
+            <li><h3>Title header</h3></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+          </ul>
+          <ul>
+            <li><h3>Title header</h3></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+          </ul>
+          <ul>
+            <li><h3>Title header</h3></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+          </ul>
+          <ul>
+            <li><h3>Title header</h3></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+          </ul>
+        </nav>
+      </section>
+      <section>
+        <div class="footer-logo">
+          <img alt="Australian Government Coat of Arms" src="/latest/img/coat-of-arms.png">
+        </div>
+        <div class="footer-links">
+          <nav>
+            <ul>
+              <li><a href="javascript:void(0)">Example global link</a></li>
+              <li><a href="javascript:void(0)">Example global link</a></li>
+              <li><a href="javascript:void(0)">Example global link</a></li>
+              <li><a href="javascript:void(0)">Example global link</a></li>
+              <li><a href="javascript:void(0)">Example global link</a></li>
+            </ul>
+          </nav>
+          <p>&copy; Commonwealth of Australia <br>
+          <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE.md">Licensed under the MIT License.</a></p>
+        </div>
+      </section>
+      </div>
+    </footer>
+
+  </body>
+</html>


### PR DESCRIPTION
## Description

This holds all the style changes done on 21/07 between cbr&syd teams in Sydney.
## Additional information
- Simplifies and better distinguishes base heading styles from `h1` to `h4` (`h5` & `h6` are identical), and separates more typographical needy stuff out under `.gov-speak`.
- Ups the core content font size from effectively 16px to 17px.
- Removes `margin-top` (previously provided by `normalize.css` — noting b/c it might affect others’ prototypes).
- …

Local nav updates:
- Extended with a new class: `.current` to denote the current within the IA of the nav tree.
- …

Minor:
- Replaces instances of `$small-spacing / 2` with `$tiny-spacing`.
- Adds some new example html files used for testing in `examples/`.
- (subsequently) Re-applies a margin-top to select affected elements.
- …
