### PR TITLE
Remove seperate icon CSS and provide zip file of image resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## UI Kit "Kraken"
 
+### Unreleased
+
+#### UI-Kit changes
+
+- Iconography
+  -  Removed ui-kit-icons.css output file
+  -  Added images.zip build output containing images used
+
 ### 1.4.0 - 2016-07-27
 
 #### UI-Kit changes

--- a/assets/sass/_icons.scss
+++ b/assets/sass/_icons.scss
@@ -1,6 +1,6 @@
 @mixin inline-background-image($img) {
-  background-image: inline('build/latest/img/icons/' + $img + '.png');
-  background-image: none, inline('assets/img/icons/' + $img + '.svg'),
+  background-image: asset-data-url('build/latest/img/icons/' + $img + '.png');
+  background-image: none, asset-data-url('assets/img/icons/' + $img + '.svg'),
   linear-gradient(transparent, transparent);
 }
 

--- a/assets/sass/ui-kit-icons.scss
+++ b/assets/sass/ui-kit-icons.scss
@@ -1,1 +1,0 @@
-@import 'icons';

--- a/package.json
+++ b/package.json
@@ -44,9 +44,8 @@
     "sass-inline-svg": "^0.0.3",
     "smoothscroll": "^0.2.2",
     "through2": "^2.0.1",
-    "webpack-stream": "^3.2.0"
-  },
-  "devDependencies": {
-    "fs": "0.0.2"
+    "webpack-stream": "^3.2.0",
+    "fs": "0.0.2",
+    "gulp-zip": "^3.2.0"
   }
 }


### PR DESCRIPTION
## Description

Remove inline images hack with a seperate icon CSS and provide zip file of image resources. This fixes use of the raw merged SCSS as we do in GOV.AU beta. 
## Additional information

I also renamed the data-url inlining function to match what we get in rails https://github.com/rails/sass-rails#asset-data-urlrelative-asset-path I don't think it's the same inline function name as Compass though :/

https://github.com/AusDTO/gov-au-ui-kit/commit/c5bd3c6d57bf8e82fbbda470c599d53ea81ad476 was what broke it
## Definition of Done
- [x] Code reviewed by one of the core developers
- [x] Stakeholder/PO review
- [x] CHANGELOG updated
