### PR TITLE
Removed border and stated transform origin on local-nav-toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,16 @@
 
 ## UI Kit "Kraken"
 
-### 1.7.0 (unreleased)
-
-Bugfixes:
-
-- Fixed [#230](https://github.com/AusDTO/gov-au-ui-kit/issues/230): margins between vertical list items
+### 1.7.0 - 2016-08-01
 
 Styleguide:
 
 - Added a disclaimer regarding accessibility and browser support.
 
+Bugfixes:
+
+- Fixed [#230](https://github.com/AusDTO/gov-au-ui-kit/issues/230): margins between vertical list items
+- Fixed [#232](https://github.com/AusDTO/gov-au-ui-kit/issues/232): local navigation mobile styling and chevron toggle displacement.
 
 ### 1.6.0 as of 2016-07-29
 

--- a/assets/sass/_accordions.scss
+++ b/assets/sass/_accordions.scss
@@ -5,7 +5,7 @@ Accordions help users find only the content they need.
 
 The **expand/collapse all** feature will be provided soon&mdash;this will be mandatory if using a series of accordion elements.
 
-<hr />
+***
 
 This guidance is in part adapted from [18F Draft US Web Design Standards](https://standards.usa.gov/getting-started/) under [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/legalcode).
 
@@ -81,11 +81,11 @@ summary {
     content: '';
     position: absolute;
     top: .5em;
-    right: $small-spacing;
     bottom: .5em;
+    right: $small-spacing;
     width: $medium-spacing;
     background-repeat: no-repeat;
-    background-position: center center; // added this not in .local-nav-toggle
+    background-position: center center;
     background-size: 100% auto;
     transform: rotate(0deg);
     transition: transform $transition-timing $transition-easing;

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -216,6 +216,7 @@ Style guide: Navigation.6 Footer navigation
 
   &::before {
     @extend %icon-chevron-down--navy;
+
     content: '';
     position: absolute;
     top: .5em;
@@ -224,6 +225,7 @@ Style guide: Navigation.6 Footer navigation
     width: $medium-spacing;
     background-repeat: no-repeat;
     background-size: 100% auto;
+    background-position: center center;
     transform: rotate(0deg);
     transition: transform $transition-timing $transition-easing;
   }

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -206,6 +206,7 @@ Style guide: Navigation.6 Footer navigation
   margin: $base-spacing 0 0;
   text-align: left;
   font-weight: $base-font-weight;
+  border: 0;
 
   &,
   &:hover {

--- a/examples/index.html
+++ b/examples/index.html
@@ -116,31 +116,6 @@
 
   <main>
     <aside class="sidebar" id="nav">
-      <!-- <nav class="local-nav" aria-label="main navigation">
-        <ul>
-          <li><a href="#">Overview</a></li>
-          <li><a href="#">Purpose</a></li>
-          <li>
-            <a href="#">Foundations</a>
-            <ul class="sub-nav-list">
-              <li><a href="#">Overview</a></li>
-              <li><a href="#">Design principles</a></li>
-              <li><a href="#">Grid</a></li>
-              <li>
-                <a href="#">Typography</a>
-                <ul class="sub-sub-nav-list">
-                  <li><a href="#">Line height and spacing</a></li>
-                  <li><a href="#">Typesetting</a></li>
-                </ul>
-              </li>
-              <li><a href="#">Text accessibility</a></li>
-              <li><a href="#">Links</a></li>
-              <li><a href="#">Lists</a></li>
-            </ul>
-          </li>
-        </ul>
-      </nav> -->
-
       <nav class="local-nav" aria-label="main navigation">
         <h1 class="is-visuallyhidden">Menu</h1>
         <ul>

--- a/examples/index.html
+++ b/examples/index.html
@@ -93,6 +93,7 @@
             <a href="#" class="button--feedback" role="button">Give feedback</a>
           </div>
         </nav>
+
       </div>
     </section>
     <section class="hero">
@@ -115,7 +116,7 @@
 
   <main>
     <aside class="sidebar" id="nav">
-      <nav class="local-nav" aria-label="main navigation">
+      <!-- <nav class="local-nav" aria-label="main navigation">
         <ul>
           <li><a href="#">Overview</a></li>
           <li><a href="#">Purpose</a></li>
@@ -138,7 +139,35 @@
             </ul>
           </li>
         </ul>
+      </nav> -->
+
+      <nav class="local-nav" aria-label="main navigation">
+        <h1 class="is-visuallyhidden">Menu</h1>
+        <ul>
+          <li>
+            <a href="#" class="is-active">Department of Communications and the Arts</a>
+            <ul>
+              <li>
+                <a href="#" class="is-active">People and structure</a>
+                <ul>
+                  <li><a href="#">Division name</a></li>
+                  <li>
+                    <a href="#" class="is-active">Division name</a>
+                    <ul>
+                      <li><a href="#" class="is-active is-current">Branch name</a></li>
+                      <li><a href="#">Branch name</a></li>
+                    </ul>
+                  </li>
+                  <li><a href="#">Division name</a></li>
+                </ul>
+              </li>
+              <li><a href="#">Portfolio</a></li>
+            </ul>
+          </li>
+        </ul>
       </nav>
+
+
     </aside>
 
     <article id="content" class="content-main">


### PR DESCRIPTION
## Description

Removed default border showing up on mobile menu, adding `border:0` to
`.local-nav-toggle`
## Additional information
- Still needs to fix the awkward un-centered animation of the chevron (my local server was being odd and not loading images)

Previously looked like this:
![8c34ef872c9dabc56e10ec42523a5d31](https://cloud.githubusercontent.com/assets/19661064/17282261/6e633cca-57e7-11e6-8feb-0008e907acef.gif)

Now looks like this (note again: ignore the missing chevron, my local server was being odd):
![image](https://cloud.githubusercontent.com/assets/19661064/17282241/342ec27c-57e7-11e6-9418-9b728d1c2934.png)
## Definition of Done
- [ ] ~~Content/documentation reviewed by Julian or someone in the Content Team~~
- [x] UX reviewed by Gary or someone the Design team
- [x] Code reviewed by one of the core developers
- [ ] ~~Acceptance Testing~~
  - [ ] ~~Cross-browser tested against standard browser matrix (TBD)~~
  - [ ] ~~Tested on multiple devices (TBD)~~
  - [x] HTML5 validation (CircleCI)~~
  - [ ] ~~Accessibility testing & WCAG2 compliance (manual/auto TBD)~~
- [x] Stakeholder/PO review
- [x] CHANGELOG updated
