### PR TITLE
Adds hardcoded version number to uikit.scss in multiline comment block

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -54,6 +54,11 @@ Using git-flow create a release branch:
 
 Make sure that wherever the version is stored or set in the code, the version now matches the version for this release.
 
+Files impacted:
+
+- `package.json`, line 3
+- `assets/sass/ui-kit.scss`, line 3
+
 ### Ensure the changelog is up to date
 
 Describe the version and list changes that we made (review the sprint in Jira if required).

--- a/assets/sass/ui-kit.scss
+++ b/assets/sass/ui-kit.scss
@@ -1,3 +1,9 @@
+/*
+
+UI-Kit version: 1.4.0
+
+*/
+
 @import 'vendor/entity';
 @import 'vendor/normalize';
 @import 'vendor/bourbon/bourbon';


### PR DESCRIPTION
## Description

Problem: as we debug the beta, we need a clear way to quickly ascertain the version of ui-kit in use, especially as we ramp up our release frequency.

Solution: add a multiline hard-coded comment block to the head of `uikit.scss`, which isn’t stripped during minification.
## Additional information

![screen shot 2016-07-28 at 1 46 30 pm](https://cloud.githubusercontent.com/assets/52766/17200561/c67edbd8-54c9-11e6-8951-3754f64928f9.png)
## Definition of Done
- [x] Code reviewed by one of the core developers

@maxious / @petronbot I can has merge?
