### PR TITLE
.abstract text responsive fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,11 @@ Styleguide:
 
 Bugfixes:
 
-- Fixed [#230](https://github.com/AusDTO/gov-au-ui-kit/issues/230): margins between vertical list items
 - Fixed [#232](https://github.com/AusDTO/gov-au-ui-kit/issues/232): local navigation mobile styling and chevron toggle displacement.
+- Added a disclaimer regarding accessibility and browser support.
+- Fixed [#230](https://github.com/AusDTO/gov-au-ui-kit/issues/230): Margins between vertical list items.
+- Fixed [#203](https://github.com/AusDTO/gov-au-ui-kit/issues/203): Abstract style doesn't apply to nested paragraphs.
+- Fixed [#227](https://github.com/AusDTO/gov-au-ui-kit/issues/227): No visual differentiation between h1 and .abstract on section page in mobile browser.
 
 ### 1.6.0 as of 2016-07-29
 

--- a/assets/sass/_typography.scss
+++ b/assets/sass/_typography.scss
@@ -251,7 +251,7 @@ h1 {
   margin-bottom: $small-spacing;
 
   @include media($tablet) {
-    font-size: rem(26);
+    font-size: rem(28);
   }
 
   @include media($desktop) {

--- a/assets/sass/_typography.scss
+++ b/assets/sass/_typography.scss
@@ -443,6 +443,24 @@ strong {
   }
 }
 
+// To be deprecated as of v2.0
+//
+// We are retaining this so that p.abstract is possible. Please use div.abstract p.
+p.abstract {
+  margin: $small-spacing 0 ($medium-spacing * 1.25);
+  padding-bottom: $medium-spacing;
+  border-bottom: 1px solid $border-colour;
+  font-size: rem(19);
+
+  @include media($tablet) {
+    font-size: rem(21);
+  }
+
+  @include media($desktop) {
+    font-size: rem(24);
+  }
+}
+
 hr {
   border-color: $border-colour;
   border-style: solid;

--- a/assets/sass/_typography.scss
+++ b/assets/sass/_typography.scss
@@ -234,7 +234,7 @@ Style guide: Typography.2 Headings & body copy
 
 // Styling for headings
 //
-// Note that we don't style h5 and h6.
+// Note that we style h5 and h6 are identical to h4.
 
 h1,
 h2,
@@ -248,6 +248,7 @@ h4 {
 
 h1 {
   font-size: rem(24);
+  margin-bottom: $small-spacing;
 
   @include media($tablet) {
     font-size: rem(26);
@@ -410,6 +411,7 @@ kbd {
 strong {
   font-weight: $bold-font-weight;
 
+  // Huh?
   &.very-bold {
     font-weight: $heading-font-weight;
   }
@@ -424,11 +426,21 @@ strong {
 //
 // For abstracts or page introductory paragraphs.
 .abstract {
-  font-size: rem(24);
-  font-weight: $base-font-weight;
-  border-bottom: 1px solid $border-colour;
-  padding-bottom: $medium-spacing;
-  margin-bottom: $medium-spacing;
+  p {
+    font-size: rem(19);
+    font-weight: $base-font-weight;
+    border-bottom: 1px solid $border-colour;
+    padding-bottom: $medium-spacing;
+    margin-bottom: $medium-spacing;
+
+    @include media($tablet) {
+      font-size: rem(21);
+    }
+
+    @include media($tablet) {
+      font-size: rem(24);
+    }
+  }
 }
 
 hr {

--- a/assets/sass/_typography.scss
+++ b/assets/sass/_typography.scss
@@ -480,10 +480,14 @@ dl,
 p,
 dt,
 dd {
-  font-size: rem(17);
+  font-size: rem(16);
   margin-top: 0; // Check up on where margin-top is coming from...
   margin-bottom: $medium-spacing;
   line-height: $base-spacing;
+
+  @include media($tablet) {
+    font-size: rem(17);
+  }
 }
 
 li {

--- a/assets/sass/_typography.scss
+++ b/assets/sass/_typography.scss
@@ -426,18 +426,18 @@ strong {
 //
 // For abstracts or page introductory paragraphs.
 .abstract {
+  margin: $medium-spacing 0 ($base-spacing * 1.25);
+  border-bottom: 1px solid $border-colour;
+
   p {
     font-size: rem(19);
     font-weight: $base-font-weight;
-    border-bottom: 1px solid $border-colour;
-    padding-bottom: $medium-spacing;
-    margin-bottom: $medium-spacing;
 
     @include media($tablet) {
       font-size: rem(21);
     }
 
-    @include media($tablet) {
+    @include media($desktop) {
       font-size: rem(24);
     }
   }

--- a/assets/sass/templates/heading-body-styles.hbs
+++ b/assets/sass/templates/heading-body-styles.hbs
@@ -9,4 +9,6 @@
 
 <p>Body copy</p>
 
-<p class="abstract">.abstact body copy</p>
+<div class="abstract">
+  <p>.abstact paragraph text</p>
+</div>

--- a/examples/index.html
+++ b/examples/index.html
@@ -147,7 +147,9 @@
 
     <article id="content" class="content-main">
       <h1>Article title that is quite a bit longer</h1>
-      <p class="abstract">This is my <code>.abstract</code> text: the quick brown fox jumped over the lazy dog.</p>
+      <div class="abstract">
+        <p>This is my <code>.abstract</code> text: the quick brown fox jumped over the lazy dog.</p>
+      </div>
 
       <p>So, let us commence with some accordions:</p>
 


### PR DESCRIPTION
## Description

See bug #227.

This is a potential fix, but has some implications:
- assumes `.abstract` is now going to be used only as a wrapper (padding/margins dependant on this)
- assumes the contents of that wrapper will only be `p` elements… (happy to extend)

Screenshot of after (cf. the bug’s screenshot):

![screen shot 2016-08-01 at 11 34 04 am](https://cloud.githubusercontent.com/assets/52766/17281040/f2908a54-57db-11e6-8041-31a77c28d661.png)
## Additional information

It might be nice to move the `article`’s `h1` and the `.abstract` into `article header` at this point?

I’d like to make this markup move anyway; how about now — what do you reckon @petronbot ?
## Definition of Done
- [ ] Content/documentation reviewed by Julian or someone in the Content Team
- [ ] UX reviewed by Gary or someone the Design team
- [x] Code reviewed by one of the core developers
- [ ] Acceptance Testing
  - [ ] Cross-browser tested against standard browser matrix (TBD)
  - [ ] Tested on multiple devices (TBD)
  - [ ] HTML5 validation (CircleCI)
  - [ ] Accessibility testing & WCAG2 compliance (manual/auto TBD)
- [ ] Stakeholder/PO review
- [x] CHANGELOG updated
