### PR TITLE
DESIGN-210: removes left margin and padding on global li scope.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 #### Bugfixes
 
-- Fixed [#xxx](https://github.com/AusDTO/gov-au-ui-kit/issues/xxx): issue title
+- Fixed [#170](https://github.com/AusDTO/gov-au-ui-kit/issues/170): Elaborate list view patterns have left alignment issues
 
 ### 1.7.2 - 2016-08-02
 

--- a/assets/sass/_typography.scss
+++ b/assets/sass/_typography.scss
@@ -513,8 +513,6 @@ dd {
 
 li {
   margin-bottom: ($small-spacing / 1.5);
-  margin-left: -($small-spacing / 4);
-  padding-left: ($small-spacing / 4);
 
   ul,
   ol {
@@ -652,7 +650,7 @@ Style guide: Typography.7 Quotations
 
 blockquote {
   margin: $medium-spacing 0;
-  padding: $small-spacing ($base-spacing + ($small-spacing * 0.75));
+  padding: $small-spacing ($base-spacing + $small-spacing);
   background-color: $background-secondary-colour;
   font-family: $base-serif;
   quotes: '\201C''\201D''\2018''\2019';


### PR DESCRIPTION
## Description

Fixes #170.

Also fixed a horizontal alignment issue with blockquotes.
## Additional information

Only downside here is that our list item markers (eg bullets or numbers) are now less spaced from the line they start. Screenshots—

Before:
![screen shot 2016-08-05 at 11 42 14 am](https://cloud.githubusercontent.com/assets/52766/17423937/63c96924-5b02-11e6-9c3a-c6337d138ca8.png)

After:
![screen shot 2016-08-05 at 11 41 30 am](https://cloud.githubusercontent.com/assets/52766/17423931/5ccfd108-5b02-11e6-8bd3-5fca7983f8ee.png)

Pretty minimal… I think this is less of an issue now that we have moved to a slightly larger base font size (compared to when I first wrote these type stylings).
## Definition of Done
- [x] UX reviewed by Gary or someone the Design team
- [x] Code reviewed by one of the core developers
- [x] Acceptance Testing
  - [x] HTML5 validation (CircleCI)
- [x] Stakeholder/PO review
- [x] CHANGELOG updated
