### PR TITLE
Adjusted styling of disabled inputs

### DIFF
--- a/assets/sass/_forms.scss
+++ b/assets/sass/_forms.scss
@@ -48,7 +48,8 @@ Style guide: Forms.1 Text input
   &:disabled,
   &[disabled] {
     cursor: not-allowed;
-    opacity: .5;
+    opacity: .25;
+    border: 2px dotted;
   }
 
 }

--- a/assets/sass/_forms.scss
+++ b/assets/sass/_forms.scss
@@ -48,8 +48,8 @@ Style guide: Forms.1 Text input
   &:disabled,
   &[disabled] {
     cursor: not-allowed;
-    opacity: .25;
-    border: 2px dotted;
+    background: $non-white;
+    border: 2px solid $light-grey;
   }
 
 }


### PR DESCRIPTION
## Description

Addressing issue #166 Bug - Disabled input field is visually similar to default

Changed the disabled input to havea  2px dotted border at 25% opacity
## Additional information

v1
![image](https://cloud.githubusercontent.com/assets/19661064/17283691/c6e9b27a-57f6-11e6-94ac-3c07443a461f.png)

v2
![image](https://cloud.githubusercontent.com/assets/19661064/17284051/96d99cae-57fa-11e6-9140-8644735c5983.png)
## Definition of Done
- [ ] Content/documentation reviewed by Julian or someone in the Content Team
- [x] UX reviewed by Gary or someone the Design team
- [x] Code reviewed by one of the core developers
- [x] Acceptance Testing
  - [x] HTML5 validation (CircleCI)
- [x] Stakeholder/PO review
- [ ] CHANGELOG updated
