### PR TITLE
Doc/calendar tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 UI-Kit:
 
+- New table style: calendar tables, for displaying a series of days and their events (eg public holidays).
 - Local nav (sidebar):
   - [undocumented] Adds new `.current` class for current page in the IA.
   - [incomplete & undocumented] Adds top-level item support.

--- a/assets/sass/_tables.scss
+++ b/assets/sass/_tables.scss
@@ -92,22 +92,9 @@ Markup:
 Style guide: Tables.3 Complex Tables
 */
 
-/*
-Accessibility
-
-The HTML for tables needs to be carefully considered for accessibility.
-* Consider using the [`scope` attribute](https://www.w3.org/TR/html401/struct/tables.html#adef-scope) to associate the header to a row or column
-* Consider using a [`<caption>` element](https://www.w3.org/wiki/HTML/Elements/caption) to title the table
-* Avoid complex tables with multiple levels of headers and spanned cells
-
-[Further guidance on tables at w3.org](https://www.w3.org/WAI/tutorials/tables/)
-
-### Table head, body, and foot
-The [`<thead>`, `<tbody>`, and `<tfoot>` elements](https://www.w3.org/TR/html401/struct/tables.html#h-11.2.3) provide no accessibility functionality but depending on browser support `<thead>` and `<tfoot>` may be repeated across pages when long tables are printed.
-
-Style guide: Tables.2 Accessibility
-*/
-
+table {
+  margin-bottom: $base-spacing;
+}
 
 .content-table {
   width: 100%;
@@ -200,3 +187,19 @@ Style guide: Tables.2 Accessibility
     background-color: $background-secondary-colour;
   }
 }
+
+/*
+Accessibility
+
+The HTML for tables needs to be carefully considered for accessibility.
+* Consider using the [`scope` attribute](https://www.w3.org/TR/html401/struct/tables.html#adef-scope) to associate the header to a row or column
+* Consider using a [`<caption>` element](https://www.w3.org/wiki/HTML/Elements/caption) to title the table
+* Avoid complex tables with multiple levels of headers and spanned cells
+
+[Further guidance on tables at w3.org](https://www.w3.org/WAI/tutorials/tables/)
+
+### Table head, body, and foot
+The [`<thead>`, `<tbody>`, and `<tfoot>` elements](https://www.w3.org/TR/html401/struct/tables.html#h-11.2.3) provide no accessibility functionality but depending on browser support `<thead>` and `<tfoot>` may be repeated across pages when long tables are printed.
+
+Style guide: Tables.4 Accessibility
+*/

--- a/examples/index.html
+++ b/examples/index.html
@@ -195,15 +195,15 @@
       <table class="calendar-table">
         <caption>Interesting stuff, 1518</caption>
         <tr>
-          <th scope="row"><time datetime="1518-15-07T02:30:00+00:00">Monday <span>15</span> July</time></th>
+          <th scope="row"><time datetime="1518-07-15">Monday <span>15</span> July</time></th>
           <td><a href="https://en.wikipedia.org/wiki/Dancing_Plague_of_1518" rel="external">DDR Dance Mania, Strasbourg edition</a></td>
         </tr>
         <tr>
-          <th scope="row"><time datetime="1518-01-07T02:30:00+00:00">Tuesday <span>16</span> July</time></th>
+          <th scope="row"><time datetime="1518-07-01">Tuesday <span>16</span> July</time></th>
           <td>Dance Mania afterparty <span class="date-info">dance till you drop!</span></td>
         </tr>
         <tr>
-          <th scope="row"><time datetime="1518-01-30T02:30:00+00:00">Tuesday <span>30</span> July</time></th>
+          <th scope="row"><time datetime="1518-30-07">Tuesday <span>30</span> July</time></th>
           <td>Dead people cleanup day</td>
         </tr>
       </table>

--- a/examples/index.html
+++ b/examples/index.html
@@ -192,6 +192,22 @@
 
       <p>incoming&hellip;</p>
 
+      <table class="calendar-table">
+        <caption>Interesting stuff, 1518</caption>
+        <tr>
+          <th scope="row"><time datetime="1518-15-07T02:30:00+00:00">Monday <span>15</span> July</time></th>
+          <td><a href="https://en.wikipedia.org/wiki/Dancing_Plague_of_1518" rel="external">DDR Dance Mania, Strasbourg edition</a></td>
+        </tr>
+        <tr>
+          <th scope="row"><time datetime="1518-01-07T02:30:00+00:00">Tuesday <span>16</span> July</time></th>
+          <td>Dance Mania afterparty <span class="date-info">dance till you drop!</span></td>
+        </tr>
+        <tr>
+          <th scope="row"><time datetime="1518-01-30T02:30:00+00:00">Tuesday <span>30</span> July</time></th>
+          <td>Dead people cleanup day</td>
+        </tr>
+      </table>
+
       <p>Vertical rhythm should be <strong>maintained</strong> between content elements:</p>
 
       <ul>

--- a/examples/index.html
+++ b/examples/index.html
@@ -203,7 +203,7 @@
           <td>Dance Mania afterparty <span class="date-info">dance till you drop!</span></td>
         </tr>
         <tr>
-          <th scope="row"><time datetime="1518-30-07">Tuesday <span>30</span> July</time></th>
+          <th scope="row"><time datetime="1518-07-30">Tuesday <span>30</span> July</time></th>
           <td>Dead people cleanup day</td>
         </tr>
       </table>


### PR DESCRIPTION
Adds calendar table example to `examples/index.html` and adds missing margin-bottom to `table`s.
