### PR TITLE
Skip-to link doc & markup to use nav instead of div

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 #### Styleguide
 
+- Updated markup documentation for skip links to use `nav` instead of `div` (does not break; targeted by the `.skip-to` class).
 - Updated documentation for `.local-nav` for `.is-active` and `.is-current` usage.
 - Improvements to *§ Tables*.
 

--- a/assets/sass/templates/skip-link.hbs
+++ b/assets/sass/templates/skip-link.hbs
@@ -1,4 +1,4 @@
-<div class="skip-to">
-  <a href="#content">Skip to main content</a>
+<nav class="skip-to">
+  <a href="#content">Skip to main content</a> 
   <a href="#nav">Skip to section navigation</a>
-</div>
+</nav>

--- a/kss-builder/index.hbs
+++ b/kss-builder/index.hbs
@@ -55,10 +55,10 @@
 </head>
 <body>
 
-<div class="skip-to">
+<nav class="skip-to">
   <a href="#content">Skip to main content</a>
   <a href="#nav">Skip to section navigation</a>
-</div>
+</nav>
 
 <header role="banner">
   <section class="govau--header">


### PR DESCRIPTION
## Description

After briefly consulting Andrew Arch I changed these from using a `<div>` wrapper to use `<nav>` instead.

This **doesn’t** introduce a markup change — the wrapper is targeted by its `.skip-to` class.
## Additional information

I also added a trailing space at the end of the first anchor skip link, so that if CSS is ever disabled the two anchors don’t touch when the skip link anchors render.

Screenshot:

![screen shot 2016-08-08 at 3 15 28 pm](https://cloud.githubusercontent.com/assets/52766/17469897/fb804fe2-5d7a-11e6-9f87-442af6448345.png)
## Definition of Done
- [x] Code reviewed by one of the core developers
- [x] Acceptance Testing
  - [x] HTML5 validation (CircleCI)
  - [x] Accessibility testing & WCAG2 compliance (manual)
- [x] Stakeholder/PO review
- [x] CHANGELOG updated
