### PR TITLE
DESIGN-315: adds missing external rel links for styleguide

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Disclaimer
 GOV-AU UI-Kit is currently in early draft release. You can help us build it by [contributing](CONTRIBUTING.md).
 
-We are being guided by accessibility and browser support best practices. We are building on a solid HTML foundation and following a philosophy of [progressive enhancement](https://en.wikipedia.org/wiki/Progressive_enhancement) over [graceful degradation](https://en.wikipedia.org/wiki/Fault_tolerance).
+We are being guided by accessibility and browser support best practices. We are building on a solid HTML foundation and following a philosophy of <a href="https://en.wikipedia.org/wiki/Progressive_enhancement" rel="external">progressive enhancement</a> over <a href="https://en.wikipedia.org/wiki/Fault_tolerance" rel="external">graceful degradation</a>.
 
 We will start structured and more thorough accessibility and cross browser testing of the framework soon. We will then document the level of accessibility and browser compatibility.
 
@@ -29,9 +29,9 @@ include in your project:
 
 ### Features
 
-- [Normalize](https://necolas.github.io/normalize.css/).
-- [Bourbon](http://bourbon.io/), version 4.2.7.
-- [Neat](http://neat.bourbon.io/), and settings for a grid framework with some good defaults.
+- <a href="https://necolas.github.io/normalize.css/" rel="external">Normalize</a>.
+- <a href="http://bourbon.io/" rel="external">Bourbon</a>, version 4.2.7.
+- <a href="http://neat.bourbon.io/" rel="external">Neat</a>, and settings for a grid framework with some good defaults.
 - Basic styling for content with some good typographic coverage.
 - Basic styling for UI elements (eg `input`, `label`, etc).
 
@@ -47,9 +47,9 @@ Teams building Australian Government sites. This was designed for GOV.AU teams, 
 
 ## How is this related to the Digital Service Standard?
 
-The [Digital Service Standard](https://www.dto.gov.au/standard/) requires teams to [build services using common design patterns](https://www.dto.gov.au/standard/6-consistent-and-responsive/). This is draft work on the framework and guidance that will eventually become the design patterns for digital content.
+The <a href="https://www.dto.gov.au/standard/" rel="external">Digital Service Standard</a> requires teams to <a href="https://www.dto.gov.au/standard/6-consistent-and-responsive/" rel="external">build services using common design patterns</a>. This is draft work on the framework and guidance that will eventually become the design patterns for digital content.
 
-You should use this with the [draft **Content Style Guide**](http://content-style-guide.apps.staging.digital.gov.au/) for Digital Transformation Office projects.
+You should use this with the <a href="http://content-style-guide.apps.staging.digital.gov.au/" rel="external">draft <strong>Content Style Guide</strong></a> for Digital Transformation Office projects.
 
 ## Build the Guide yourself
 
@@ -76,11 +76,11 @@ at `./build/latest/ui-kit.css`.
 
 We have automated the build, with a few additions:
 
-- `sass-lint` for [linting](https://en.wikipedia.org/wiki/Lint_(software)
-- `cssnano` for [CSS compression](http://cssnano.co/)
-- `autoprefixer` for adding [CSS vendor prefixes](https://autoprefixer.github.io/)
-- `AusDTO/gulp-html` for [HTML validation](https://github.com/AusDTO/gulp-html)
-- `kss` for auto-building a [living style guide](http://warpspire.com/kss/)
+- `sass-lint` for <a href="https://en.wikipedia.org/wiki/Lint_(software)" rel="external">linting</a>
+- `cssnano` for <a href="http://cssnano.co/" rel="external">CSS compression</a>
+- `autoprefixer` for adding <a href="https://autoprefixer.github.io/" rel="external">CSS vendor prefixes</a>
+- `AusDTO/gulp-html` for <a href="https://github.com/AusDTO/gulp-html" rel="external">HTML validation</a>
+- `kss` for auto-building a <a href="http://warpspire.com/kss/" rel="external">living style guide</a>
 
 Our CI build is available as a shell script at `bin/cibuild.sh`.
 
@@ -94,13 +94,13 @@ Some of the key libraries we use are:
 - `kss ^3.0.0-beta.14`
 - `sass-lint ^1.7.0`
 
-`^` = compatible with version (see [semver](https://docs.npmjs.com/misc/semver#caret-ranges-123-025-004)).
+`^` = compatible with version (see <a href="https://docs.npmjs.com/misc/semver#caret-ranges-123-025-004" rel="external">semver</a>).
 
 ## Make gov-au-ui-kit better
 
-- Create a new [GitHub issue](https://github.com/AusDTO/gov-au-ui-kit/issues/new), or comment on [existing issues](https://github.com/AusDTO/gov-au-ui-kit/issues).
-- Contribute to this repository. Please see [CONTRIBUTING.md](CONTRIBUTING.md), [Contributor Code of Conduct](code_of_conduct.md) and [our code Conventions](conventions.md), (also see [Block Element Modifier](http://getbem.com/)), first.
-- Contact us on slack in `#govau-guide`.
+- Contribute to our <a href="https://github.com/AusDTO/gov-au-ui-kit/issues" rel="external">GitHub issue register</a> by logging new issues and joining the discussion.
+- Contribute to this repository. Please see [CONTRIBUTING.md](CONTRIBUTING.md), [Contributor Code of Conduct](code_of_conduct.md) and [our code Conventions](conventions.md), (also see <a href="http://getbem.com/" rel="external">Block Element Modifier</a>), first.
+- Contact us via the DTO slack in `#govau-guide`.
 
 ## Project goal
 
@@ -130,7 +130,7 @@ We may create an installer wrapper (likely node-based), or release via git submo
 
 ### 1st general goal
 
-Meet the general look and feel of the [gov.au alpha](http://gov.au/alpha), with room for some improvements.
+Meet the general look and feel of the <a href="http://gov.au/alpha" rel="external">gov.au alpha</a> with room for some improvements.
 
 This will allow us to establish the basics of the framework while meeting a relatively easily met static target.
 
@@ -155,10 +155,10 @@ Iterate in 2 ways:
 
 ## Copyright & license
 
-Copyright Digital Transformation Office. [Licensed under the MIT license](https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE).
+Copyright Digital Transformation Office. <a href="(https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE" rel="external license">Licensed under the MIT license</a>.
 
-This repository includes [Bourbon](http://bourbon.io/), [Neat](http://neat.bourbon.io/) and [Normalize.css](https://necolas.github.io/normalize.css/). All also use the MIT license.
+This repository includes <a href="http://bourbon.io/" rel="external">Bourbon</a>, <a href="http://neat.bourbon.io/" rel="external">Neat</a> and <a href="https://necolas.github.io/normalize.css/" rel="external">Normalize.css</a>. All also use the MIT license.
 
 ![](https://www.dto.gov.au/images/govt-crest.png "logo of the DTO")
 
-gov-au-ui-kit is maintained and funded by the [Digital Transformation Office](https://www.dto.gov.au/).
+gov-au-ui-kit is maintained and funded by the <a href="https://www.dto.gov.au/" rel="external">Digital Transformation Office</a>.

--- a/assets/sass/_accordions.scss
+++ b/assets/sass/_accordions.scss
@@ -7,7 +7,7 @@ The **expand/collapse all** feature will be provided soon&mdash;this will be man
 
 ***
 
-This guidance is in part adapted from [18F Draft US Web Design Standards](https://standards.usa.gov/getting-started/) under [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/legalcode).
+This guidance is in part adapted from <a href="https://standards.usa.gov/getting-started/" rel="external">18F Draft US Web Design Standards</a> under <a href="https://creativecommons.org/publicdomain/zero/1.0/legalcode" rel="external">CC0 1.0 Universal</a>.
 
 Markup: templates/accordion.hbs
 

--- a/assets/sass/_buttons.scss
+++ b/assets/sass/_buttons.scss
@@ -9,9 +9,9 @@ Use button text to describe what the button does&mdash;keep it short.
 
 The button alignment in [forms](section-forms.html) should put the primary action button at the left edge, in the user's line of sight.
 
-<hr />
+***
 
-This guidance is in part adapted from [GOV.UK elements](http://govuk-elements.herokuapp.com/) under [Open Government Licence v3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/), and [18F Draft US Web Design Standards](https://standards.usa.gov/getting-started/) under [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/legalcode).
+This guidance is in part adapted from <a href="http://govuk-elements.herokuapp.com" rel="external">GOV.UK elements</a> under <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="external">Open Government Licence v3.0</a>, and <a href="https://standards.usa.gov/getting-started/" rel="external">18F Draft US Web Design Standards</a> under <a href="https://creativecommons.org/publicdomain/zero/1.0/legalcode" rel="external">CC0 1.0 Universal</a>.
 
 Style guide: Buttons
 */

--- a/assets/sass/_colours.scss
+++ b/assets/sass/_colours.scss
@@ -3,7 +3,7 @@ Colours
 
 A basic palette of colours that are clear and accessible.
 
-We are finalising the colours&mdash;for help [log a GitHub issue](https://github.com/AusDTO/gov-au-ui-kit/issues).
+We are finalising the colours&mdash;for help <a href="https://github.com/AusDTO/gov-au-ui-kit/issues" rel="external">log a GitHub issue</a>.
 
 Style guide: Colours
 */
@@ -184,7 +184,7 @@ $light-blue:    #e8f5fa;
 /*
 Accessibility
 
-The [recommended colour contrast ratio](http://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html) for text and interactive elements should be at least 4.5:1.
+The <a href="http://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html" rel="external">recommended colour contrast ratio</a> for text and interactive elements should be at least 4.5:1.
 
 ### Accessible combinations
 <p class="guide-colour-block bg-non-black">non-white on non-black<span class="invert">AAA</span></p>

--- a/assets/sass/_forms.scss
+++ b/assets/sass/_forms.scss
@@ -7,7 +7,7 @@ Ask only 1 question per page.
 
 ***
 
-This guidance is in part adapted from [GOV.UK elements](http://govuk-elements.herokuapp.com/) under [Open Government Licence v3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/) and [GOV.UK design patterns](https://www.gov.uk/service-manual/user-centred-design/resources/patterns/) under [Open Government Licence v2.0](http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2/).
+This guidance is in part adapted from <a href="http://govuk-elements.herokuapp.com/" rel="external">GOV.UK elements</a> under <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="external">Open Government Licence v3.0</a> and <a href="https://www.gov.uk/service-manual/user-centred-design/resources/patterns/" rel="external">GOV.UK design patterns</a> under <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2/" rel="external">Open Government Licence v2.0</a>.
 
 Style guide: Forms
 */

--- a/assets/sass/_grid-layout.scss
+++ b/assets/sass/_grid-layout.scss
@@ -39,7 +39,7 @@ We define the grid placement for the following page layout elements:
 - `main.content-main`
 - `aside`.
 
-To create your own element you will need to use the [Neat `span-columns` function](http://thoughtbot.github.io/neat-docs/latest/#span-columns).
+To create your own element you will need to use the <a href="http://thoughtbot.github.io/neat-docs/latest/#span-columns" rel="external">Neat <code>span-columns</code> function</a>.
 
 For each new element you will need to set column properties for the breakpoints, from smallest to largest:
 

--- a/assets/sass/_grid-settings.scss
+++ b/assets/sass/_grid-settings.scss
@@ -37,7 +37,7 @@ This framework has a mobile-first default layout of 4 columns, and adds 3 breakp
 - Tablet: 12 columns, 768px minimum
 - Desktop: 16 columns, 1200px minimum
 
-If you give an element a modified grid setting consider the implications for all breakpoints. The Digital Service Standard recommends you [build using mobile first design principles](https://www.dto.gov.au/standard/6-consistent-and-responsive/).
+If you give an element a modified grid setting consider the implications for all breakpoints. The Digital Service Standard recommends you <a href="https://www.dto.gov.au/standard/6-consistent-and-responsive/" rel="external">build using mobile first design principles</a>.
 
 Please also consider the [font size](section-typography.html#kssref-typography-2-headings-body-copy-1-breakpoints) at different breakpoints.
 

--- a/assets/sass/_grid-settings.scss
+++ b/assets/sass/_grid-settings.scss
@@ -1,9 +1,9 @@
 /*
 Grid
 
-This framework uses [Bourbon](http://bourbon.io/) and [Neat](http://neat.bourbon.io/) to create a consistent 16 column responsive grid layout with good defaults.
+This framework uses <a href="http://bourbon.io/" rel="external">Bourbon</a> and <a href="http://neat.bourbon.io/" rel="external">Neat</a> to create a consistent 16 column responsive grid layout with good defaults.
 
-Bourbon is a [SASS](http://sass-lang.com/) mixin library (it provides little styling). Neat is a flexible grid framework.
+Bourbon is a <a href="http://sass-lang.com/" rel="external">SASS</a> mixin library (it provides little styling). Neat is a flexible grid framework.
 
 Avoid mixing this layout with other grid layouts.
 
@@ -13,11 +13,11 @@ Primary content is always contained in 12 columns. This allows for seamless intr
 
 The grid unit proportions, gutters and spacing are defined in `_grid-settings.scss`.
 
-If you need an element not defined here you are probably not the only one&mdash;please [log a GitHub issue](https://github.com/AusDTO/gov-au-ui-kit/issues) so we can provide it for everyone.
+If you need an element not defined here you are probably not the only one&mdash;please <a href="https://github.com/AusDTO/gov-au-ui-kit/issues" rel="external">log a GitHub issue</a> so we can provide it for everyone.
 
-<hr />
+***
 
-This guidance is in part adapted from [GOV.UK elements](http://govuk-elements.herokuapp.com/) under [Open Government Licence v3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/), and [18F Draft US Web Design Standards](https://standards.usa.gov/getting-started/) under [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/legalcode).
+This guidance is in part adapted from <a href="http://govuk-elements.herokuapp.com" rel="external">GOV.UK elements</a> under <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="external">Open Government Licence v3.0</a>, and <a href="https://standards.usa.gov/getting-started/" rel="external">18F Draft US Web Design Standards</a> under <a href="https://creativecommons.org/publicdomain/zero/1.0/legalcode" rel="external">CC0 1.0 Universal</a>.
 
 Style guide: Grid
 */
@@ -71,7 +71,7 @@ Turn on the visual grid to help debugging:
 $visual-grid: true;
 ```
 
-See the example [Bourbon Neat working grid layout](http://neat.bourbon.io/examples/).
+See the example <a href="http://neat.bourbon.io/examples/" rel="external">Bourbon Neat working grid layout</a>.
 
 Style guide: Grid.4 Debugging
 */

--- a/assets/sass/_lists.scss
+++ b/assets/sass/_lists.scss
@@ -30,7 +30,7 @@ You can change the number of columns used:
 - `.vertical-list--thirds` give 3 columns of list items
 - `.vertical-list--fourths` give 4 columns of list items.
 
-For [browsers that don't support Flexbox layout](http://caniuse.com/#feat=flexbox) lists will appear as in horizontal style with images (if used) below each list item.
+For <a href="http://caniuse.com/#feat=flexbox" rel="external">browsers that don't support Flexbox layout</a> lists will appear as in horizontal style with images (if used) below each list item.
 
 Markup: templates/lists-vertical.hbs
 

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -5,7 +5,7 @@ Ensure users understand where they are in the service, where they have been and 
 
 ***
 
-This guidance is in part adapted from [18F Draft US Web Design Standards](https://standards.usa.gov/getting-started/) under [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/legalcode).
+This guidance is in part adapted from <a href="https://standards.usa.gov/getting-started/" rel="external">18F Draft US Web Design Standards</a> under <a href="https://creativecommons.org/publicdomain/zero/1.0/legalcode" rel="external">CC0 1.0 Universal</a>.
 
 Style guide: Navigation
 */

--- a/assets/sass/_typography.scss
+++ b/assets/sass/_typography.scss
@@ -11,7 +11,7 @@ Style guide: Typography
 /*
 Typeface
 
-We are currently testing the open source [Open Sans family](https://www.google.com/fonts/specimen/Open+Sans) in 3 styles.
+We are currently testing the open source <a href="https://www.google.com/fonts/specimen/Open+Sans" rel="external">Open Sans family</a> in 3 styles.
 
 <div class="guide-example--type"><h3>Open Sans regular 400</h3>
   <p>ABCDEFGHIJKLMNOPQRSTUVWXYZ<br />
@@ -47,7 +47,7 @@ We are currently testing the use of webfonts.
 
 The font stacks should still achieve a high degree of coverage across a range of browsers and operating systems using the fall-backs (roughly 95% coverage).
 
-You need to load webfonts through the [Google Web Font Loader](https://github.com/typekit/webfontloader) via `<script>` to add Open Sans via the HTML `head`. This supports modern browsers and older versions of Internet Explorer.
+You need to load webfonts through the <a href="https://github.com/typekit/webfontloader" rel="external">Google Web Font Loader</a> via `<script>` to add Open Sans via the HTML `head`. This supports modern browsers and older versions of Internet Explorer.
 
 Style guide: Typography.1 Typeface.1 Font stacks
 */

--- a/assets/sass/_typography.scss
+++ b/assets/sass/_typography.scss
@@ -389,7 +389,7 @@ kbd {
 /*
 Show keyboard input
 
-Use the [`<kbd>` element](http://w3c.github.io/html/textlevel-semantics.html#the-kbd-element) to show users which key to press.
+Use the <a href="http://w3c.github.io/html/textlevel-semantics.html#the-kbd-element" rel="external"><code>kbd</code> element</a> to show users which key to press.
 
 Markup: Copy text to clipboard using <kbd>Ctrl</kbd> + <kbd>C</kbd>.
 

--- a/examples/type-contact.html
+++ b/examples/type-contact.html
@@ -167,7 +167,7 @@
       9am – 5pm AEDST<br>
       Monday to Friday excluding ACT public holidays  </p>
 
-      <p>If you have a hearing or speech impairment, use the <a href="http://relayservice.gov.au/">National Relay Service</a> to access any of our listed phone numbers.<br>
+      <p>If you have a hearing or speech impairment, use the <a href="http://relayservice.gov.au/" rel="external">National Relay Service</a> to access any of our listed phone numbers.<br>
       Telephone: <a href="tel:1300555727">1300 555 727</a></p>
 
       <h3>Media enquiries</h3>

--- a/examples/type-role.html
+++ b/examples/type-role.html
@@ -243,75 +243,75 @@
 
         <p>A portolio is an area of responsibility for how Australia is run. The Communications portfolio is led by the <a href="link">Minister for Communications</a>.</p>
 
-        <h3 id="australia-council-for-the-arts"><a href="http://www.australiacouncil.gov.au/">Australia Council for the Arts</a></h3>
+        <h3 id="australia-council-for-the-arts"><a href="http://www.australiacouncil.gov.au/" rel="external">Australia Council for the Arts</a></h3>
 
         <p>The Australian Government's arts funding and advisory body.</p>
 
-        <h3 id="australia-post"><a href="http://auspost.com.au/">Australia Post</a></h3>
+        <h3 id="australia-post"><a href="http://auspost.com.au/" rel="external">Australia Post</a></h3>
 
         <p>Providing reliable and affordable postal, retail, financial and travel services.</p>
 
-        <h3 id="australian-broadcasting-corporation-abc"><a href="http://www.abc.net.au/">Australian Broadcasting corporation (ABC)</a></h3>
+        <h3 id="australian-broadcasting-corporation-abc"><a href="http://www.abc.net.au/" rel="external">Australian Broadcasting corporation (ABC)</a></h3>
 
         <p>Australia’s public broadcaster, including national and local television and radio programs.</p>
 
-        <h3 id="australian-communications-and-media-authority-acma"><a href="http://www.acma.gov.au/">Australian Communications and Media Authority (ACMA)</a></h3>
+        <h3 id="australian-communications-and-media-authority-acma"><a href="http://www.acma.gov.au/" rel="external">Australian Communications and Media Authority (ACMA)</a></h3>
 
         <p>Responsible for the regulation of broadcasting, the internet, radiocommunications and telecommunications.</p>
 
-        <h3 id="australian-film-television-and-radio-school-aftrs"><a href="https://www.aftrs.edu.au/">Australian Film Television and Radio School (AFTRS)</a></h3>
+        <h3 id="australian-film-television-and-radio-school-aftrs"><a href="https://www.aftrs.edu.au/" rel="external">Australian Film Television and Radio School (AFTRS)</a></h3>
 
         <p>The leading institution for the education and training of creative talent.</p>
 
-        <h3 id="australian-national-maritime-museum"><a href="http://www.anmm.gov.au/">Australian National Maritime Museum</a></h3>
+        <h3 id="australian-national-maritime-museum"><a href="http://www.anmm.gov.au/" rel="external">Australian National Maritime Museum</a></h3>
 
         <p>Australia’s national centre for maritime collections, exhibitions, research and archaeology.</p>
 
-        <h3 id="bundanon-trust"><a href="https://bundanon.com.au/">Bundanon Trust</a></h3>
+        <h3 id="bundanon-trust"><a href="https://bundanon.com.au/" rel="external">Bundanon Trust</a></h3>
 
         <p>Supporting arts practice and engagement through education, exhibition and performance programs.</p>
 
-        <h3 id="australia-business-arts-foundation-operating-as-creative-partnerships-australia"><a href="https://www.creativepartnershipsaustralia.org.au/">Australia Business Arts Foundation (operating as Creative Partnerships Australia)</a></h3>
+        <h3 id="australia-business-arts-foundation-operating-as-creative-partnerships-australia"><a href="https://www.creativepartnershipsaustralia.org.au/" rel="external">Australia Business Arts Foundation (operating as Creative Partnerships Australia)</a></h3>
 
         <p>Bringing artists, donors, businesses and arts organisations together to promote a more sustainable and vibrant arts sector.</p>
 
-        <h3 id="the-museum-of-australian-democracy"><a href="http://moadoph.gov.au/">The Museum of Australian Democracy</a></h3>
+        <h3 id="the-museum-of-australian-democracy"><a href="http://moadoph.gov.au/" rel="external">The Museum of Australian Democracy</a></h3>
 
         <p>Helping people to understand Australia’s social and political history by interpreting the past and present and exploring the future.</p>
 
-        <h3 id="national-film-and-sound-archive"><a href="http://www.nfsa.gov.au/">National Film and Sound Archive</a></h3>
+        <h3 id="national-film-and-sound-archive"><a href="http://www.nfsa.gov.au/" rel="external">National Film and Sound Archive</a></h3>
 
         <p>The nation’s living archive – collecting, preserving and sharing our rich audiovisual heritage.</p>
 
-        <h3 id="national-gallery-of-australia-nga"><a href="http://nga.gov.au/">National Gallery of Australia (NGA)</a></h3>
+        <h3 id="national-gallery-of-australia-nga"><a href="http://nga.gov.au/" rel="external">National Gallery of Australia (NGA)</a></h3>
 
         <p>Australia's national cultural institution for the visual arts.</p>
 
-        <h3 id="national-library-of-australia-nla"><a href="https://www.nla.gov.au/">National Library of Australia (NLA)</a></h3>
+        <h3 id="national-library-of-australia-nla"><a href="https://www.nla.gov.au/" rel="external">National Library of Australia (NLA)</a></h3>
 
         <p>Ensuring that important documentary resources are collected, preserved and made accessible to the public.</p>
 
-        <h3 id="national-museum-of-australia"><a href="http://www.nma.gov.au/">National Museum of Australia</a></h3>
+        <h3 id="national-museum-of-australia"><a href="http://www.nma.gov.au/" rel="external">National Museum of Australia</a></h3>
 
         <p>A social history museum exploring the land, nation and people of Australia.</p>
 
-        <h3 id="national-portrait-gallery-australia-npga"><a href="http://www.portrait.gov.au/">National Portrait Gallery Australia (NPGA)</a></h3>
+        <h3 id="national-portrait-gallery-australia-npga"><a href="http://www.portrait.gov.au/" rel="external">National Portrait Gallery Australia (NPGA)</a></h3>
 
         <p>The national collection of portraits of Australians reflects the breadth and energy of Australian culture and endeavour.</p>
 
-        <h3 id="nbn-co-limited"><a href="http://www.nbnco.com.au/">NBN Co Limited</a></h3>
+        <h3 id="nbn-co-limited"><a href="http://www.nbnco.com.au/" rel="external">NBN Co Limited</a></h3>
 
         <p>Delivering Australia’s first national, open access broadband network to all Australians.</p>
 
-        <h3 id="office-of-the-children-s-e-safety-commissioner"><a href="https://www.esafety.gov.au/">Office of the Children’s e-Safety Commissioner</a></h3>
+        <h3 id="office-of-the-children-s-e-safety-commissioner"><a href="https://www.esafety.gov.au/" rel="external">Office of the Children’s e-Safety Commissioner</a></h3>
 
         <p>Committed to helping young people have safe, positive experiences online.</p>
 
-        <h3 id="screen-australia"><a href="http://www.screenaustralia.gov.au/">Screen Australia</a></h3>
+        <h3 id="screen-australia"><a href="http://www.screenaustralia.gov.au/" rel="external">Screen Australia</a></h3>
 
         <p>Funding the production of everything from feature films to documentaries, television drama, children’s programs and online web series.</p>
 
-        <h3 id="special-broadcasting-service-sbs"><a href="http://www.sbs.com.au/">Special broadcasting service (SBS)</a></h3>
+        <h3 id="special-broadcasting-service-sbs"><a href="http://www.sbs.com.au/" rel="external">Special broadcasting service (SBS)</a></h3>
 
         <p>Australia’s multicultural and multilingual broadcaster.</p>
 

--- a/kss-builder/index.hbs
+++ b/kss-builder/index.hbs
@@ -75,7 +75,7 @@
   <section class="hero">
     <div class="wrapper">
       <span class="site-title">{{options.title}}</span>
-      <p class="tagline">A living style guide of the UI-Kit <abbr title="Sassy CSS">SCSS</abbr> framework, built from the source, using <a href="http://warpspire.com/kss/"><abbr title="Knyle Style Sheets">KSS</abbr></a>.</p>
+      <p class="tagline">A living style guide of the UI-Kit <abbr title="Sassy CSS">SCSS</abbr> framework, built from the source, using <a href="http://warpspire.com/kss/" rel="external"><abbr title="Knyle Style Sheets">KSS</abbr></a>.</p>
       <p>Documents UI-Kit release: <code>v{{package "version"}}</code></p>
       <p>Last updated: <time datetime="{{moment "" ""}}">{{moment "" "DD MMMM Y"}}</time></p>
     </div>
@@ -217,11 +217,11 @@
       <div class="footer-links">
         <nav>
           <ul>
-            <li><a href="https://www.dto.gov.au/privacy-statement/">Privacy Statement</a></li>
+            <li><a href="https://www.dto.gov.au/privacy-statement/" rel="external">Privacy Statement</a></li>
           </ul>
         </nav>
         <p>&copy; Commonwealth of Australia <br>
-        <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE.md">Licensed under the MIT License.</a></p>
+        <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE.md" rel="external license">Licensed under the MIT License.</a></p>
       </div>
     </section>
   </div>

--- a/kss-builder/kss-assets/prettify.js
+++ b/kss-builder/kss-assets/prettify.js
@@ -19,7 +19,7 @@
  *
  * <p>
  * For a fairly comprehensive set of languages see the
- * <a href="http://google-code-prettify.googlecode.com/svn/trunk/README.html#langs">README</a>
+ * <a href="http://google-code-prettify.googlecode.com/svn/trunk/README.html#langs" rel="external">README</a>
  * file that came with this source.  At a minimum, the lexer should work on a
  * number of languages including C and friends, Java, Python, Bash, SQL, HTML,
  * XML, CSS, Javascript, and Makefiles.  It works passably on Ruby, PHP and Awk


### PR DESCRIPTION
## Description

Moves a lot of Markdown links over into HTML, and adds `rel="external"` to anchors linking off-site.

This is entirely unmanageable into the future… but it’s a decent improvement to let users know which anchors link internally within the guide, and which ones go offsite.
## Additional information

I omitted editing the `_tables.scss` partial because @joolswood has already added the external rels there.

Also added `rel="external"` to the KSS `index.hbs` template.
## Definition of Done
- [x] UX reviewed by Gary or someone the Design team
- [x] Code reviewed by one of the core developers
- [x] Acceptance Testing
  - [x] HTML5 validation (CircleCI)
