### PR TITLE
Feature: adds a link to the GH source in the KSS examples source line reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Next release (scheduled 2016-07-26)
 
-UI-Kit:
+#### UI-Kit changes
 
 - Callouts: extends with a new class to highlight specific dates (`.callout--calendar-event`).
 - Text input `type` `tel` support.
@@ -21,17 +21,17 @@ UI-Kit:
   - ‘Old’ headings retained and available when wrapped in a container with the class `.gov-speak` (demarcated for more complex typography, eg for annual reports).
   - Refactors numerous `@extends` to clean up CSS output + numerous minor code improvs.
 
-Styleguide:
+#### Styleguide changes
 
-We have revised a number of our styleguide sections, simplifying them while adding explicit accessibility guidance under a common heading. Sections revised:
+Source references in the styleguide examples now link to the file & line in our GitHub repository. If you have feedback on our code please let get in touch. :)
+
+We have also revised a number of our styleguide sections, simplifying them while adding explicit accessibility guidance under a common heading. Sections revised:
 
 - Forms
 - Accordions
 - Tables
 
-Bugfixes:
-
-- …
+#### Other changes
 
 Build environment:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,11 @@
 
 - Callouts: extends with a new class to highlight specific dates (`.callout--calendar-event`).
 - Text input `type` `tel` support.
-- New table style: calendar tables, for displaying a series of days and their events (eg public holidays).
+- New table style: calendar tables, for displaying a series of dates and their events (eg public holidays).
 - Local nav (sidebar):
   - Now appears to the right of the main content space (not markup change required).
   - Toggle-able to the left (as previously) by applying `.sidebar-has-controls` to the `<main>` element.
   - [undocumented] Adds new `.current` class for current page in the IA.
-  - [undocumented] [MARKUP CHANGE] `.is-active` has been replaced by `.active`.
   - [incomplete & undocumented] Adds top-level item support.
 - Typography overhaul:
   - Removes `margin-top` from most content elements (headings excluded).

--- a/kss-builder/index.hbs
+++ b/kss-builder/index.hbs
@@ -192,7 +192,7 @@
 
           {{#if sourceFile.name}}
             <div class="kss-source">
-              Source: <code>{{sourceFile.name}}</code>, line {{sourceFile.line}}
+              Source on GitHub: <a href="https://github.com/AusDTO/gov-au-ui-kit/tree/develop/assets/sass/{{sourceFile.name}}#L{{sourceFile.line}}" rel="external gh-source-ref"><code>{{sourceFile.name}}</code></a>, line {{sourceFile.line}}
             </div>
           {{/if}}
 

--- a/kss-builder/index.hbs
+++ b/kss-builder/index.hbs
@@ -192,7 +192,7 @@
 
           {{#if sourceFile.name}}
             <div class="kss-source">
-              Source on GitHub: <a href="https://github.com/AusDTO/gov-au-ui-kit/tree/develop/assets/sass/{{sourceFile.name}}#L{{sourceFile.line}}" rel="external gh-source-ref"><code>{{sourceFile.name}}</code></a>, line {{sourceFile.line}}
+              Source on GitHub: <a href="https://github.com/AusDTO/gov-au-ui-kit/tree/master/assets/sass/{{sourceFile.name}}#L{{sourceFile.line}}" rel="external gh-source-ref"><code>{{sourceFile.name}}</code></a>, line {{sourceFile.line}}
             </div>
           {{/if}}
 


### PR DESCRIPTION
## Description

Figured I’d just add it; was a pet-peeve. :)

![screen shot 2016-07-26 at 7 00 46 pm](https://cloud.githubusercontent.com/assets/52766/17132161/df3c0554-5363-11e6-90db-4577cf652cf1.png)
## Additional information

The linking is pretty basic:

```
https://github.com/AusDTO/gov-au-ui-kit/tree/develop/assets/sass/{{sourceFile.name}}#L{{sourceFile.line}}
```

If someone wants to improve it feel free. :)

I couldn’t find a backlog item for it? :S
