### PR TITLE
Revisit Vertical list styles so that margins appear between items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,16 @@
 
 ## UI Kit "Kraken"
 
-### `develop` of 2016-07-30
+### 1.7.0 (unreleased)
 
-Added a disclaimer regarding accessibility and browser support.
+Bugfixes:
+
+- Fixed [#230](https://github.com/AusDTO/gov-au-ui-kit/issues/230): margins between vertical list items
+
+Styleguide:
+
+- Added a disclaimer regarding accessibility and browser support.
+
 
 ### 1.6.0 as of 2016-07-29
 

--- a/assets/js/ui-kit.js
+++ b/assets/js/ui-kit.js
@@ -1,3 +1,4 @@
+var flexibility = require('flexibility');
 var smoothScroll = require('smoothscroll');
 
 (function (document) {
@@ -46,7 +47,7 @@ var smoothScroll = require('smoothscroll');
       if (!toggle) {
           toggleElem.textContent = elem.dataset.toggleLabel || 'Menu';
       }
-      
+
       toggleElem.setAttribute('aria-controls', panelLabel);
       toggleElem.className = panelLabel + '-toggle';
       toggleElem.targetElem = elem;

--- a/assets/js/ui-kit.js
+++ b/assets/js/ui-kit.js
@@ -1,4 +1,3 @@
-var flexibility = require('flexibility');
 var smoothScroll = require('smoothscroll');
 
 (function (document) {

--- a/assets/sass/_lists.scss
+++ b/assets/sass/_lists.scss
@@ -186,10 +186,15 @@ Style guide: List styles.4 Highlighted word style
 
     border-top: 4px solid $border-colour;
     border-bottom: none;
+    margin: 0;
     flex: 0 0 100%;
 
     @include media($tablet) {
-      flex-basis: 48%;
+      flex-basis: (96% / 2);
+
+      &:not(:nth-child(2n)) {
+        margin-right: 4%;
+      }
     }
 
     article {
@@ -240,8 +245,16 @@ Style guide: List styles.4 Highlighted word style
   }
 
   > li {
-    @include media ($tablet) {
-      flex: 0 0 31%;
+    @include media($tablet) {
+      flex: 0 0 (92% / 3);
+
+      &:not(:nth-child(2n)) {
+        margin-right: 0;
+      }
+
+      &:not(:nth-child(3n)) {
+        margin-right: 4%;
+      }
     }
   }
 }
@@ -257,8 +270,17 @@ Style guide: List styles.4 Highlighted word style
   }
 
   > li {
-    @include media ($tablet) {
-      flex: 0 0 22%;
+    @include media($tablet) {
+      flex: 0 0 (88% / 4);
+
+      &:not(:nth-child(2n)),
+      &:not(:nth-child(3n)) {
+        margin-right: 0;
+      }
+
+      &:not(:nth-child(4n)) {
+        margin-right: 4%;
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "css-select": "^1.2.0",
     "del": "^2.2.0",
     "dom-serializer": "^0.1.0",
+    "flexibility": "^2.0.1",
+    "fs": "0.0.2",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^3.1.0",
     "gulp-connect": "^4.1.0",
@@ -35,6 +37,7 @@
     "gulp-svg2png": "^1.0.2",
     "gulp-uglify": "^1.5.3",
     "gulp-util": "^3.0.7",
+    "gulp-zip": "^3.2.0",
     "handlebars.moment": "^1.0.4",
     "htmlparser2": "^3.9.1",
     "kss": "^3.0.0-beta.14",
@@ -44,8 +47,6 @@
     "sass-inline-svg": "^0.0.3",
     "smoothscroll": "^0.2.2",
     "through2": "^2.0.1",
-    "webpack-stream": "^3.2.0",
-    "fs": "0.0.2",
-    "gulp-zip": "^3.2.0"
+    "webpack-stream": "^3.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "css-select": "^1.2.0",
     "del": "^2.2.0",
     "dom-serializer": "^0.1.0",
-    "flexibility": "^2.0.1",
     "fs": "0.0.2",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^3.1.0",


### PR DESCRIPTION
## Description

This PR restores margins between vertical list items.  I've stuck with `flexbox` styles because we're using modifier classnames here (`.list-vertical--fourths`) we're still going to run into override problems with Neat's `omega()`.

Fixes: https://github.com/AusDTO/gov-au-ui-kit/issues/230
### Vertical list with 2 columns (default)

![image](https://cloud.githubusercontent.com/assets/5482613/17280919/75403960-57da-11e6-9567-ba828471fd5f.png)
### Vertical list with 3 columns

![image](https://cloud.githubusercontent.com/assets/5482613/17280922/801ab1c6-57da-11e6-84fb-b942467b4401.png)
### Vertical list with 4 columns

![image](https://cloud.githubusercontent.com/assets/5482613/17280926/907ca600-57da-11e6-9abc-162b2427ba4f.png)
## Definition of Done
- [x] Code reviewed by one of the core developers
- [x] Stakeholder/PO review
- [x] CHANGELOG updated
