### PR TITLE
Adds tel to forms + margins to labels and hint text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 UI-Kit:
 
+- Text input `type` `tel` support.
 - New table style: calendar tables, for displaying a series of days and their events (eg public holidays).
 - Local nav (sidebar):
   - [undocumented] Adds new `.current` class for current page in the IA.

--- a/assets/sass/_forms.scss
+++ b/assets/sass/_forms.scss
@@ -17,7 +17,7 @@ Text input
 
 Single line text inputs.
 
-They can be limited to number input only by setting the `type` attribute to `number`. To trigger the num-pad on iPhones, add a pattern attribute to the input element: `pattern="[0-9]*"`.
+They can be limited to number input only by setting the `type` attribute to `number`. For telephone numbers set the `type` attribute to `tel`. To trigger the num-pad on iPhones, add a pattern attribute to the input element: `pattern="[0-9]*"`.
 
 Markup: templates/text-input-single-line.hbs
 
@@ -64,16 +64,20 @@ form {
 
   label {
     display: block;
+    margin-bottom: $tiny-spacing;
+    margin-top: $tiny-spacing;
   }
 
   .hint {
     display: block;
-    color: $body-text-colour;
+    margin-bottom: $tiny-spacing;
     font-size: rem(14);
+    color: $body-text-colour;
   }
 
   [type='text'],
   [type='number'],
+  [type='tel'],
   [type='email'],
   [type='password'] {
     @extend %base-input;
@@ -217,7 +221,7 @@ Markup:
     <label for="aaa">AAA</label>
     <input id="bbb" name="reply" type="checkbox" value="BBB"/>
     <label for="bbb">BBB</label>
-     <input id="ccc" name="reply" type="checkbox" value="CCC"/>
+    <input id="ccc" name="reply" type="checkbox" value="CCC"/>
     <label for="ccc">CCC</label>
   </fieldset>
 </form>

--- a/assets/sass/templates/text-input-single-line.hbs
+++ b/assets/sass/templates/text-input-single-line.hbs
@@ -1,11 +1,15 @@
 <form>
   <p>
-    <label for="textin">A text input field</label>
+    <label for="textin">A <code>text</code> input field</label>
     <input name="textin" id="textin" type="text" />
   </p>
   <p>
-    <label for="numberin">A number input field</label>
+    <label for="numberin">A <code>number</code> input field</label>
     <input name="numberin" id="numberin" type="number" pattern="[0-9]*" />
+  </p>
+  <p>
+    <label for="phonein">A phone number (<code>tel</code>) input field:</label>
+    <input name="phonein" id="phonein" type="tel" pattern="[0-9]*" />
   </p>
   <p>
     <label for="textinvalid">An invalid field</label>
@@ -16,7 +20,7 @@
     <input name="textvalid" id="textvalid" type="text" class="valid" />
   </p>
   <p>
-    <label for="textdisabled">A disabled field</label>
+    <label for="textdisabled">A <code>disabled</code> field</label>
     <input name="textdisabled" id="textdisabled" type="text" disabled />
   </p>
 </form>


### PR DESCRIPTION
Adds `type="tel"` support for `input` and documentation of it (thanks to @jonathanconway from PR #188).

I’ve also given the `label`s and `.hint` text some more whitespace via margins, and fixed an indentation issue.
## Screenshots

Text inputs, inc. `tel`:
![screen shot 2016-07-25 at 2 56 07 pm](https://cloud.githubusercontent.com/assets/52766/17090877/394cb274-5278-11e6-845b-51f32021a4ca.png)

Margins for the labels and hint text:
![screen shot 2016-07-25 at 2 56 28 pm](https://cloud.githubusercontent.com/assets/52766/17090885/49478e1a-5278-11e6-9212-4d66552f94bb.png)
