### PR TITLE
Style updates for Calendar Callout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## UI Kit "Kraken"
 
+### 1.8.0 - Unreleased
+
+UI-Kit changes
+
+- Style changes to Calendar Event Callout class `.callout--calendar-event` (documented under *§ Typography*).
+
 ### 1.7.1 - 2016-08-01
 
 Bugfixes:

--- a/assets/sass/_typography.scss
+++ b/assets/sass/_typography.scss
@@ -568,7 +568,9 @@ Style guide: Typography.5 Callouts & warnings
 .callout--calendar-event {
   @extend %base-callout;
 
-  padding-bottom: $small-spacing; // reset
+  margin-left: 0;
+  box-shadow: none;
+  padding-bottom: $small-spacing;
   background-color: $callout-bg-light-colour;
 
   time,


### PR DESCRIPTION
## Description

Style changes only to the Calendar Event Callout (`.callout--calendar-event`)

Callouts now look like this:

![image](https://cloud.githubusercontent.com/assets/5482613/17286273/e04a98a0-580b-11e6-8315-a21e4b1d94a1.png)
## Definition of Done
- [x] UX reviewed by Gary or someone the Design team
- [x] Code reviewed by one of the core developers
- [x] Acceptance Testing
  - [x] HTML5 validation (CircleCI)
- [x] Stakeholder/PO review
- [x] CHANGELOG updated
