### PR TITLE
Group of links ("Related"/"Popular") for multipurpose use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 ## UI Kit "Kraken"
 
-### Unreleased
+### 1.5.0 - Unreleased
 
 #### UI-Kit changes
 
 - Iconography
   -  Removed ui-kit-icons.css output file
   -  Added images.zip build output containing images used
+- Groups of links added (documented *§ Navigation*)
 
 ### 1.4.0 - 2016-07-27
 

--- a/assets/sass/_grid-settings.scss
+++ b/assets/sass/_grid-settings.scss
@@ -70,7 +70,7 @@ Style guide: Grid.4 Debugging
 */
 
 // Toggle visibility of your grid columns for development/debugging.
-$visual-grid: true;
+$visual-grid: false;
 
 $border-box-sizing: true;
 $disable-warnings: true;

--- a/assets/sass/_grid-settings.scss
+++ b/assets/sass/_grid-settings.scss
@@ -51,10 +51,15 @@ Style guide: Grid.3 Breakpoints
 */
 
 @import 'vendor/neat/neat-helpers';
-$mobile: new-breakpoint(min-width 420px 8);
-$mobile-only: new-breakpoint(min-width 420px max-width 768px - 1)
-$tablet: new-breakpoint(min-width 768px 12);
-$tablet-only: new-breakpoint(min-width 768px max-width 1200px - 1)
+
+$mobile-minwidth: 420px;
+$tablet-minwidth: 768px;
+$desktop-minwidth: 1200px;
+
+$mobile: new-breakpoint(min-width $mobile-minwidth 8);
+$mobile-only: new-breakpoint(min-width #{$mobile-minwidth} max-width #{$tablet-minwidth - 1} 8);
+$tablet: new-breakpoint(min-width $tablet-minwidth 12);
+$tablet-only: new-breakpoint(min-width #{$tablet-minwidth} max-width #{$desktop-minwidth - 1} 12);
 $desktop: new-breakpoint(min-width $max-width 16);
 
 /*

--- a/assets/sass/_grid-settings.scss
+++ b/assets/sass/_grid-settings.scss
@@ -70,7 +70,7 @@ Style guide: Grid.4 Debugging
 */
 
 // Toggle visibility of your grid columns for development/debugging.
-$visual-grid: false;
+$visual-grid: true;
 
 $border-box-sizing: true;
 $disable-warnings: true;

--- a/assets/sass/_grid-settings.scss
+++ b/assets/sass/_grid-settings.scss
@@ -52,9 +52,9 @@ Style guide: Grid.3 Breakpoints
 
 @import 'vendor/neat/neat-helpers';
 $mobile: new-breakpoint(min-width 420px 8);
-$mobile-only: new-breakpoint(min-width 420px max-width (768px - 1))
+$mobile-only: new-breakpoint(min-width 420px max-width 768px - 1)
 $tablet: new-breakpoint(min-width 768px 12);
-$tablet-only: new-breakpoint(min-width 768px max-width (1200px - 1))
+$tablet-only: new-breakpoint(min-width 768px max-width 1200px - 1)
 $desktop: new-breakpoint(min-width $max-width 16);
 
 /*

--- a/assets/sass/_grid-settings.scss
+++ b/assets/sass/_grid-settings.scss
@@ -52,7 +52,9 @@ Style guide: Grid.3 Breakpoints
 
 @import 'vendor/neat/neat-helpers';
 $mobile: new-breakpoint(min-width 420px 8);
+$mobile-only: new-breakpoint(min-width 420px max-width (768px - 1))
 $tablet: new-breakpoint(min-width 768px 12);
+$tablet-only: new-breakpoint(min-width 768px max-width (1200px - 1))
 $desktop: new-breakpoint(min-width $max-width 16);
 
 /*

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -548,7 +548,7 @@ Groups of links span from 2 columns (`$mobile`) up to 4 columns (`$tablet` and `
 You can use groups of links:
 
 - in the header (eg listing popular links across the site)
-- anywhere within an `article` (eg as a list of related links).
+- anywhere within an `article` (eg as a list of related topics).
 
 Markup: templates/groups-links.hbs
 

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -539,7 +539,53 @@ Style guide: Navigation.7 Skip links
 }
 
 
-/* Grouped links */
+// /* Grouped links 1 */
+// .links-group {
+//   @include outer-container;
+//   // margin: ($base-spacing * 1.5) 0;​
+//   margin-top: 3em;
+//
+//   h2 {
+//     font-size: 1em;
+//     margin-top: 0;
+//     padding: 0;
+//   }
+//
+//   .popular-now {
+//     margin: 0;
+//     padding: 0;
+//     list-style: none;
+//
+//     // ul {
+//     //   @include clearfix;
+//     //   margin: 0;
+//     //   padding: 0;
+//     //   list-style: none;
+//     // }
+//
+//     li {
+//       @include span-columns(4);
+//       float: left;
+//
+//       @include media ($mobile) {
+//         @include span-columns(2 of 4);
+//         // @include omega(2n);
+//         }
+//
+//       @include media ($tablet) {
+//         @include span-columns(3 of 12);
+//         @include omega(4n);
+//         }
+//
+//       @include media ($desktop) {
+//         @include span-columns(4 of 16);
+//         @include omega(4n);
+//         }
+//       }
+//   }
+// }
+
+/* Grouped links 2 */
 .links-group {
   @include outer-container;
   // margin: ($base-spacing * 1.5) 0;​
@@ -566,13 +612,14 @@ Style guide: Navigation.7 Skip links
     li {
       @include span-columns(4);
       float: left;
+      background-color: $aqua;
 
-      @include media ($mobile) {
+      @include media ($mobile-only) {
         @include span-columns(2 of 4);
-        // @include omega(2n);
+        @include omega(2n);
         }
 
-      @include media ($tablet) {
+      @include media ($tablet-only) {
         @include span-columns(3 of 12);
         @include omega(4n);
         }

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -558,25 +558,20 @@ Style guide: Navigation.7 Skip links
 
     li {
       // @include span-columns(4);
-      background-color: $aqua;
       min-height: 48px;
       float: left;
 
       @include media ($mobile) {
-        background-color: $maroon;
-        @include span-columns(2 of 4);
+        @include span-columns(4 of 4);
         // @include omega(2n);
         }
 
       @include media ($tablet) {
-        background-color: $red;
-        // flex: 0 0 22%;
         @include span-columns(3 of 12);
         @include omega(4n);
         }
 
       @include media ($desktop) {
-        background-color: $light-aqua;
         @include span-columns(4 of 16);
         @include omega(4n);
         }

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -554,56 +554,9 @@ Style guide: Navigation.8 Link groups
 */
 
 
-// /* Grouped links 1 */
-// .links-group {
-//   @include outer-container;
-//   // margin: ($base-spacing * 1.5) 0;​
-//   margin-top: 3em;
-//
-//   h2 {
-//     font-size: 1em;
-//     margin-top: 0;
-//     padding: 0;
-//   }
-//
-//   .popular-now {
-//     margin: 0;
-//     padding: 0;
-//     list-style: none;
-//
-//     // ul {
-//     //   @include clearfix;
-//     //   margin: 0;
-//     //   padding: 0;
-//     //   list-style: none;
-//     // }
-//
-//     li {
-//       @include span-columns(4);
-//       float: left;
-//
-//       @include media ($mobile) {
-//         @include span-columns(2 of 4);
-//         // @include omega(2n);
-//         }
-//
-//       @include media ($tablet) {
-//         @include span-columns(3 of 12);
-//         @include omega(4n);
-//         }
-//
-//       @include media ($desktop) {
-//         @include span-columns(4 of 16);
-//         @include omega(4n);
-//         }
-//       }
-//   }
-// }
-
 /* Grouped links 2 */
 .links-group {
   @include outer-container;
-  // margin: ($base-spacing * 1.5) 0;​
   margin-top: 3em;
 
   h2 {
@@ -612,22 +565,16 @@ Style guide: Navigation.8 Link groups
     padding: 0;
   }
 
+  // this is a ul class that i'm not sure if it's necessary...
+
   .popular-now {
-    margin: 0;
     padding: 0;
     list-style: none;
-
-    // ul {
-    //   @include clearfix;
-    //   margin: 0;
-    //   padding: 0;
-    //   list-style: none;
-    // }
 
     li {
       @include span-columns(4);
       float: left;
-      background-color: $aqua;
+      margin-top: 0.5em;
 
       @include media ($mobile-only) {
         @include span-columns(2 of 4);

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -568,7 +568,7 @@ Style guide: Navigation.7 Skip links
       float: left;
 
       @include media ($mobile) {
-        @include span-columns(4 of 4);
+        @include span-columns(2 of 4);
         // @include omega(2n);
         }
 

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -552,23 +552,13 @@ You can use groups of links:
 
 Markup: templates/groups-links.hbs
 
-Style guide: Navigation.8 Groups of links
+Style guide: Navigation.8 Group of links
 */
 
-/* Grouped links 2 */
 .links-group {
   @include outer-container;
-  margin-top: 3em;
 
-  h2 {
-    font-size: 1em;
-    margin-top: 0;
-    padding: 0;
-  }
-
-  // this is a ul class that i'm not sure if it's necessary...
-
-  .popular-now {
+  ul {
     padding: 0;
     list-style: none;
 

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -575,14 +575,6 @@ Style guide: Navigation.7 Skip links
         @include span-columns(4 of 16);
         @include omega(4n);
         }
-
-
-
-      //
-      // @include media($tablet) {
-      //   flex: 0 0 22%;
-      //   @include span-columns (4)
-      // }
       }
   }
 }

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -556,8 +556,15 @@ Style guide: Navigation.7 Skip links
     padding: 0;
     list-style: none;
 
+    // ul {
+    //   @include clearfix;
+    //   margin: 0;
+    //   padding: 0;
+    //   list-style: none;
+    // }
+
     li {
-      // @include span-columns(4);
+      @include span-columns(4);
       min-height: 48px;
       float: left;
 

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -541,6 +541,7 @@ Style guide: Navigation.7 Skip links
 
 /* Grouped links */
 .links-group {
+  @include outer-container;
   // margin: ($base-spacing * 1.5) 0;​
   margin-top: 2em;
 
@@ -551,40 +552,36 @@ Style guide: Navigation.7 Skip links
   }
 
   .popular-now {
-    @include outer-container;
     margin: 0;
     padding: 0;
     list-style: none;
 
-    // &.no-border {
-    //   li:nth-child(-n+4) {
-    //     border-top: none;
-    //     padding-top: 0;
-    //   }
-    // }
-
-    // @include media ($desktop) {
-    //   @include span-columns (16)
-    // }
-
     li {
       // @include span-columns(4);
+      background-color: $aqua;
+      min-height: 48px;
       float: left;
 
-      @include media ($desktop) {
-        @include span-columns(4);
-        @include omega(4n);
+      @include media ($mobile) {
+        background-color: $maroon;
+        @include span-columns(2 of 4);
+        // @include omega(2n);
         }
 
       @include media ($tablet) {
-        @include span-columns(3);
+        background-color: $red;
+        // flex: 0 0 22%;
+        @include span-columns(3 of 12);
         @include omega(4n);
         }
 
-      // @include media ($mobile) {
-      //   @include span-columns(3);
-      //   @include omega(4n);
-      //   }
+      @include media ($desktop) {
+        background-color: $light-aqua;
+        @include span-columns(4 of 16);
+        @include omega(4n);
+        }
+
+
 
       //
       // @include media($tablet) {
@@ -592,10 +589,6 @@ Style guide: Navigation.7 Skip links
       //   @include span-columns (4)
       // }
       }
-  }
-
-  a {
-    color: $white;
   }
 }
 

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -538,6 +538,21 @@ Style guide: Navigation.7 Skip links
   }
 }
 
+/*
+Link groups
+
+Use link groups to draw the user's attention to content somewhere else that will either anticipate their needs, or better meet them.
+
+Groups span from 4 down to 2 columns.
+
+You can use link groups:
+
+- in the header (eg listing popular links across the site)
+- anywhere within an `article` (eg as a list of related links).
+
+Style guide: Navigation.8 Link groups
+*/
+
 
 // /* Grouped links 1 */
 // .links-group {

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -539,20 +539,21 @@ Style guide: Navigation.7 Skip links
 }
 
 /*
-Link groups
+Groups of links
 
-Use link groups to draw the user's attention to content somewhere else that will either anticipate their needs, or better meet them.
+Use groups of links to help users find content elsewhere that will meet their needs.
 
-Groups span from 4 down to 2 columns.
+Groups of links span from 2 columns (`$mobile`) up to 4 columns (`$tablet` and `$desktop`).
 
-You can use link groups:
+You can use groups of links:
 
 - in the header (eg listing popular links across the site)
 - anywhere within an `article` (eg as a list of related links).
 
-Style guide: Navigation.8 Link groups
-*/
+Markup: templates/groups-links.hbs
 
+Style guide: Navigation.8 Groups of links
+*/
 
 /* Grouped links 2 */
 .links-group {

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -538,6 +538,67 @@ Style guide: Navigation.7 Skip links
   }
 }
 
+
+/* Grouped links */
+.links-group {
+  // margin: ($base-spacing * 1.5) 0;​
+  margin-top: 2em;
+
+  h2 {
+    font-size: 1em;
+    margin-top: 0;
+    padding: 0;
+  }
+
+  .popular-now {
+    @include outer-container;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+
+    // &.no-border {
+    //   li:nth-child(-n+4) {
+    //     border-top: none;
+    //     padding-top: 0;
+    //   }
+    // }
+
+    // @include media ($desktop) {
+    //   @include span-columns (16)
+    // }
+
+    li {
+      // @include span-columns(4);
+      float: left;
+
+      @include media ($desktop) {
+        @include span-columns(4);
+        @include omega(4n);
+        }
+
+      @include media ($tablet) {
+        @include span-columns(3);
+        @include omega(4n);
+        }
+
+      // @include media ($mobile) {
+      //   @include span-columns(3);
+      //   @include omega(4n);
+      //   }
+
+      //
+      // @include media($tablet) {
+      //   flex: 0 0 22%;
+      //   @include span-columns (4)
+      // }
+      }
+  }
+
+  a {
+    color: $white;
+  }
+}
+
 /*
 Accessibility
 

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -543,7 +543,7 @@ Style guide: Navigation.7 Skip links
 .links-group {
   @include outer-container;
   // margin: ($base-spacing * 1.5) 0;​
-  margin-top: 2em;
+  margin-top: 3em;
 
   h2 {
     font-size: 1em;
@@ -565,7 +565,6 @@ Style guide: Navigation.7 Skip links
 
     li {
       @include span-columns(4);
-      min-height: 48px;
       float: left;
 
       @include media ($mobile) {

--- a/assets/sass/_page-header.scss
+++ b/assets/sass/_page-header.scss
@@ -208,6 +208,16 @@
   }
 }
 
+.feedback {
+  display: none;
+
+  @include media($tablet) {
+    display: block;
+    float: right;
+    margin-left: $base-spacing;
+  }
+}
+
 .button--feedback {
   @extend .inverted;
 

--- a/assets/sass/_page-header.scss
+++ b/assets/sass/_page-header.scss
@@ -59,6 +59,24 @@
   }
 }
 
+.govau--header,
+.prerelease-govau--header {
+  .links-group {
+    margin: ($base-spacing * 1.5) 0;
+
+    h2 {
+      font-size: rem(17);
+      font-weight: $bold-font-weight;
+      margin-top: 0;
+      padding: 0;
+    }
+
+    a {
+      color: $white;
+    }
+  }
+}
+
 .govau--header {
   @include link-colours($link-inverted-colour, $link-inverted-colour, $link-colour);
   @include button-colours($header-bg-colour, $body-inverted-text-colour, $body-inverted-text-colour, $body-inverted-text-colour, $header-bg-colour);
@@ -187,48 +205,6 @@
 .homeintro {
   p {
     font-size: rem(24);
-  }
-}
-
-.links-group {
-
-  margin: ($base-spacing * 1.5) 0;
-
-  h2 {
-    font-size: rem(17); //Should this be a var?
-    font-weight: $bold-font-weight;
-    margin-top: 0;
-    padding: 0;
-  }
-
-  ul {
-    @include clearfix;
-    margin: 0;
-    padding: 0;
-    list-style: none;
-  }
-
-  li {
-    width: 50%;
-    float: left;
-
-    @include media($tablet) {
-      width: 25%;
-    }
-  }
-
-  a {
-    color: $white;
-  }
-}
-
-.feedback {
-  display: none;
-
-  @include media($tablet) {
-    display: block;
-    float: right;
-    margin-left: $base-spacing;
   }
 }
 

--- a/assets/sass/templates/groups-links.hbs
+++ b/assets/sass/templates/groups-links.hbs
@@ -1,8 +1,8 @@
-<header role="banner">
-  <section class="hero">
-    <div class="wrapper">
-      <div class="links-group">
-        <h2>Popular links</h2>
+
+<nav class="hero">
+  <div class="wrapper">
+    <div class="links-group">
+      <h2>Popular links</h2>
         <ul class="popular-now">
           <li><a href="#">Dates and times</a></li>
           <li><a href="#">Tax returns</a></li>
@@ -10,11 +10,10 @@
         </ul>
       </div>
     </div>
-  </section>
-</header>
+</nav>
 
 <div class="links-group">
-  <h3>Related links</h2>
+  <h3>Related topics</h2>
   <ul class="popular-now">
     <li><a href="#">Dates and times</a></li>
     <li><a href="#">Tax returns</a></li>

--- a/assets/sass/templates/groups-links.hbs
+++ b/assets/sass/templates/groups-links.hbs
@@ -1,0 +1,23 @@
+<header role="banner">
+  <section class="hero">
+    <div class="wrapper">
+      <div class="links-group">
+        <h2>Popular links</h2>
+        <ul class="popular-now">
+          <li><a href="#">Dates and times</a></li>
+          <li><a href="#">Tax returns</a></li>
+          <li><a href="#">Broadband</a></li>
+        </ul>
+      </div>
+    </div>
+  </section>
+</header>
+
+<div class="links-group">
+  <h3>Related links</h2>
+  <ul class="popular-now">
+    <li><a href="#">Dates and times</a></li>
+    <li><a href="#">Tax returns</a></li>
+    <li><a href="#">Broadband</a></li>
+  </ul>
+</div>

--- a/assets/sass/templates/groups-links.hbs
+++ b/assets/sass/templates/groups-links.hbs
@@ -1,16 +1,20 @@
-
-<nav class="hero">
+<div class="hero-sml">
   <div class="wrapper">
     <div class="links-group">
-      <h2>Popular links</h2>
+      <h4>Popular links</h4>
         <ul class="popular-now">
           <li><a href="#">Dates and times</a></li>
           <li><a href="#">Tax returns</a></li>
           <li><a href="#">Broadband</a></li>
+          <li><a href="#">Public holidays</a></li>
+          <li><a href="#">Broadband</a></li>
+          <li><a href="#">Public holidays</a></li>
+          <li><a href="#">Tax returns</a></li>
+          <li><a href="#">Dates and times</a></li>
         </ul>
       </div>
     </div>
-</nav>
+</div>
 
 <div class="links-group">
   <h3>Related topics</h2>
@@ -18,5 +22,10 @@
     <li><a href="#">Dates and times</a></li>
     <li><a href="#">Tax returns</a></li>
     <li><a href="#">Broadband</a></li>
+    <li><a href="#">Public holidays</a></li>
+    <li><a href="#">Broadband</a></li>
+    <li><a href="#">Public holidays</a></li>
+    <li><a href="#">Tax returns</a></li>
+    <li><a href="#">Dates and times</a></li>
   </ul>
 </div>

--- a/examples/group-links.html
+++ b/examples/group-links.html
@@ -26,7 +26,7 @@
     });
   </script>
 
-  <link rel="stylesheet" type="text/css" href="./build/latest/ui-kit.css"/>
+  <link rel="stylesheet" type="text/css" href="../latest/ui-kit.css"/>
   <!-- <link rel="stylesheet" type="text/css" href="https://gov-au-ui-kit.apps.staging.digital.gov.au/latest/ui-kit.min.css"/> -->
 
 
@@ -42,7 +42,7 @@
           src='//cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.3/jquery.xdomainrequest.min.js'></script>
   <![endif]-->
 
-  <script type="text/javascript" src="/Users/Ham/gov-au-ui-kit/build/latest"></script>
+  <script type="text/javascript" src="/Users/Ham/gov-au-ui-kit/build/latest/ui-kit.js"></script>
   <!-- <script type="text/javascript" src="https://gov-au-ui-kit.apps.staging.digital.gov.au/latest/ui-kit.min.js"></script> -->
 
 

--- a/examples/group-links.html
+++ b/examples/group-links.html
@@ -82,6 +82,7 @@
       <div class="wrapper">
         <span class="site-title">Department of Intertubes</span>
         <p class="tagline">Calibration of intertube serialisation will be a real game-changer.</p>
+
         <div class="links-group">
           <h2>Popular links</h2>
           <ul class="popular-now">

--- a/examples/group-links.html
+++ b/examples/group-links.html
@@ -26,7 +26,7 @@
     });
   </script>
 
-  <link rel="stylesheet" type="text/css" href="/Users/hannah-ustwo/My Stuff/Work/gov-au-ui-kit/build/latest/ui-kit.css"/>
+  <link rel="stylesheet" type="text/css" href="../latest/ui-kit.css"/>
   <!-- <link rel="stylesheet" type="text/css" href="https://gov-au-ui-kit.apps.staging.digital.gov.au/latest/ui-kit.min.css"/> -->
 
 
@@ -42,7 +42,7 @@
           src='//cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.3/jquery.xdomainrequest.min.js'></script>
   <![endif]-->
 
-  <script type="text/javascript" src="/Users/hannah-ustwo/My Stuff/Work/gov-au-ui-kit/build/latest/ui-kit.js"></script>
+  <script type="text/javascript" src="../latest/ui-kit.js"></script>
   <!-- <script type="text/javascript" src="https://gov-au-ui-kit.apps.staging.digital.gov.au/latest/ui-kit.min.js"></script> -->
 
 
@@ -162,22 +162,25 @@
       <h1>Article title that is quite a bit longer</h1>
       <p class="abstract">This is my <code>.abstract</code> text: the quick brown fox jumped over the lazy dog.</p>
 
+      <p>Let's try some article links</p>
+      <!-- testing group links -->
+            <div class="links-group">
+              <h2>Popular links</h2>
+              <ul class="popular-now">
+                <li><a href="#">Dates and times</a></li>
+                <li><a href="#">Tax returns</a></li>
+                <li><a href="#">Broadband</a></li>
+                <li><a href="#">Elections</a></li>
+                <li><a href="#">Television reception</a></li>
+                <li><a href="#">School Holidays</a></li>
+                <li><a href="#">This is a link</a></li>
+                <li><a href="#">This is a link</a></li>
+              </ul>
+            </div>
+      <!-- end testing group links -->
+
       <p>So, let us commence with some accordions:</p>
-<!-- testing group links -->
-      <div class="links-group">
-        <h2>Popular links</h2>
-        <ul class="popular-now">
-          <li><a href="#">Dates and times</a></li>
-          <li><a href="#">Tax returns</a></li>
-          <li><a href="#">Broadband</a></li>
-          <li><a href="#">Elections</a></li>
-          <li><a href="#">Television reception</a></li>
-          <li><a href="#">School Holidays</a></li>
-          <li><a href="#">This is a link</a></li>
-          <li><a href="#">This is a link</a></li>
-        </ul>
-      </div>
-<!-- end testing group links -->
+
       <div class="video">
         <div class="video-wrapper">
           <!-- <embed src="https://www.youtube.com/embed/w3lsDQD9_98?showinfo=0&iv_load_policy=3&controls=0" allowfullscreen> -->

--- a/examples/group-links.html
+++ b/examples/group-links.html
@@ -42,7 +42,7 @@
           src='//cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.3/jquery.xdomainrequest.min.js'></script>
   <![endif]-->
 
-  <script type="text/javascript" src="/Users/Ham/gov-au-ui-kit/build/latest/ui-kit.js"></script>
+  <script type="text/javascript" src="../latest/ui-kit.js"></script>
   <!-- <script type="text/javascript" src="https://gov-au-ui-kit.apps.staging.digital.gov.au/latest/ui-kit.min.js"></script> -->
 
 
@@ -55,27 +55,6 @@
   </div>
 
   <header role="banner">
-
-    <section class="controls--contrast">
-      <div class="wrapper">
-        <section>
-          <nav class="breadcrumbs--inverted" aria-label="controls-breadcrumb">
-            <ul>
-              <li><a href="#" title="Home">Editorial</a></li>
-              <li><a href="#" title="Menu1">PMC</a></li>
-              <li>Menu2</li>
-            </ul>
-          </nav>
-          <a href="#" role="button">Edit</a>
-        </section>
-        <section class="right">
-          <ul class="inline-links--inverted">
-            <li><a href="#">Help</a></li>
-            <li><a href="#">Sign Out</a></li>
-          </ul>
-        </section>
-      </div>
-    </section>
     <section class="govau--header">
       <div class="wrapper">
         <div class="govau--logo">
@@ -113,7 +92,7 @@
             <li><a href="#">Television reception</a></li>
             <li><a href="#">School Holidays</a></li>
             <li><a href="#">This is a link</a></li>
-            <li><a href="#">This is a link</a></li>
+            <!-- <li><a href="#">This is a link</a></li> -->
           </ul>
         </div>
       </div>
@@ -160,12 +139,24 @@
 
     <article id="content" class="content-main">
       <h1>Article title that is quite a bit longer</h1>
-      <p class="abstract">This is my <code>.abstract</code> text: the quick brown fox jumped over the lazy dog.</p>
+      <p class="abstract">The abstract quick brown fox jumped over the lazy dog.</p>
+      <p>
+        Nulla vitae elit libero, a pharetra augue. Cras mattis consectetur purus sit amet fermentum. Nullam id dolor id nibh ultricies vehicula ut id elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas faucibus mollis interdum. Etiam porta sem malesuada magna mollis euismod. Donec id elit non mi porta gravida at eget metus. Nulla vitae elit libero, a pharetra augue.
+      </p>
 
-      <p>Let's try some article links</p>
+      <blockquote class="pullquote">
+        <p><em>Mystical explanations.</em>&mdash;Mystical explanations are considered deep. The truth is that they are not
+          even superficial.</p>
+      </blockquote>
+
+      <p>
+        Cras justo odio, dapibus ac facilisis in, egestas eget quam. Curabitur blandit tempus porttitor. Cras mattis consectetur purus sit amet fermentum. Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Donec ullamcorper nulla non metus auctor fringilla. Vestibulum id ligula porta felis euismod semper.
+      </p>
+
+      <p>This is the end of an article. Let's try some grouped links</p>
       <!-- testing group links -->
             <div class="links-group">
-              <h2>Popular links</h2>
+              <h2>Popular links related to this</h2>
               <ul class="popular-now">
                 <li><a href="#">Dates and times</a></li>
                 <li><a href="#">Tax returns</a></li>
@@ -173,359 +164,11 @@
                 <li><a href="#">Elections</a></li>
                 <li><a href="#">Television reception</a></li>
                 <li><a href="#">School Holidays</a></li>
-                <li><a href="#">This is a link</a></li>
-                <li><a href="#">This is a link</a></li>
               </ul>
             </div>
       <!-- end testing group links -->
 
-      <p>So, let us commence with some accordions:</p>
 
-      <div class="video">
-        <div class="video-wrapper">
-          <!-- <embed src="https://www.youtube.com/embed/w3lsDQD9_98?showinfo=0&iv_load_policy=3&controls=0" allowfullscreen> -->
-        </div>
-      </div>
-
-      <p>More seriously, here is an accordion that uses the <code>details</code> and <code>summary</code> elements.</p>
-
-      <details data-label="accordion-example" aria-expanded="false">
-        <summary>foobar</summary>
-        <div class="accordion-panel">
-            <p>I am a paragraph of text!</p>
-        </div>
-      </details>
-
-      <details open data-label="accordion-example-2" aria-expanded="true">
-        <summary>barfoo</summary>
-        <div class="accordion-panel">
-            <p>You can nest just about any common content inside an accordion, like lists, blockquotes, and more:</p>
-            <blockquote>
-              <p>And yet the system is not closed. One aperture remains: and through it the whole interplay of resemblances would be in danger of escaping from itself, or of remaining hidden in darkness, if there were not a further form of similitude to close the circle &mdash; to render it at once perfect and manifest.</p>
-              <footer>
-                <cite>Foucault, M. (1994). <em>The Order of Things: an archaeology of the human sciences</em>. New York: Vintage Books. pp 28&ndash;29.</cite>
-              </footer>
-            </blockquote>
-            <ol>
-              <li>first sorted list item</li>
-              <li>second sorted list item
-                <ol>
-                  <li>another item</li>
-                </ol>
-              </li>
-              <li>and another item</li>
-            </ol>
-        </div>
-      </details>
-
-      <blockquote>
-        <p>Pascal said things should line up; the rhythm of things must be maintained!</p>
-      </blockquote>
-
-      <p>Accordions can also be achieved using the <code>.accordion</code> class on a <code>dl</code> (definition list), using the <code>dt</code> effectively as the <code>summary</code>:</p>
-
-      <p>incoming&hellip;</p>
-
-      <p>Vertical rhythm should be <strong>maintained</strong> between content elements:</p>
-
-      <ul>
-        <li>an unsorted list item</li>
-        <li>another unsorted list item</li>
-      </ul>
-
-      <p>A paragraph with a badge: <span class="badge--beta">beta</span></p>
-
-      <p>Sorted list:</p>
-
-      <ol>
-        <li>first sorted list item</li>
-        <li>second sorted list item
-          <ol>
-            <li>another item</li>
-          </ol>
-        </li>
-        <li>and another item</li>
-      </ol>
-
-      <!-- List with image -->
-      <ul class="list-horizontal">
-
-        <!-- Hero list item -->
-        <li class="hero-item">
-          <figure>
-            <img src="../kss-assets/img/img-placeholder.gif" alt="example image"/>
-          </figure>
-          <article>
-            <h3>
-              <a href="#">Hero list item</a>
-            </h3>
-
-            <p>Can be paired with horizontal list items for emphasis</p>
-
-          </article>
-        </li>
-
-        <!-- List item with an image -->
-        <li>
-          <figure>
-            <img src="../kss-assets/img/img-placeholder.gif" alt="example image" />
-          </figure>
-          <article>
-            <h3>
-              <a href="#">About The Digital Transformation Office</a>
-            </h3>
-
-            <div class="meta">
-              <time datetime="2016-05-08 00:00">08 May 2016</time>
-              <a href="#" rel="author">Author</a>
-            </div>
-
-            <p>The Digital Transformation Office (DTO) was established as an executive agency in July 2015. Its mission is to lead the transformation of government services to deliver a better experience for Australians.</p>
-
-            <footer class="tags">
-              <dl>
-                <dt>Topics:</dt>
-                <dd><a href="#">Tag Name</a></dd>
-                <dd><a href="#">Tag name</a></dd>
-                <dd><a href="#">Tag Name</a></dd>
-                <dd><a href="#">Tag Name</a></dd>
-                <dd><a href="#">Tag Name</a></dd>
-                <dd><a href="#">Tag Name</a></dd>
-              </dl>
-            </footer>
-          </article>
-        </li>
-
-        <!-- List item with no image where there should be one -->
-        <li>
-          <figure>
-          </figure>
-          <article>
-            <h3>
-              <a href="#">About The Digital Transformation Office</a>
-            </h3>
-
-            <div class="meta">
-              <time datetime="2016-05-08 00:00">08 May 2016</time>
-              <a href="#" rel="author">Author</a>
-            </div>
-
-            <p>The Digital Transformation Office (DTO) was established as an executive agency in July 2015. Its mission is to lead the transformation of government services to deliver a better experience for Australians.</p>
-
-            <footer class="tags">
-              <dl>
-                <dt>Topics:</dt>
-                <dd><a href="#">Tag Name</a></dd>
-                <dd><a href="#">Tag name</a></dd>
-                <dd><a href="#">Tag Name</a></dd>
-                <dd><a href="#">Tag Name</a></dd>
-                <dd><a href="#">Tag Name</a></dd>
-                <dd><a href="#">Tag Name</a></dd>
-              </dl>
-            </footer>
-          </article>
-        </li>
-
-        <!-- List item with no image -->
-        <li>
-          <article>
-            <h3>
-              <a href="#">About The Digital Transformation Office</a>
-            </h3>
-
-            <div class="meta">
-              <time datetime="2016-05-08 00:00">08 May 2016</time> <a href="#" rel="author">Author</a>
-            </div>
-
-            <p>The Digital Transformation Office (DTO) was established as an executive agency in July 2015. Its mission is to lead the transformation of government services to deliver a better experience for Australians.</p>
-
-            <footer class="tags">
-              <dl>
-                <dt>Topics:</dt>
-                <dd><a href="#">Tag Name</a></dd>
-                <dd><a href="#">Tag name</a></dd>
-                <dd><a href="#">Tag Name</a></dd>
-                <dd><a href="#">Tag Name</a></dd>
-                <dd><a href="#">Tag Name</a></dd>
-                <dd><a href="#">Tag Name</a></dd>
-              </dl>
-            </footer>
-          </article>
-        </li>
-
-        <!-- List item  -->
-        <li>
-          <article>
-            <h3>
-              <a href="#">About The Digital Transformation Office</a>
-            </h3>
-
-            <p>The Digital Transformation Office (DTO)</p>
-
-          </article>
-        </li>
-      </ul>
-
-      <h2>Buttons and links</h2>
-
-      <p>A <a href="#">text link</a> can appear within a chunk of text, or within any text element. Buttons can be grouped
-        together:</p>
-
-      <p>
-        <a href="#" role="button">Primary Button</a>
-        <a href="#" role="button" class="contrast">Contrast button</a>
-        <a href="#" role="button" class="disabled">Disabled</a>
-      </p>
-
-      <p>It would be way cool to have <code>kbd</code> support, so that we can tell people how to <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>Delete</kbd>, or how to win their games faster by mashing <kbd>F11</kbd>.</p>
-
-      <h2>Quotations and citations</h2>
-
-      <p>We need to be able to cater for both block quotations, as well as in-line quotations via the <code>q</code>
-        element, because Simon said <q>yo dawg, get them quotes on yo!</q></p>
-
-      <p>The <code>q</code> element is unlikely to see a lot of use, unless we play with the editors to be used for
-        authoring and editing things. The other issue with using the <code>content</code> property is that text selection
-        of its contents is not available, so the opening and closing quotation marks are not selectable.</p>
-
-      <p>Time for a <code>blockquote</code>, which are distinct from in-line qutoations via the <code>q</code> element.
-      </p>
-
-      <blockquote>
-        <p>Blockquotes are block-level elements that contain in-line elements.</p>
-        <p>This means we can place multiple paragraphs, lists, etc. into a block quotation. We can also use it nest
-          another blockquote, like so:</p>
-        <blockquote>
-          <p><em>How far the moral sphere extends.</em>&mdash;As soon as we see a new image, we immediately construct it
-            with the aid of all our previous experiences, <em>depending on the degree</em> of our honesty and justice. All
-            experiences are moral experiences, even in the realm of sense perception.</p>
-          <footer>
-            <cite>1887, Nietzsche (1974). <em>The Gay Science</em> [second edition], &sect; 114. Translated from the
-              German by W. Kaufmann. New York: Vintage Books.</cite>
-          </footer>
-        </blockquote>
-        <p>While inside the block quotation, let us test a few other nested elements:</p>
-        <ul>
-          <li>first sorted list item</li>
-          <li>second sorted list item
-            <ol>
-              <li>another item</li>
-              <li>and again&hellip;</li>
-            </ol>
-          </li>
-          <li>and another item</li>
-        </ul>
-        <p>The other thing that is worth noting is that we can place the <code>footer</code> element contextually inside
-          other block-level elements; they are not restricted to a single use per page. This allows us to use
-          <code>footer</code> inside a <code>blockquote</code>, and within that we can provide a citation via the <code>cite</code>
-          element.</p>
-        <footer>
-          <cite><a href="link">Citation source</a></cite>
-        </footer>
-      </blockquote>
-
-      <p>We can draw attention to a quotation by using the <code>.pullquote</code> class for a block quotation.</p>
-
-      <blockquote class="pullquote">
-        <p><em>Mystical explanations.</em>&mdash;Mystical explanations are considered deep. The truth is that they are not
-          even superficial.</p>
-      </blockquote>
-
-      <h3>Heading Level 3</h3>
-      <p>As well as definition lists:</p>
-
-      <dl>
-        <dt>Definition term 1</dt>
-        <dd>Definition description</dd>
-        <dd>A single definition term can have many definitions.</dd>
-
-        <dt>Second definition term</dt>
-        <dd>Another definition.</dd>
-      </dl>
-
-      <h4>Heading Level 4</h4>
-
-      <p>These interespersed elements aim to show the <em>vertical rhythm</em> between various content elements, using
-        predominately margin-bottom, and only margin-top in the instances where it would be too cumbersome or hacky to try
-        continue with just margin-bottom.</p>
-
-      <p class="callout">This is a callout.</p>
-
-      <p class="callout--warning">This is a warning callout.</p>
-
-      <p>This makes maintaining the vertical rhythm between content easier, and avoids spacing bugs, as well as sizing
-        bugs that aren't immediately apparent when just testing with a few paragraphs and headings.</p>
-
-      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Qui dicta minus molestiae vel beatae natus eveniet
-        ratione temporibus aperiam harum alias officiis assumenda officia quibusdam deleniti eos cupiditate dolore
-        doloribus!</p>
-      <p>Ad dolore dignissimos asperiores dicta facere optio quod commodi nam tempore recusandae. Rerum sed nulla eum vero
-        expedita ex delectus voluptates rem at neque quos facere sequi unde optio aliquam!</p>
-      <p>Tenetur quod quidem in voluptatem corporis dolorum dicta sit pariatur porro quaerat autem ipsam odit quam beatae
-        tempora quibusdam illum! Modi velit odio nam nulla unde amet odit pariatur at!</p>
-      <p>Consequatur rerum amet fuga expedita sunt et tempora saepe? Iusto nihil explicabo perferendis quos provident
-        delectus ducimus necessitatibus reiciendis optio tempora unde earum doloremque commodi laudantium ad nulla vel
-        odio?</p>
-
-      <ul>
-        <li>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nam vero.</li>
-        <li>Laboriosam quaerat sapiente minima nam minus similique illum architecto et!</li>
-        <li>Incidunt vitae quae facere ducimus nostrum aliquid dolorum veritatis dicta!</li>
-        <li>Tenetur laborum quod cum excepturi recusandae porro sint quas soluta!</li>
-      </ul>
-
-      <h5>Heading Level 5</h5>
-
-      <ol>
-        <li>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nam vero.</li>
-        <li>Laboriosam quaerat sapiente minima nam minus similique illum architecto et!</li>
-        <li>Incidunt vitae quae facere ducimus nostrum aliquid dolorum veritatis dicta!</li>
-        <li>Tenetur laborum quod cum excepturi recusandae porro sint quas soluta!</li>
-      </ol>
-
-      <section class="form-wrapper">
-
-        <h2>Contact Us</h2>
-        <form>
-          <p>
-            <label for="name">Your name</label>
-            <input type="text" id="name"/>
-          </p>
-          <p>
-            <label for="colour">Your favourite colour</label>
-            <input type="text" id="colour" disabled/>
-          </p>
-          <p>
-            <label for="contact">Your contact</label>
-            <span class="hint" id="name-hint">Please provide an email address.</span>
-            <input type="email" id="contact" aria-describedby="name-hint" required/>
-          </p>
-
-          <fieldset id="reply">
-            <legend>Would you like a reply?</legend>
-            <input id="yes" name="reply" type="radio" value="Yes"/>
-            <label for="yes">Yes</label>
-            <input id="no" name="reply" type="radio" value="No"/>
-            <label for="no">No</label>
-            <input id="maybe" name="reply" type="radio" value="Maybe"/>
-            <label for="maybe">Maybe</label>
-          </fieldset>
-
-          <fieldset id="comms">
-            <legend>What method(s) of communication do you prefer?</legend>
-            <input id="radio" name="comms" type="checkbox" value="Radio"/>
-            <label for="radio">Radio</label>
-            <input id="telephone" name="comms" type="checkbox" value="Telephone"/>
-            <label for="telephone">Telephone</label>
-          </fieldset>
-
-          <p>
-            <label for="message">Your message</label>
-            <textarea id="message"></textarea>
-          </p>
-          <input type="submit" value="Submit"/>
-          <input type="reset" value="Reset"/>
-        </form>
 
       </section>
 

--- a/examples/group-links.html
+++ b/examples/group-links.html
@@ -163,10 +163,24 @@
       <p class="abstract">This is my <code>.abstract</code> text: the quick brown fox jumped over the lazy dog.</p>
 
       <p>So, let us commence with some accordions:</p>
-
+<!-- testing group links -->
+      <div class="links-group">
+        <h2>Popular links</h2>
+        <ul class="popular-now">
+          <li><a href="#">Dates and times</a></li>
+          <li><a href="#">Tax returns</a></li>
+          <li><a href="#">Broadband</a></li>
+          <li><a href="#">Elections</a></li>
+          <li><a href="#">Television reception</a></li>
+          <li><a href="#">School Holidays</a></li>
+          <li><a href="#">This is a link</a></li>
+          <li><a href="#">This is a link</a></li>
+        </ul>
+      </div>
+<!-- end testing group links -->
       <div class="video">
         <div class="video-wrapper">
-          <embed src="https://www.youtube.com/embed/w3lsDQD9_98?showinfo=0&iv_load_policy=3&controls=0" allowfullscreen>
+          <!-- <embed src="https://www.youtube.com/embed/w3lsDQD9_98?showinfo=0&iv_load_policy=3&controls=0" allowfullscreen> -->
         </div>
       </div>
 

--- a/examples/group-links.html
+++ b/examples/group-links.html
@@ -168,10 +168,6 @@
             </div>
       <!-- end testing group links -->
 
-
-
-      </section>
-
     </article>
   </main>
 

--- a/examples/group-links.html
+++ b/examples/group-links.html
@@ -26,7 +26,7 @@
     });
   </script>
 
-  <link rel="stylesheet" type="text/css" href="../latest/ui-kit.css"/>
+  <link rel="stylesheet" type="text/css" href="./build/latest/ui-kit.css"/>
   <!-- <link rel="stylesheet" type="text/css" href="https://gov-au-ui-kit.apps.staging.digital.gov.au/latest/ui-kit.min.css"/> -->
 
 
@@ -42,7 +42,7 @@
           src='//cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.3/jquery.xdomainrequest.min.js'></script>
   <![endif]-->
 
-  <script type="text/javascript" src="../latest/ui-kit.js"></script>
+  <script type="text/javascript" src="/Users/Ham/gov-au-ui-kit/build/latest"></script>
   <!-- <script type="text/javascript" src="https://gov-au-ui-kit.apps.staging.digital.gov.au/latest/ui-kit.min.js"></script> -->
 
 

--- a/examples/group-links.html
+++ b/examples/group-links.html
@@ -1,0 +1,574 @@
+<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<!--[if lt IE 7 ]>
+<html lang="en" class="ie6 no-js">    <![endif]-->
+<!--[if IE 7 ]>
+<html lang="en" class="ie7 no-js">    <![endif]-->
+<!--[if IE 8 ]>
+<html lang="en" class="ie8 no-js">    <![endif]-->
+<!--[if IE 9 ]>
+<html lang="en" class="ie9 no-js">    <![endif]-->
+<!--[if (gt IE 9)|!(IE)]><!-->
+<html lang="en" class="no-js"><!--<![endif]-->
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="x-ua-compatible" content="ie=edge">
+  <!-- viewport declaration must be included in <head> for media queries to work correctly on real devices -->
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Example Pages</title>
+
+  <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.16/webfont.js"></script>
+  <script>
+    WebFont.load({
+      google: {
+        families: ['Open+Sans:400italic,700,400:latin,latin-ext']
+      }
+    });
+  </script>
+
+  <link rel="stylesheet" type="text/css" href="/Users/hannah-ustwo/My Stuff/Work/gov-au-ui-kit/build/latest/ui-kit.css"/>
+  <!-- <link rel="stylesheet" type="text/css" href="https://gov-au-ui-kit.apps.staging.digital.gov.au/latest/ui-kit.min.css"/> -->
+
+
+  <!--[if lt IE 9]>
+  <script src="//code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ="
+          crossorigin="anonymous"></script>
+  <script type="text/javascript"
+          src="//cdnjs.cloudflare.com/ajax/libs/corysimmons-selectivizr2/1.0.8/selectivizr2.min.js"></script>
+  <![endif]-->
+  <!--[if lte IE 9]>
+  <script type='text/javascript' src='//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js'></script>
+  <script type='text/javascript'
+          src='//cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.3/jquery.xdomainrequest.min.js'></script>
+  <![endif]-->
+
+  <script type="text/javascript" src="/Users/hannah-ustwo/My Stuff/Work/gov-au-ui-kit/build/latest/ui-kit.js"></script>
+  <!-- <script type="text/javascript" src="https://gov-au-ui-kit.apps.staging.digital.gov.au/latest/ui-kit.min.js"></script> -->
+
+
+</head>
+<body>
+
+  <div class="skip-to">
+    <a href="#content">Skip to main content</a>
+    <a href="#nav">Skip to section navigation</a>
+  </div>
+
+  <header role="banner">
+
+    <section class="controls--contrast">
+      <div class="wrapper">
+        <section>
+          <nav class="breadcrumbs--inverted" aria-label="controls-breadcrumb">
+            <ul>
+              <li><a href="#" title="Home">Editorial</a></li>
+              <li><a href="#" title="Menu1">PMC</a></li>
+              <li>Menu2</li>
+            </ul>
+          </nav>
+          <a href="#" role="button">Edit</a>
+        </section>
+        <section class="right">
+          <ul class="inline-links--inverted">
+            <li><a href="#">Help</a></li>
+            <li><a href="#">Sign Out</a></li>
+          </ul>
+        </section>
+      </div>
+    </section>
+    <section class="govau--header">
+      <div class="wrapper">
+        <div class="govau--logo">
+          <a href="#" class="logo">gov.au</a> <span class="badge--default">draft</span>
+        </div>
+        <div class="feedback" tabindex="1">
+          <a href="#" class="button--feedback">Give feedback</a>
+        </div>
+        <nav class="global-nav" aria-label="global navigation" tabindex="2">
+          <ul>
+            <li><a href="#">About us</a></li>
+            <li><a href="#">Information and services</a></li>
+            <li><a href="#">Ministers</a></li>
+            <li><a href="#">News</a></li>
+            <li><a href="#">Departments & Agencies</a></li>
+            <li><a href="#">Contact us</a></li>
+          </ul>
+          <div class="feedback">
+            <a href="#" class="button--feedback">Give feedback</a>
+          </div>
+        </nav>
+      </div>
+    </section>
+    <section class="hero">
+      <div class="wrapper">
+        <span class="site-title">Department of Intertubes</span>
+        <p class="tagline">Calibration of intertube serialisation will be a real game-changer.</p>
+        <div class="links-group">
+          <h2>Popular links</h2>
+          <ul class="popular-now">
+            <li><a href="#">Dates and times</a></li>
+            <li><a href="#">Tax returns</a></li>
+            <li><a href="#">Broadband</a></li>
+            <li><a href="#">Elections</a></li>
+            <li><a href="#">Television reception</a></li>
+            <li><a href="#">School Holidays</a></li>
+            <li><a href="#">This is a link</a></li>
+            <li><a href="#">This is a link</a></li>
+          </ul>
+        </div>
+      </div>
+    </section>
+  </header>
+
+  <nav class="breadcrumbs" aria-label="breadcrumb">
+    <div class="wrapper">
+      <ul>
+        <li><a href="#" title="Home">Home</a></li>
+        <li><a href="#" title="Menu1">Menu1</a></li>
+        <li>Menu2</li>
+      </ul>
+    </div>
+  </nav>
+
+  <main>
+    <aside class="sidebar" id="nav">
+      <nav class="local-nav" aria-label="main navigation">
+        <ul>
+          <li><a href="#">Overview</a></li>
+          <li><a href="#">Purpose</a></li>
+          <li>
+            <a href="#">Foundations</a>
+            <ul class="sub-nav-list">
+              <li><a href="#">Overview</a></li>
+              <li><a href="#">Design principles</a></li>
+              <li><a href="#">Grid</a></li>
+              <li>
+                <a href="#">Typography</a>
+                <ul class="sub-sub-nav-list">
+                  <li><a href="#">Line height and spacing</a></li>
+                  <li><a href="#">Typesetting</a></li>
+                </ul>
+              </li>
+              <li><a href="#">Text accessibility</a></li>
+              <li><a href="#">Links</a></li>
+              <li><a href="#">Lists</a></li>
+            </ul>
+          </li>
+        </ul>
+      </nav>
+    </aside>
+
+    <article id="content" class="content-main">
+      <h1>Article title that is quite a bit longer</h1>
+      <p class="abstract">This is my <code>.abstract</code> text: the quick brown fox jumped over the lazy dog.</p>
+
+      <p>So, let us commence with some accordions:</p>
+
+      <div class="video">
+        <div class="video-wrapper">
+          <embed src="https://www.youtube.com/embed/w3lsDQD9_98?showinfo=0&iv_load_policy=3&controls=0" allowfullscreen>
+        </div>
+      </div>
+
+      <p>More seriously, here is an accordion that uses the <code>details</code> and <code>summary</code> elements.</p>
+
+      <details data-label="accordion-example" aria-expanded="false">
+        <summary>foobar</summary>
+        <div class="accordion-panel">
+            <p>I am a paragraph of text!</p>
+        </div>
+      </details>
+
+      <details open data-label="accordion-example-2" aria-expanded="true">
+        <summary>barfoo</summary>
+        <div class="accordion-panel">
+            <p>You can nest just about any common content inside an accordion, like lists, blockquotes, and more:</p>
+            <blockquote>
+              <p>And yet the system is not closed. One aperture remains: and through it the whole interplay of resemblances would be in danger of escaping from itself, or of remaining hidden in darkness, if there were not a further form of similitude to close the circle &mdash; to render it at once perfect and manifest.</p>
+              <footer>
+                <cite>Foucault, M. (1994). <em>The Order of Things: an archaeology of the human sciences</em>. New York: Vintage Books. pp 28&ndash;29.</cite>
+              </footer>
+            </blockquote>
+            <ol>
+              <li>first sorted list item</li>
+              <li>second sorted list item
+                <ol>
+                  <li>another item</li>
+                </ol>
+              </li>
+              <li>and another item</li>
+            </ol>
+        </div>
+      </details>
+
+      <blockquote>
+        <p>Pascal said things should line up; the rhythm of things must be maintained!</p>
+      </blockquote>
+
+      <p>Accordions can also be achieved using the <code>.accordion</code> class on a <code>dl</code> (definition list), using the <code>dt</code> effectively as the <code>summary</code>:</p>
+
+      <p>incoming&hellip;</p>
+
+      <p>Vertical rhythm should be <strong>maintained</strong> between content elements:</p>
+
+      <ul>
+        <li>an unsorted list item</li>
+        <li>another unsorted list item</li>
+      </ul>
+
+      <p>A paragraph with a badge: <span class="badge--beta">beta</span></p>
+
+      <p>Sorted list:</p>
+
+      <ol>
+        <li>first sorted list item</li>
+        <li>second sorted list item
+          <ol>
+            <li>another item</li>
+          </ol>
+        </li>
+        <li>and another item</li>
+      </ol>
+
+      <!-- List with image -->
+      <ul class="list-horizontal">
+
+        <!-- Hero list item -->
+        <li class="hero-item">
+          <figure>
+            <img src="../kss-assets/img/img-placeholder.gif" alt="example image"/>
+          </figure>
+          <article>
+            <h3>
+              <a href="#">Hero list item</a>
+            </h3>
+
+            <p>Can be paired with horizontal list items for emphasis</p>
+
+          </article>
+        </li>
+
+        <!-- List item with an image -->
+        <li>
+          <figure>
+            <img src="../kss-assets/img/img-placeholder.gif" alt="example image" />
+          </figure>
+          <article>
+            <h3>
+              <a href="#">About The Digital Transformation Office</a>
+            </h3>
+
+            <div class="meta">
+              <time datetime="2016-05-08 00:00">08 May 2016</time>
+              <a href="#" rel="author">Author</a>
+            </div>
+
+            <p>The Digital Transformation Office (DTO) was established as an executive agency in July 2015. Its mission is to lead the transformation of government services to deliver a better experience for Australians.</p>
+
+            <footer class="tags">
+              <dl>
+                <dt>Topics:</dt>
+                <dd><a href="#">Tag Name</a></dd>
+                <dd><a href="#">Tag name</a></dd>
+                <dd><a href="#">Tag Name</a></dd>
+                <dd><a href="#">Tag Name</a></dd>
+                <dd><a href="#">Tag Name</a></dd>
+                <dd><a href="#">Tag Name</a></dd>
+              </dl>
+            </footer>
+          </article>
+        </li>
+
+        <!-- List item with no image where there should be one -->
+        <li>
+          <figure>
+          </figure>
+          <article>
+            <h3>
+              <a href="#">About The Digital Transformation Office</a>
+            </h3>
+
+            <div class="meta">
+              <time datetime="2016-05-08 00:00">08 May 2016</time>
+              <a href="#" rel="author">Author</a>
+            </div>
+
+            <p>The Digital Transformation Office (DTO) was established as an executive agency in July 2015. Its mission is to lead the transformation of government services to deliver a better experience for Australians.</p>
+
+            <footer class="tags">
+              <dl>
+                <dt>Topics:</dt>
+                <dd><a href="#">Tag Name</a></dd>
+                <dd><a href="#">Tag name</a></dd>
+                <dd><a href="#">Tag Name</a></dd>
+                <dd><a href="#">Tag Name</a></dd>
+                <dd><a href="#">Tag Name</a></dd>
+                <dd><a href="#">Tag Name</a></dd>
+              </dl>
+            </footer>
+          </article>
+        </li>
+
+        <!-- List item with no image -->
+        <li>
+          <article>
+            <h3>
+              <a href="#">About The Digital Transformation Office</a>
+            </h3>
+
+            <div class="meta">
+              <time datetime="2016-05-08 00:00">08 May 2016</time> <a href="#" rel="author">Author</a>
+            </div>
+
+            <p>The Digital Transformation Office (DTO) was established as an executive agency in July 2015. Its mission is to lead the transformation of government services to deliver a better experience for Australians.</p>
+
+            <footer class="tags">
+              <dl>
+                <dt>Topics:</dt>
+                <dd><a href="#">Tag Name</a></dd>
+                <dd><a href="#">Tag name</a></dd>
+                <dd><a href="#">Tag Name</a></dd>
+                <dd><a href="#">Tag Name</a></dd>
+                <dd><a href="#">Tag Name</a></dd>
+                <dd><a href="#">Tag Name</a></dd>
+              </dl>
+            </footer>
+          </article>
+        </li>
+
+        <!-- List item  -->
+        <li>
+          <article>
+            <h3>
+              <a href="#">About The Digital Transformation Office</a>
+            </h3>
+
+            <p>The Digital Transformation Office (DTO)</p>
+
+          </article>
+        </li>
+      </ul>
+
+      <h2>Buttons and links</h2>
+
+      <p>A <a href="#">text link</a> can appear within a chunk of text, or within any text element. Buttons can be grouped
+        together:</p>
+
+      <p>
+        <a href="#" role="button">Primary Button</a>
+        <a href="#" role="button" class="contrast">Contrast button</a>
+        <a href="#" role="button" class="disabled">Disabled</a>
+      </p>
+
+      <p>It would be way cool to have <code>kbd</code> support, so that we can tell people how to <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>Delete</kbd>, or how to win their games faster by mashing <kbd>F11</kbd>.</p>
+
+      <h2>Quotations and citations</h2>
+
+      <p>We need to be able to cater for both block quotations, as well as in-line quotations via the <code>q</code>
+        element, because Simon said <q>yo dawg, get them quotes on yo!</q></p>
+
+      <p>The <code>q</code> element is unlikely to see a lot of use, unless we play with the editors to be used for
+        authoring and editing things. The other issue with using the <code>content</code> property is that text selection
+        of its contents is not available, so the opening and closing quotation marks are not selectable.</p>
+
+      <p>Time for a <code>blockquote</code>, which are distinct from in-line qutoations via the <code>q</code> element.
+      </p>
+
+      <blockquote>
+        <p>Blockquotes are block-level elements that contain in-line elements.</p>
+        <p>This means we can place multiple paragraphs, lists, etc. into a block quotation. We can also use it nest
+          another blockquote, like so:</p>
+        <blockquote>
+          <p><em>How far the moral sphere extends.</em>&mdash;As soon as we see a new image, we immediately construct it
+            with the aid of all our previous experiences, <em>depending on the degree</em> of our honesty and justice. All
+            experiences are moral experiences, even in the realm of sense perception.</p>
+          <footer>
+            <cite>1887, Nietzsche (1974). <em>The Gay Science</em> [second edition], &sect; 114. Translated from the
+              German by W. Kaufmann. New York: Vintage Books.</cite>
+          </footer>
+        </blockquote>
+        <p>While inside the block quotation, let us test a few other nested elements:</p>
+        <ul>
+          <li>first sorted list item</li>
+          <li>second sorted list item
+            <ol>
+              <li>another item</li>
+              <li>and again&hellip;</li>
+            </ol>
+          </li>
+          <li>and another item</li>
+        </ul>
+        <p>The other thing that is worth noting is that we can place the <code>footer</code> element contextually inside
+          other block-level elements; they are not restricted to a single use per page. This allows us to use
+          <code>footer</code> inside a <code>blockquote</code>, and within that we can provide a citation via the <code>cite</code>
+          element.</p>
+        <footer>
+          <cite><a href="link">Citation source</a></cite>
+        </footer>
+      </blockquote>
+
+      <p>We can draw attention to a quotation by using the <code>.pullquote</code> class for a block quotation.</p>
+
+      <blockquote class="pullquote">
+        <p><em>Mystical explanations.</em>&mdash;Mystical explanations are considered deep. The truth is that they are not
+          even superficial.</p>
+      </blockquote>
+
+      <h3>Heading Level 3</h3>
+      <p>As well as definition lists:</p>
+
+      <dl>
+        <dt>Definition term 1</dt>
+        <dd>Definition description</dd>
+        <dd>A single definition term can have many definitions.</dd>
+
+        <dt>Second definition term</dt>
+        <dd>Another definition.</dd>
+      </dl>
+
+      <h4>Heading Level 4</h4>
+
+      <p>These interespersed elements aim to show the <em>vertical rhythm</em> between various content elements, using
+        predominately margin-bottom, and only margin-top in the instances where it would be too cumbersome or hacky to try
+        continue with just margin-bottom.</p>
+
+      <p class="callout">This is a callout.</p>
+
+      <p class="callout--warning">This is a warning callout.</p>
+
+      <p>This makes maintaining the vertical rhythm between content easier, and avoids spacing bugs, as well as sizing
+        bugs that aren't immediately apparent when just testing with a few paragraphs and headings.</p>
+
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Qui dicta minus molestiae vel beatae natus eveniet
+        ratione temporibus aperiam harum alias officiis assumenda officia quibusdam deleniti eos cupiditate dolore
+        doloribus!</p>
+      <p>Ad dolore dignissimos asperiores dicta facere optio quod commodi nam tempore recusandae. Rerum sed nulla eum vero
+        expedita ex delectus voluptates rem at neque quos facere sequi unde optio aliquam!</p>
+      <p>Tenetur quod quidem in voluptatem corporis dolorum dicta sit pariatur porro quaerat autem ipsam odit quam beatae
+        tempora quibusdam illum! Modi velit odio nam nulla unde amet odit pariatur at!</p>
+      <p>Consequatur rerum amet fuga expedita sunt et tempora saepe? Iusto nihil explicabo perferendis quos provident
+        delectus ducimus necessitatibus reiciendis optio tempora unde earum doloremque commodi laudantium ad nulla vel
+        odio?</p>
+
+      <ul>
+        <li>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nam vero.</li>
+        <li>Laboriosam quaerat sapiente minima nam minus similique illum architecto et!</li>
+        <li>Incidunt vitae quae facere ducimus nostrum aliquid dolorum veritatis dicta!</li>
+        <li>Tenetur laborum quod cum excepturi recusandae porro sint quas soluta!</li>
+      </ul>
+
+      <h5>Heading Level 5</h5>
+
+      <ol>
+        <li>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nam vero.</li>
+        <li>Laboriosam quaerat sapiente minima nam minus similique illum architecto et!</li>
+        <li>Incidunt vitae quae facere ducimus nostrum aliquid dolorum veritatis dicta!</li>
+        <li>Tenetur laborum quod cum excepturi recusandae porro sint quas soluta!</li>
+      </ol>
+
+      <section class="form-wrapper">
+
+        <h2>Contact Us</h2>
+        <form>
+          <p>
+            <label for="name">Your name</label>
+            <input type="text" id="name"/>
+          </p>
+          <p>
+            <label for="colour">Your favourite colour</label>
+            <input type="text" id="colour" disabled/>
+          </p>
+          <p>
+            <label for="contact">Your contact</label>
+            <span class="hint" id="name-hint">Please provide an email address.</span>
+            <input type="email" id="contact" aria-describedby="name-hint" required/>
+          </p>
+
+          <fieldset id="reply">
+            <legend>Would you like a reply?</legend>
+            <input id="yes" name="reply" type="radio" value="Yes"/>
+            <label for="yes">Yes</label>
+            <input id="no" name="reply" type="radio" value="No"/>
+            <label for="no">No</label>
+            <input id="maybe" name="reply" type="radio" value="Maybe"/>
+            <label for="maybe">Maybe</label>
+          </fieldset>
+
+          <fieldset id="comms">
+            <legend>What method(s) of communication do you prefer?</legend>
+            <input id="radio" name="comms" type="checkbox" value="Radio"/>
+            <label for="radio">Radio</label>
+            <input id="telephone" name="comms" type="checkbox" value="Telephone"/>
+            <label for="telephone">Telephone</label>
+          </fieldset>
+
+          <p>
+            <label for="message">Your message</label>
+            <textarea id="message"></textarea>
+          </p>
+          <input type="submit" value="Submit"/>
+          <input type="reset" value="Reset"/>
+        </form>
+
+      </section>
+
+    </article>
+  </main>
+
+  <footer role="contentinfo">
+    <div class="wrapper">
+      <section class="footer-top">
+        <nav>
+          <ul>
+            <li><h3>Title header</h3></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+          </ul>
+          <ul>
+            <li><h3>Title header</h3></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+          </ul>
+          <ul>
+            <li><h3>Title header</h3></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+          </ul>
+          <ul>
+            <li><h3>Title header</h3></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+            <li><a href="javascript:void(0)">This is a footer link</a></li>
+          </ul>
+        </nav>
+      </section>
+      <section>
+        <div class="footer-logo">
+          <img alt="Australian Government Coat of Arms" src="/latest/img/coat-of-arms.png">
+        </div>
+        <div class="footer-links">
+          <nav>
+            <ul>
+              <li><a href="javascript:void(0)">Example global link</a></li>
+              <li><a href="javascript:void(0)">Example global link</a></li>
+              <li><a href="javascript:void(0)">Example global link</a></li>
+              <li><a href="javascript:void(0)">Example global link</a></li>
+              <li><a href="javascript:void(0)">Example global link</a></li>
+            </ul>
+          </nav>
+          <p>&copy; Commonwealth of Australia <br>
+          <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE.md">Licensed under the MIT License.</a></p>
+        </div>
+      </section>
+      </div>
+    </footer>
+
+  </body>
+</html>

--- a/examples/header-home.html
+++ b/examples/header-home.html
@@ -73,7 +73,6 @@
             <li><a href="#">Television reception</a></li>
             <li><a href="#">School Holidays</a></li>
             <li><a href="#">This is a link</a></li>
-            <li><a href="#">This is a link</a></li>
           </ul>
         </div>
 


### PR DESCRIPTION
## Description

Messing with Bourbon Neat layout setup with ULs to get 2-4 columns of links to appear in. Meant to be multipurpose for use in various areas.

Primary focus is on the group of links titled “Popular now” to appear in homepage heroes. It
should also be flexible to live in other areas, i.e. after an article
## Additional information
- I can't get the links into two columns in mobile. Got stuck with the omega bug.
- Desktop and desktop seem alright staying in 4 columns, but hopefully I'm not just settling because I got stuck...

![image](https://cloud.githubusercontent.com/assets/19661064/17127153/af4d4596-5346-11e6-8c05-bf73b008eef8.png)

---
- [x] Content/documentation reviewed by Julian or someone in the Content Team
- [x] UX reviewed by Gary or someone the Design team
- [x] Code reviewed by one of the core developers
- [x] Stakeholder/PO review
- [x] CHANGELOG updated
