### PR TITLE
Accessibility notes per-feature

### DIFF
--- a/assets/sass/_accordions.scss
+++ b/assets/sass/_accordions.scss
@@ -30,13 +30,16 @@ When implementing accordions:
 - For multiple accordion elements each `details` element must have its own `data-label` attribute.
 - This framework allows a text/string search of accordion content, even when collapsed (string itself remains hidden until opened).
 
-<div class="guide-micro-callout">
-  <h3> Accessibility notes:​</h3>
-  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-  **Untested** WCAG:AA manual compliance<br/>
-  **Untested** Supported browsers tested
-</div>
+<details data-label="accordion-accessibility" aria-expanded="false">
+  <summary>Accessibility notes</summary>
+  <div class="accordion-panel">
+
+    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+    **Untested** WCAG:AA manual compliance<br/>
+    **Untested** Supported browsers tested</p>
+  </div>
+</details>
 
 Style guide: Accordions.1 Usability
 */
@@ -125,4 +128,9 @@ summary {
     padding-bottom: 0;
     top: $small-spacing * -2;
   }
+
+  :first-child {
+    margin-top: 0;
+  }
+
 }

--- a/assets/sass/_accordions.scss
+++ b/assets/sass/_accordions.scss
@@ -30,6 +30,14 @@ When implementing accordions:
 - For multiple accordion elements each `details` element must have its own `data-label` attribute.
 - This framework allows a text/string search of accordion content, even when collapsed (string itself remains hidden until opened).
 
+<div class="guide-micro-callout">
+  <h3> Accessibility notes:​</h3>
+  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+  **Untested** WCAG:AA manual compliance<br/>
+  **Untested** Supported browsers tested
+</div>
+
 Style guide: Accordions.1 Usability
 */
 

--- a/assets/sass/_accordions.scss
+++ b/assets/sass/_accordions.scss
@@ -31,13 +31,18 @@ When implementing accordions:
 - This framework allows a text/string search of accordion content, even when collapsed (string itself remains hidden until opened).
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility notes</summary>
+  <summary>Accessibility & browser testing</summary>
   <div class="accordion-panel">
-
-    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-    **Untested** WCAG:AA manual compliance<br/>
-    **Untested** Supported browsers tested</p>
+  <strong>Passed</strong>:
+    <ul>
+      <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
+      <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
+    </ul>
+  <strong>Untested</strong>:
+    <ul>
+      <li>WCAG:AA manual</li>
+      <li>Browser support &mdash; automated and manual</li>
+    </ul>
   </div>
 </details>
 

--- a/assets/sass/_accordions.scss
+++ b/assets/sass/_accordions.scss
@@ -31,7 +31,7 @@ When implementing accordions:
 - This framework allows a text/string search of accordion content, even when collapsed (string itself remains hidden until opened).
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility & browser testing</summary>
+  <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
     <ul>

--- a/assets/sass/_buttons.scss
+++ b/assets/sass/_buttons.scss
@@ -28,6 +28,14 @@ Do not apply styles to disabled buttons.
 
 Markup: templates/buttons-examples.hbs
 
+<div class="guide-micro-callout">
+  <h3> Accessibility notes:​</h3>
+  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+  **Untested** WCAG:AA manual compliance<br/>
+  **Untested** Supported browsers tested
+</div>
+
 Style guide: Buttons.1 Creating buttons
 */
 

--- a/assets/sass/_buttons.scss
+++ b/assets/sass/_buttons.scss
@@ -29,7 +29,7 @@ Do not apply styles to disabled buttons.
 Markup: templates/buttons-examples.hbs
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility & browser testing</summary>
+  <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
     <ul>

--- a/assets/sass/_buttons.scss
+++ b/assets/sass/_buttons.scss
@@ -29,13 +29,18 @@ Do not apply styles to disabled buttons.
 Markup: templates/buttons-examples.hbs
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility notes</summary>
+  <summary>Accessibility & browser testing</summary>
   <div class="accordion-panel">
-
-    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-    **Untested** WCAG:AA manual compliance<br/>
-    **Untested** Supported browsers tested</p>
+  <strong>Passed</strong>:
+    <ul>
+      <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
+      <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
+    </ul>
+  <strong>Untested</strong>:
+    <ul>
+      <li>WCAG:AA manual</li>
+      <li>Browser support &mdash; automated and manual</li>
+    </ul>
   </div>
 </details>
 

--- a/assets/sass/_buttons.scss
+++ b/assets/sass/_buttons.scss
@@ -28,13 +28,16 @@ Do not apply styles to disabled buttons.
 
 Markup: templates/buttons-examples.hbs
 
-<div class="guide-micro-callout">
-  <h3> Accessibility notes:​</h3>
-  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-  **Untested** WCAG:AA manual compliance<br/>
-  **Untested** Supported browsers tested
-</div>
+<details data-label="accordion-accessibility" aria-expanded="false">
+  <summary>Accessibility notes</summary>
+  <div class="accordion-panel">
+
+    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+    **Untested** WCAG:AA manual compliance<br/>
+    **Untested** Supported browsers tested</p>
+  </div>
+</details>
 
 Style guide: Buttons.1 Creating buttons
 */

--- a/assets/sass/_colours.scss
+++ b/assets/sass/_colours.scss
@@ -207,7 +207,7 @@ The <a href="http://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-con
 <p class="guide-colour-block bg-light-blue">non-black on light-blue <span class="invert">AA</span></p>
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility & browser testing</summary>
+  <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
     <ul>

--- a/assets/sass/_colours.scss
+++ b/assets/sass/_colours.scss
@@ -207,13 +207,18 @@ The <a href="http://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-con
 <p class="guide-colour-block bg-light-blue">non-black on light-blue <span class="invert">AA</span></p>
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility notes</summary>
+  <summary>Accessibility & browser testing</summary>
   <div class="accordion-panel">
-
-    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-    **Untested** WCAG:AA manual compliance<br/>
-    **Untested** Supported browsers tested</p>
+  <strong>Passed</strong>:
+    <ul>
+      <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
+      <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
+    </ul>
+  <strong>Untested</strong>:
+    <ul>
+      <li>WCAG:AA manual</li>
+      <li>Browser support &mdash; automated and manual</li>
+    </ul>
   </div>
 </details>
 

--- a/assets/sass/_colours.scss
+++ b/assets/sass/_colours.scss
@@ -206,13 +206,16 @@ The <a href="http://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-con
 <p class="guide-colour-block bg-light-yellow">non-black on light-yellow <span class="invert">AA</span></p>
 <p class="guide-colour-block bg-light-blue">non-black on light-blue <span class="invert">AA</span></p>
 
-<div class="guide-micro-callout">
-  <h3> Accessibility notes:​</h3>
-  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-  **Untested** WCAG:AA manual compliance<br/>
-  **Untested** Supported browsers tested
-</div>
+<details data-label="accordion-accessibility" aria-expanded="false">
+  <summary>Accessibility notes</summary>
+  <div class="accordion-panel">
+
+    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+    **Untested** WCAG:AA manual compliance<br/>
+    **Untested** Supported browsers tested</p>
+  </div>
+</details>
 
 Style guide: Colours.3 Accessibility
 */

--- a/assets/sass/_colours.scss
+++ b/assets/sass/_colours.scss
@@ -206,6 +206,14 @@ The <a href="http://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-con
 <p class="guide-colour-block bg-light-yellow">non-black on light-yellow <span class="invert">AA</span></p>
 <p class="guide-colour-block bg-light-blue">non-black on light-blue <span class="invert">AA</span></p>
 
+<div class="guide-micro-callout">
+  <h3> Accessibility notes:​</h3>
+  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+  **Untested** WCAG:AA manual compliance<br/>
+  **Untested** Supported browsers tested
+</div>
+
 Style guide: Colours.3 Accessibility
 */
 

--- a/assets/sass/_forms.scss
+++ b/assets/sass/_forms.scss
@@ -21,6 +21,14 @@ They can be limited to number input only by setting the `type` attribute to `num
 
 Markup: templates/text-input-single-line.hbs
 
+<div class="guide-micro-callout">
+  <h3> Accessibility notes:​</h3>
+  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+  **Untested** WCAG:AA manual compliance<br/>
+  **Untested** Supported browsers tested
+</div>
+
 Style guide: Forms.1 Text input
 */
 
@@ -94,6 +102,14 @@ form {
     <label for="texta">An input for longer responses</label>
     <textarea name="texta" id="texta"></textarea>
   </form>
+
+  <div class="guide-micro-callout">
+    <h3> Accessibility notes:​</h3>
+    **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+    **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+    **Untested** WCAG:AA manual compliance<br/>
+    **Untested** Supported browsers tested
+  </div>
 
   Style guide: Forms.2 Text area input
   */
@@ -170,6 +186,14 @@ form {
       <label for="no">No</label>
     </fieldset>
   </form>
+  
+  <div class="guide-micro-callout">
+    <h3> Accessibility notes:​</h3>
+    **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+    **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+    **Untested** WCAG:AA manual compliance<br/>
+    **Untested** Supported browsers tested
+  </div>
 
   Style guide: Forms.3 Radio button input
   */
@@ -227,6 +251,14 @@ Markup:
     <label for="ccc">CCC</label>
   </fieldset>
 </form>
+
+<div class="guide-micro-callout">
+  <h3> Accessibility notes:​</h3>
+  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+  **Untested** WCAG:AA manual compliance<br/>
+  **Untested** Supported browsers tested
+</div>
 
 Style guide: Forms.4 Checkbox input
 */

--- a/assets/sass/_forms.scss
+++ b/assets/sass/_forms.scss
@@ -22,7 +22,7 @@ They can be limited to number input only by setting the `type` attribute to `num
 Markup: templates/text-input-single-line.hbs
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility & browser testing</summary>
+  <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
     <ul>
@@ -112,7 +112,7 @@ form {
   </form>
 
   <details data-label="accordion-accessibility" aria-expanded="false">
-    <summary>Accessibility & browser testing</summary>
+    <summary>Accessibility &amp; browser testing</summary>
     <div class="accordion-panel">
     <strong>Passed</strong>:
       <ul>
@@ -204,7 +204,7 @@ form {
   </form>
 
   <details data-label="accordion-accessibility" aria-expanded="false">
-    <summary>Accessibility & browser testing</summary>
+    <summary>Accessibility &amp; browser testing</summary>
     <div class="accordion-panel">
     <strong>Passed</strong>:
       <ul>
@@ -277,7 +277,7 @@ Markup:
 </form>
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility & browser testing</summary>
+  <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
     <ul>

--- a/assets/sass/_forms.scss
+++ b/assets/sass/_forms.scss
@@ -21,13 +21,16 @@ They can be limited to number input only by setting the `type` attribute to `num
 
 Markup: templates/text-input-single-line.hbs
 
-<div class="guide-micro-callout">
-  <h3> Accessibility notes:​</h3>
-  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-  **Untested** WCAG:AA manual compliance<br/>
-  **Untested** Supported browsers tested
-</div>
+<details data-label="accordion-accessibility" aria-expanded="false">
+  <summary>Accessibility notes</summary>
+  <div class="accordion-panel">
+
+    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+    **Untested** WCAG:AA manual compliance<br/>
+    **Untested** Supported browsers tested</p>
+  </div>
+</details>
 
 Style guide: Forms.1 Text input
 */
@@ -103,13 +106,16 @@ form {
     <textarea name="texta" id="texta"></textarea>
   </form>
 
-  <div class="guide-micro-callout">
-    <h3> Accessibility notes:​</h3>
-    **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-    **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-    **Untested** WCAG:AA manual compliance<br/>
-    **Untested** Supported browsers tested
-  </div>
+  <details data-label="accordion-accessibility" aria-expanded="false">
+    <summary>Accessibility notes</summary>
+    <div class="accordion-panel">
+
+      <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+      **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+      **Untested** WCAG:AA manual compliance<br/>
+      **Untested** Supported browsers tested</p>
+    </div>
+  </details>
 
   Style guide: Forms.2 Text area input
   */
@@ -186,14 +192,17 @@ form {
       <label for="no">No</label>
     </fieldset>
   </form>
-  
-  <div class="guide-micro-callout">
-    <h3> Accessibility notes:​</h3>
-    **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-    **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-    **Untested** WCAG:AA manual compliance<br/>
-    **Untested** Supported browsers tested
-  </div>
+
+  <details data-label="accordion-accessibility" aria-expanded="false">
+    <summary>Accessibility notes</summary>
+    <div class="accordion-panel">
+
+      <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+      **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+      **Untested** WCAG:AA manual compliance<br/>
+      **Untested** Supported browsers tested</p>
+    </div>
+  </details>
 
   Style guide: Forms.3 Radio button input
   */
@@ -252,13 +261,16 @@ Markup:
   </fieldset>
 </form>
 
-<div class="guide-micro-callout">
-  <h3> Accessibility notes:​</h3>
-  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-  **Untested** WCAG:AA manual compliance<br/>
-  **Untested** Supported browsers tested
-</div>
+<details data-label="accordion-accessibility" aria-expanded="false">
+  <summary>Accessibility notes</summary>
+  <div class="accordion-panel">
+
+    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+    **Untested** WCAG:AA manual compliance<br/>
+    **Untested** Supported browsers tested</p>
+  </div>
+</details>
 
 Style guide: Forms.4 Checkbox input
 */

--- a/assets/sass/_forms.scss
+++ b/assets/sass/_forms.scss
@@ -22,13 +22,18 @@ They can be limited to number input only by setting the `type` attribute to `num
 Markup: templates/text-input-single-line.hbs
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility notes</summary>
+  <summary>Accessibility & browser testing</summary>
   <div class="accordion-panel">
-
-    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-    **Untested** WCAG:AA manual compliance<br/>
-    **Untested** Supported browsers tested</p>
+  <strong>Passed</strong>:
+    <ul>
+      <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
+      <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
+    </ul>
+  <strong>Untested</strong>:
+    <ul>
+      <li>WCAG:AA manual</li>
+      <li>Browser support &mdash; automated and manual</li>
+    </ul>
   </div>
 </details>
 
@@ -107,13 +112,18 @@ form {
   </form>
 
   <details data-label="accordion-accessibility" aria-expanded="false">
-    <summary>Accessibility notes</summary>
+    <summary>Accessibility & browser testing</summary>
     <div class="accordion-panel">
-
-      <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-      **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-      **Untested** WCAG:AA manual compliance<br/>
-      **Untested** Supported browsers tested</p>
+    <strong>Passed</strong>:
+      <ul>
+        <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
+        <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
+      </ul>
+    <strong>Untested</strong>:
+      <ul>
+        <li>WCAG:AA manual</li>
+        <li>Browser support &mdash; automated and manual</li>
+      </ul>
     </div>
   </details>
 
@@ -194,13 +204,18 @@ form {
   </form>
 
   <details data-label="accordion-accessibility" aria-expanded="false">
-    <summary>Accessibility notes</summary>
+    <summary>Accessibility & browser testing</summary>
     <div class="accordion-panel">
-
-      <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-      **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-      **Untested** WCAG:AA manual compliance<br/>
-      **Untested** Supported browsers tested</p>
+    <strong>Passed</strong>:
+      <ul>
+        <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
+        <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
+      </ul>
+    <strong>Untested</strong>:
+      <ul>
+        <li>WCAG:AA manual</li>
+        <li>Browser support &mdash; automated and manual</li>
+      </ul>
     </div>
   </details>
 
@@ -262,13 +277,18 @@ Markup:
 </form>
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility notes</summary>
+  <summary>Accessibility & browser testing</summary>
   <div class="accordion-panel">
-
-    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-    **Untested** WCAG:AA manual compliance<br/>
-    **Untested** Supported browsers tested</p>
+  <strong>Passed</strong>:
+    <ul>
+      <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
+      <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
+    </ul>
+  <strong>Untested</strong>:
+    <ul>
+      <li>WCAG:AA manual</li>
+      <li>Browser support &mdash; automated and manual</li>
+    </ul>
   </div>
 </details>
 

--- a/assets/sass/_grid-layout.scss
+++ b/assets/sass/_grid-layout.scss
@@ -226,13 +226,16 @@ Long lines reduce legibility. Lines of text should be no longer than 75 characte
 
 Low-vision users should be able to increase the size of the text by up to 200 per cent without breaking the layout.
 
-<div class="guide-micro-callout">
-  <h3> Accessibility notes:​</h3>
-  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-  **Untested** WCAG:AA manual compliance<br/>
-  **Untested** Supported browsers tested
-</div>
+<details data-label="accordion-accessibility" aria-expanded="false">
+  <summary>Accessibility notes</summary>
+  <div class="accordion-panel">
+
+    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+    **Untested** WCAG:AA manual compliance<br/>
+    **Untested** Supported browsers tested</p>
+  </div>
+</details>
 
 Style guide: Grid.8 Accessibility
 */

--- a/assets/sass/_grid-layout.scss
+++ b/assets/sass/_grid-layout.scss
@@ -227,7 +227,7 @@ Long lines reduce legibility. Lines of text should be no longer than 75 characte
 Low-vision users should be able to increase the size of the text by up to 200 per cent without breaking the layout.
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility & browser testing</summary>
+  <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
     <ul>

--- a/assets/sass/_grid-layout.scss
+++ b/assets/sass/_grid-layout.scss
@@ -226,5 +226,13 @@ Long lines reduce legibility. Lines of text should be no longer than 75 characte
 
 Low-vision users should be able to increase the size of the text by up to 200 per cent without breaking the layout.
 
+<div class="guide-micro-callout">
+  <h3> Accessibility notes:​</h3>
+  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+  **Untested** WCAG:AA manual compliance<br/>
+  **Untested** Supported browsers tested
+</div>
+
 Style guide: Grid.8 Accessibility
 */

--- a/assets/sass/_grid-layout.scss
+++ b/assets/sass/_grid-layout.scss
@@ -227,13 +227,18 @@ Long lines reduce legibility. Lines of text should be no longer than 75 characte
 Low-vision users should be able to increase the size of the text by up to 200 per cent without breaking the layout.
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility notes</summary>
+  <summary>Accessibility & browser testing</summary>
   <div class="accordion-panel">
-
-    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-    **Untested** WCAG:AA manual compliance<br/>
-    **Untested** Supported browsers tested</p>
+  <strong>Passed</strong>:
+    <ul>
+      <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
+      <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
+    </ul>
+  <strong>Untested</strong>:
+    <ul>
+      <li>WCAG:AA manual</li>
+      <li>Browser support &mdash; automated and manual</li>
+    </ul>
   </div>
 </details>
 

--- a/assets/sass/_links.scss
+++ b/assets/sass/_links.scss
@@ -20,13 +20,18 @@ Link to external sites using `rel="external"`.
 Markup: templates/basic-links.hbs
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility notes</summary>
+  <summary>Accessibility & browser testing</summary>
   <div class="accordion-panel">
-
-    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-    **Untested** WCAG:AA manual compliance<br/>
-    **Untested** Supported browsers tested</p>
+  <strong>Passed</strong>:
+    <ul>
+      <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
+      <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
+    </ul>
+  <strong>Untested</strong>:
+    <ul>
+      <li>WCAG:AA manual</li>
+      <li>Browser support &mdash; automated and manual</li>
+    </ul>
   </div>
 </details>
 
@@ -92,13 +97,18 @@ Style guide: Link styles.1 Hover links
     Markup: <a class="see-more" href="#">See more</a>
 
     <details data-label="accordion-accessibility" aria-expanded="false">
-      <summary>Accessibility notes</summary>
+      <summary>Accessibility & browser testing</summary>
       <div class="accordion-panel">
-
-        <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-        **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-        **Untested** WCAG:AA manual compliance<br/>
-        **Untested** Supported browsers tested</p>
+      <strong>Passed</strong>:
+        <ul>
+          <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
+          <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
+        </ul>
+      <strong>Untested</strong>:
+        <ul>
+          <li>WCAG:AA manual</li>
+          <li>Browser support &mdash; automated and manual</li>
+        </ul>
       </div>
     </details>
 

--- a/assets/sass/_links.scss
+++ b/assets/sass/_links.scss
@@ -19,6 +19,14 @@ Link to external sites using `rel="external"`.
 
 Markup: templates/basic-links.hbs
 
+<div class="guide-micro-callout">
+  <h3> Accessibility notes:​</h3>
+  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+  **Untested** WCAG:AA manual compliance<br/>
+  **Untested** Supported browsers tested
+</div>
+
 Style guide: Link styles.1 Hover links
 */
 
@@ -79,6 +87,14 @@ Style guide: Link styles.1 Hover links
     to take the user to a index page of all items.
 
     Markup: <a class="see-more" href="#">See more</a>
+
+    <div class="guide-micro-callout">
+      <h3> Accessibility notes:​</h3>
+      **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+      **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+      **Untested** WCAG:AA manual compliance<br/>
+      **Untested** Supported browsers tested
+    </div>
 
     Style guide: Link styles.2 See more link
     */

--- a/assets/sass/_links.scss
+++ b/assets/sass/_links.scss
@@ -20,7 +20,7 @@ Link to external sites using `rel="external"`.
 Markup: templates/basic-links.hbs
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility & browser testing</summary>
+  <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
     <ul>
@@ -97,7 +97,7 @@ Style guide: Link styles.1 Hover links
     Markup: <a class="see-more" href="#">See more</a>
 
     <details data-label="accordion-accessibility" aria-expanded="false">
-      <summary>Accessibility & browser testing</summary>
+      <summary>Accessibility &amp; browser testing</summary>
       <div class="accordion-panel">
       <strong>Passed</strong>:
         <ul>

--- a/assets/sass/_links.scss
+++ b/assets/sass/_links.scss
@@ -19,13 +19,16 @@ Link to external sites using `rel="external"`.
 
 Markup: templates/basic-links.hbs
 
-<div class="guide-micro-callout">
-  <h3> Accessibility notes:​</h3>
-  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-  **Untested** WCAG:AA manual compliance<br/>
-  **Untested** Supported browsers tested
-</div>
+<details data-label="accordion-accessibility" aria-expanded="false">
+  <summary>Accessibility notes</summary>
+  <div class="accordion-panel">
+
+    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+    **Untested** WCAG:AA manual compliance<br/>
+    **Untested** Supported browsers tested</p>
+  </div>
+</details>
 
 Style guide: Link styles.1 Hover links
 */
@@ -88,13 +91,16 @@ Style guide: Link styles.1 Hover links
 
     Markup: <a class="see-more" href="#">See more</a>
 
-    <div class="guide-micro-callout">
-      <h3> Accessibility notes:​</h3>
-      **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-      **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-      **Untested** WCAG:AA manual compliance<br/>
-      **Untested** Supported browsers tested
-    </div>
+    <details data-label="accordion-accessibility" aria-expanded="false">
+      <summary>Accessibility notes</summary>
+      <div class="accordion-panel">
+
+        <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+        **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+        **Untested** WCAG:AA manual compliance<br/>
+        **Untested** Supported browsers tested</p>
+      </div>
+    </details>
 
     Style guide: Link styles.2 See more link
     */

--- a/assets/sass/_lists.scss
+++ b/assets/sass/_lists.scss
@@ -17,6 +17,14 @@ Horizontal style provides a single column of list items.
 
 Markup: templates/lists-horizontal.hbs
 
+<div class="guide-micro-callout">
+  <h3> Accessibility notes:​</h3>
+  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+  **Untested** WCAG:AA manual compliance<br/>
+  **Untested** Supported browsers tested
+</div>
+
 Style guide: List styles.1 Horizontal style
 */
 
@@ -34,6 +42,14 @@ For <a href="http://caniuse.com/#feat=flexbox" rel="external">browsers that don'
 
 Markup: templates/lists-vertical.hbs
 
+<div class="guide-micro-callout">
+  <h3> Accessibility notes:​</h3>
+  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+  **Untested** WCAG:AA manual compliance<br/>
+  **Untested** Supported browsers tested
+</div>
+
 Style guide: List styles.2 Vertical style
 */
 
@@ -44,6 +60,14 @@ Use small list style for large groups of list items.
 
 Markup: templates/lists-small.hbs
 
+<div class="guide-micro-callout">
+  <h3> Accessibility notes:​</h3>
+  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+  **Untested** WCAG:AA manual compliance<br/>
+  **Untested** Supported browsers tested
+</div>
+
 Style guide: List styles.3 Small list style
 */
 
@@ -53,6 +77,14 @@ Highlighted words style
 Use highlighted words style for a list with repeating phrases.
 
 Markup: templates/lists-highlighted.hbs
+
+<div class="guide-micro-callout">
+  <h3> Accessibility notes:​</h3>
+  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+  **Untested** WCAG:AA manual compliance<br/>
+  **Untested** Supported browsers tested
+</div>
 
 Style guide: List styles.4 Highlighted word style
 */

--- a/assets/sass/_lists.scss
+++ b/assets/sass/_lists.scss
@@ -18,13 +18,18 @@ Horizontal style provides a single column of list items.
 Markup: templates/lists-horizontal.hbs
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility notes</summary>
+  <summary>Accessibility & browser testing</summary>
   <div class="accordion-panel">
-
-    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-    **Untested** WCAG:AA manual compliance<br/>
-    **Untested** Supported browsers tested</p>
+  <strong>Passed</strong>:
+    <ul>
+      <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
+      <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
+    </ul>
+  <strong>Untested</strong>:
+    <ul>
+      <li>WCAG:AA manual</li>
+      <li>Browser support &mdash; automated and manual</li>
+    </ul>
   </div>
 </details>
 
@@ -46,13 +51,18 @@ For <a href="http://caniuse.com/#feat=flexbox" rel="external">browsers that don'
 Markup: templates/lists-vertical.hbs
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility notes</summary>
+  <summary>Accessibility & browser testing</summary>
   <div class="accordion-panel">
-
-    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-    **Untested** WCAG:AA manual compliance<br/>
-    **Untested** Supported browsers tested</p>
+  <strong>Passed</strong>:
+    <ul>
+      <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
+      <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
+    </ul>
+  <strong>Untested</strong>:
+    <ul>
+      <li>WCAG:AA manual</li>
+      <li>Browser support &mdash; automated and manual</li>
+    </ul>
   </div>
 </details>
 
@@ -67,13 +77,18 @@ Use small list style for large groups of list items.
 Markup: templates/lists-small.hbs
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility notes</summary>
+  <summary>Accessibility & browser testing</summary>
   <div class="accordion-panel">
-
-    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-    **Untested** WCAG:AA manual compliance<br/>
-    **Untested** Supported browsers tested</p>
+  <strong>Passed</strong>:
+    <ul>
+      <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
+      <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
+    </ul>
+  <strong>Untested</strong>:
+    <ul>
+      <li>WCAG:AA manual</li>
+      <li>Browser support &mdash; automated and manual</li>
+    </ul>
   </div>
 </details>
 

--- a/assets/sass/_lists.scss
+++ b/assets/sass/_lists.scss
@@ -17,13 +17,16 @@ Horizontal style provides a single column of list items.
 
 Markup: templates/lists-horizontal.hbs
 
-<div class="guide-micro-callout">
-  <h3> Accessibility notes:​</h3>
-  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-  **Untested** WCAG:AA manual compliance<br/>
-  **Untested** Supported browsers tested
-</div>
+<details data-label="accordion-accessibility" aria-expanded="false">
+  <summary>Accessibility notes</summary>
+  <div class="accordion-panel">
+
+    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+    **Untested** WCAG:AA manual compliance<br/>
+    **Untested** Supported browsers tested</p>
+  </div>
+</details>
 
 Style guide: List styles.1 Horizontal style
 */
@@ -42,13 +45,16 @@ For <a href="http://caniuse.com/#feat=flexbox" rel="external">browsers that don'
 
 Markup: templates/lists-vertical.hbs
 
-<div class="guide-micro-callout">
-  <h3> Accessibility notes:​</h3>
-  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-  **Untested** WCAG:AA manual compliance<br/>
-  **Untested** Supported browsers tested
-</div>
+<details data-label="accordion-accessibility" aria-expanded="false">
+  <summary>Accessibility notes</summary>
+  <div class="accordion-panel">
+
+    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+    **Untested** WCAG:AA manual compliance<br/>
+    **Untested** Supported browsers tested</p>
+  </div>
+</details>
 
 Style guide: List styles.2 Vertical style
 */
@@ -60,13 +66,16 @@ Use small list style for large groups of list items.
 
 Markup: templates/lists-small.hbs
 
-<div class="guide-micro-callout">
-  <h3> Accessibility notes:​</h3>
-  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-  **Untested** WCAG:AA manual compliance<br/>
-  **Untested** Supported browsers tested
-</div>
+<details data-label="accordion-accessibility" aria-expanded="false">
+  <summary>Accessibility notes</summary>
+  <div class="accordion-panel">
+
+    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+    **Untested** WCAG:AA manual compliance<br/>
+    **Untested** Supported browsers tested</p>
+  </div>
+</details>
 
 Style guide: List styles.3 Small list style
 */
@@ -78,13 +87,16 @@ Use highlighted words style for a list with repeating phrases.
 
 Markup: templates/lists-highlighted.hbs
 
-<div class="guide-micro-callout">
-  <h3> Accessibility notes:​</h3>
-  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-  **Untested** WCAG:AA manual compliance<br/>
-  **Untested** Supported browsers tested
-</div>
+<details data-label="accordion-accessibility" aria-expanded="false">
+  <summary>Accessibility notes</summary>
+  <div class="accordion-panel">
+
+    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+    **Untested** WCAG:AA manual compliance<br/>
+    **Untested** Supported browsers tested</p>
+  </div>
+</details>
 
 Style guide: List styles.4 Highlighted word style
 */

--- a/assets/sass/_lists.scss
+++ b/assets/sass/_lists.scss
@@ -18,7 +18,7 @@ Horizontal style provides a single column of list items.
 Markup: templates/lists-horizontal.hbs
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility & browser testing</summary>
+  <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
     <ul>
@@ -51,7 +51,7 @@ For <a href="http://caniuse.com/#feat=flexbox" rel="external">browsers that don'
 Markup: templates/lists-vertical.hbs
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility & browser testing</summary>
+  <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
     <ul>
@@ -77,7 +77,7 @@ Use small list style for large groups of list items.
 Markup: templates/lists-small.hbs
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility & browser testing</summary>
+  <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
     <ul>

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -20,7 +20,7 @@ Older browsers (IE8 and lower) and those without JavaScript will get an expanded
 Markup: templates/global-navigation.hbs
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility & browser testing</summary>
+  <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
     <ul>
@@ -54,7 +54,7 @@ Use active state to show where the user is. Use `class="is-active"` for each cli
 Markup: templates/local-navigation.hbs
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility & browser testing</summary>
+  <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
     <ul>
@@ -82,7 +82,7 @@ They appear directly under a page header or hero, from `$tablet` breakpoint upwa
 Markup: templates/breadcrumbs.hbs
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility & browser testing</summary>
+  <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
     <ul>
@@ -112,7 +112,7 @@ Users with modern browsers will see a smooth scroll down the page.
 Markup: templates/index-links.hbs
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility & browser testing</summary>
+  <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
     <ul>
@@ -138,7 +138,7 @@ You can present a list of links as a horizontal block using an unsorted list wit
 Markup: templates/inline-links.hbs
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility & browser testing</summary>
+  <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
     <ul>
@@ -170,7 +170,7 @@ This framework uses CSS Flexboxes to manage columns. It provides:
 Markup: templates/footer-navigation.hbs
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility & browser testing</summary>
+  <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
     <ul>
@@ -553,7 +553,7 @@ Include skip links between the opening of the `<body>` and the page `<header>`.
 Markup: templates/skip-link.hbs
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility & browser testing</summary>
+  <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
     <ul>
@@ -668,7 +668,7 @@ You can use groups of links:
 Markup: templates/groups-links.hbs
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility & browser testing</summary>
+  <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
     <ul>

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -19,6 +19,14 @@ Older browsers (IE8 and lower) and those without JavaScript will get an expanded
 
 Markup: templates/global-navigation.hbs
 
+<div class="guide-micro-callout">
+  <h3> Accessibility notes:​</h3>
+  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+  **Untested** WCAG:AA manual compliance<br/>
+  **Untested** Supported browsers tested
+</div>
+
 Style guide: Navigation.1 Global navigation
 */
 
@@ -37,6 +45,14 @@ Use active state to show where the user is. Use `class="is-active"` for each cli
 
 Markup: templates/local-navigation.hbs
 
+<div class="guide-micro-callout">
+  <h3> Accessibility notes:​</h3>
+  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+  **Untested** WCAG:AA manual compliance<br/>
+  **Untested** Supported browsers tested
+</div>
+
 Style guide: Navigation.2 Local navigation
 */
 
@@ -48,6 +64,14 @@ Breadcrumbs help the user understand where they are in the service and how they 
 They appear directly under a page header or hero, from `$tablet` breakpoint upwards.
 
 Markup: templates/breadcrumbs.hbs
+
+<div class="guide-micro-callout">
+  <h3> Accessibility notes:​</h3>
+  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+  **Untested** WCAG:AA manual compliance<br/>
+  **Untested** Supported browsers tested
+</div>
 
 Style guide: Navigation.3 Breadcrumbs
 */
@@ -63,6 +87,14 @@ Users with modern browsers will see a smooth scroll down the page.
 
 Markup: templates/index-links.hbs
 
+<div class="guide-micro-callout">
+  <h3> Accessibility notes:​</h3>
+  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+  **Untested** WCAG:AA manual compliance<br/>
+  **Untested** Supported browsers tested
+</div>
+
 Style guide: Navigation.4 Contents links
 */
 
@@ -72,6 +104,14 @@ Inline links
 You can present a list of links as a horizontal block using an unsorted list with the `.inline-links` class.
 
 Markup: templates/inline-links.hbs
+
+<div class="guide-micro-callout">
+  <h3> Accessibility notes:​</h3>
+  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+  **Untested** WCAG:AA manual compliance<br/>
+  **Untested** Supported browsers tested
+</div>
 
 Style guide: Navigation.5 Inline links
 */
@@ -88,6 +128,14 @@ This framework uses CSS Flexboxes to manage columns. It provides:
 - 4 columns for `$desktop` breakpoint.
 
 Markup: templates/footer-navigation.hbs
+
+<div class="guide-micro-callout">
+  <h3> Accessibility notes:​</h3>
+  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+  **Untested** WCAG:AA manual compliance<br/>
+  **Untested** Supported browsers tested
+</div>
 
 Style guide: Navigation.6 Footer navigation
 */
@@ -456,6 +504,14 @@ Include skip links between the opening of the `<body>` and the page `<header>`.
 
 Markup: templates/skip-link.hbs
 
+<div class="guide-micro-callout">
+  <h3> Accessibility notes:​</h3>
+  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+  **Untested** WCAG:AA manual compliance<br/>
+  **Untested** Supported browsers tested
+</div>
+
 Style guide: Navigation.7 Skip links
 */
 
@@ -554,6 +610,14 @@ You can use groups of links:
 - anywhere within an `article` (eg as a list of related topics).
 
 Markup: templates/groups-links.hbs
+
+<div class="guide-micro-callout">
+  <h3> Accessibility notes:​</h3>
+  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+  **Untested** WCAG:AA manual compliance<br/>
+  **Untested** Supported browsers tested
+</div>
 
 Style guide: Navigation.8 Group of links
 */

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -19,13 +19,16 @@ Older browsers (IE8 and lower) and those without JavaScript will get an expanded
 
 Markup: templates/global-navigation.hbs
 
-<div class="guide-micro-callout">
-  <h3> Accessibility notes:​</h3>
-  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-  **Untested** WCAG:AA manual compliance<br/>
-  **Untested** Supported browsers tested
-</div>
+<details data-label="accordion-accessibility" aria-expanded="false">
+  <summary>Accessibility notes</summary>
+  <div class="accordion-panel">
+
+    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+    **Untested** WCAG:AA manual compliance<br/>
+    **Untested** Supported browsers tested</p>
+  </div>
+</details>
 
 Style guide: Navigation.1 Global navigation
 */
@@ -45,13 +48,16 @@ Use active state to show where the user is. Use `class="is-active"` for each cli
 
 Markup: templates/local-navigation.hbs
 
-<div class="guide-micro-callout">
-  <h3> Accessibility notes:​</h3>
-  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-  **Untested** WCAG:AA manual compliance<br/>
-  **Untested** Supported browsers tested
-</div>
+<details data-label="accordion-accessibility" aria-expanded="false">
+  <summary>Accessibility notes</summary>
+  <div class="accordion-panel">
+
+    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+    **Untested** WCAG:AA manual compliance<br/>
+    **Untested** Supported browsers tested</p>
+  </div>
+</details>
 
 Style guide: Navigation.2 Local navigation
 */
@@ -65,13 +71,16 @@ They appear directly under a page header or hero, from `$tablet` breakpoint upwa
 
 Markup: templates/breadcrumbs.hbs
 
-<div class="guide-micro-callout">
-  <h3> Accessibility notes:​</h3>
-  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-  **Untested** WCAG:AA manual compliance<br/>
-  **Untested** Supported browsers tested
-</div>
+<details data-label="accordion-accessibility" aria-expanded="false">
+  <summary>Accessibility notes</summary>
+  <div class="accordion-panel">
+
+    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+    **Untested** WCAG:AA manual compliance<br/>
+    **Untested** Supported browsers tested</p>
+  </div>
+</details>
 
 Style guide: Navigation.3 Breadcrumbs
 */
@@ -87,13 +96,16 @@ Users with modern browsers will see a smooth scroll down the page.
 
 Markup: templates/index-links.hbs
 
-<div class="guide-micro-callout">
-  <h3> Accessibility notes:​</h3>
-  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-  **Untested** WCAG:AA manual compliance<br/>
-  **Untested** Supported browsers tested
-</div>
+<details data-label="accordion-accessibility" aria-expanded="false">
+  <summary>Accessibility notes</summary>
+  <div class="accordion-panel">
+
+    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+    **Untested** WCAG:AA manual compliance<br/>
+    **Untested** Supported browsers tested</p>
+  </div>
+</details>
 
 Style guide: Navigation.4 Contents links
 */
@@ -105,13 +117,16 @@ You can present a list of links as a horizontal block using an unsorted list wit
 
 Markup: templates/inline-links.hbs
 
-<div class="guide-micro-callout">
-  <h3> Accessibility notes:​</h3>
-  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-  **Untested** WCAG:AA manual compliance<br/>
-  **Untested** Supported browsers tested
-</div>
+<details data-label="accordion-accessibility" aria-expanded="false">
+  <summary>Accessibility notes</summary>
+  <div class="accordion-panel">
+
+    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+    **Untested** WCAG:AA manual compliance<br/>
+    **Untested** Supported browsers tested</p>
+  </div>
+</details>
 
 Style guide: Navigation.5 Inline links
 */
@@ -129,13 +144,16 @@ This framework uses CSS Flexboxes to manage columns. It provides:
 
 Markup: templates/footer-navigation.hbs
 
-<div class="guide-micro-callout">
-  <h3> Accessibility notes:​</h3>
-  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-  **Untested** WCAG:AA manual compliance<br/>
-  **Untested** Supported browsers tested
-</div>
+<details data-label="accordion-accessibility" aria-expanded="false">
+  <summary>Accessibility notes</summary>
+  <div class="accordion-panel">
+
+    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+    **Untested** WCAG:AA manual compliance<br/>
+    **Untested** Supported browsers tested</p>
+  </div>
+</details>
 
 Style guide: Navigation.6 Footer navigation
 */
@@ -504,13 +522,16 @@ Include skip links between the opening of the `<body>` and the page `<header>`.
 
 Markup: templates/skip-link.hbs
 
-<div class="guide-micro-callout">
-  <h3> Accessibility notes:​</h3>
-  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-  **Untested** WCAG:AA manual compliance<br/>
-  **Untested** Supported browsers tested
-</div>
+<details data-label="accordion-accessibility" aria-expanded="false">
+  <summary>Accessibility notes</summary>
+  <div class="accordion-panel">
+
+    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+    **Untested** WCAG:AA manual compliance<br/>
+    **Untested** Supported browsers tested</p>
+  </div>
+</details>
 
 Style guide: Navigation.7 Skip links
 */
@@ -611,13 +632,16 @@ You can use groups of links:
 
 Markup: templates/groups-links.hbs
 
-<div class="guide-micro-callout">
-  <h3> Accessibility notes:​</h3>
-  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-  **Untested** WCAG:AA manual compliance<br/>
-  **Untested** Supported browsers tested
-</div>
+<details data-label="accordion-accessibility" aria-expanded="false">
+  <summary>Accessibility notes</summary>
+  <div class="accordion-panel">
+
+    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+    **Untested** WCAG:AA manual compliance<br/>
+    **Untested** Supported browsers tested</p>
+  </div>
+</details>
 
 Style guide: Navigation.8 Group of links
 */

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -20,13 +20,18 @@ Older browsers (IE8 and lower) and those without JavaScript will get an expanded
 Markup: templates/global-navigation.hbs
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility notes</summary>
+  <summary>Accessibility & browser testing</summary>
   <div class="accordion-panel">
-
-    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-    **Untested** WCAG:AA manual compliance<br/>
-    **Untested** Supported browsers tested</p>
+  <strong>Passed</strong>:
+    <ul>
+      <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
+      <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
+    </ul>
+  <strong>Untested</strong>:
+    <ul>
+      <li>WCAG:AA manual</li>
+      <li>Browser support &mdash; automated and manual</li>
+    </ul>
   </div>
 </details>
 
@@ -49,13 +54,18 @@ Use active state to show where the user is. Use `class="is-active"` for each cli
 Markup: templates/local-navigation.hbs
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility notes</summary>
+  <summary>Accessibility & browser testing</summary>
   <div class="accordion-panel">
-
-    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-    **Untested** WCAG:AA manual compliance<br/>
-    **Untested** Supported browsers tested</p>
+  <strong>Passed</strong>:
+    <ul>
+      <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
+      <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
+    </ul>
+  <strong>Untested</strong>:
+    <ul>
+      <li>WCAG:AA manual</li>
+      <li>Browser support &mdash; automated and manual</li>
+    </ul>
   </div>
 </details>
 
@@ -72,13 +82,18 @@ They appear directly under a page header or hero, from `$tablet` breakpoint upwa
 Markup: templates/breadcrumbs.hbs
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility notes</summary>
+  <summary>Accessibility & browser testing</summary>
   <div class="accordion-panel">
-
-    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-    **Untested** WCAG:AA manual compliance<br/>
-    **Untested** Supported browsers tested</p>
+  <strong>Passed</strong>:
+    <ul>
+      <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
+      <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
+    </ul>
+  <strong>Untested</strong>:
+    <ul>
+      <li>WCAG:AA manual</li>
+      <li>Browser support &mdash; automated and manual</li>
+    </ul>
   </div>
 </details>
 
@@ -97,13 +112,18 @@ Users with modern browsers will see a smooth scroll down the page.
 Markup: templates/index-links.hbs
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility notes</summary>
+  <summary>Accessibility & browser testing</summary>
   <div class="accordion-panel">
-
-    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-    **Untested** WCAG:AA manual compliance<br/>
-    **Untested** Supported browsers tested</p>
+  <strong>Passed</strong>:
+    <ul>
+      <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
+      <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
+    </ul>
+  <strong>Untested</strong>:
+    <ul>
+      <li>WCAG:AA manual</li>
+      <li>Browser support &mdash; automated and manual</li>
+    </ul>
   </div>
 </details>
 
@@ -118,13 +138,18 @@ You can present a list of links as a horizontal block using an unsorted list wit
 Markup: templates/inline-links.hbs
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility notes</summary>
+  <summary>Accessibility & browser testing</summary>
   <div class="accordion-panel">
-
-    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-    **Untested** WCAG:AA manual compliance<br/>
-    **Untested** Supported browsers tested</p>
+  <strong>Passed</strong>:
+    <ul>
+      <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
+      <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
+    </ul>
+  <strong>Untested</strong>:
+    <ul>
+      <li>WCAG:AA manual</li>
+      <li>Browser support &mdash; automated and manual</li>
+    </ul>
   </div>
 </details>
 
@@ -145,13 +170,18 @@ This framework uses CSS Flexboxes to manage columns. It provides:
 Markup: templates/footer-navigation.hbs
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility notes</summary>
+  <summary>Accessibility & browser testing</summary>
   <div class="accordion-panel">
-
-    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-    **Untested** WCAG:AA manual compliance<br/>
-    **Untested** Supported browsers tested</p>
+  <strong>Passed</strong>:
+    <ul>
+      <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
+      <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
+    </ul>
+  <strong>Untested</strong>:
+    <ul>
+      <li>WCAG:AA manual</li>
+      <li>Browser support &mdash; automated and manual</li>
+    </ul>
   </div>
 </details>
 
@@ -523,13 +553,18 @@ Include skip links between the opening of the `<body>` and the page `<header>`.
 Markup: templates/skip-link.hbs
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility notes</summary>
+  <summary>Accessibility & browser testing</summary>
   <div class="accordion-panel">
-
-    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-    **Untested** WCAG:AA manual compliance<br/>
-    **Untested** Supported browsers tested</p>
+  <strong>Passed</strong>:
+    <ul>
+      <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
+      <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
+    </ul>
+  <strong>Untested</strong>:
+    <ul>
+      <li>WCAG:AA manual</li>
+      <li>Browser support &mdash; automated and manual</li>
+    </ul>
   </div>
 </details>
 
@@ -633,13 +668,18 @@ You can use groups of links:
 Markup: templates/groups-links.hbs
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility notes</summary>
+  <summary>Accessibility & browser testing</summary>
   <div class="accordion-panel">
-
-    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-    **Untested** WCAG:AA manual compliance<br/>
-    **Untested** Supported browsers tested</p>
+  <strong>Passed</strong>:
+    <ul>
+      <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
+      <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
+    </ul>
+  <strong>Untested</strong>:
+    <ul>
+      <li>WCAG:AA manual</li>
+      <li>Browser support &mdash; automated and manual</li>
+    </ul>
   </div>
 </details>
 

--- a/assets/sass/_tables.scss
+++ b/assets/sass/_tables.scss
@@ -146,13 +146,16 @@ Title tables using the <a href="https://www.w3.org/wiki/HTML/Elements/caption" r
 
 Row and column headers should be set with the <a href="https://www.w3.org/TR/html401/struct/tables.html#adef-scope" rel="external">`scope` attribute</a>.
 
-<div class="guide-micro-callout">
-  <h3> Accessibility notes:​</h3>
-  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-  **Untested** WCAG:AA manual compliance<br/>
-  **Untested** Supported browsers tested
-</div>
+<details data-label="accordion-accessibility" aria-expanded="false">
+  <summary>Accessibility notes</summary>
+  <div class="accordion-panel">
+
+    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+    **Untested** WCAG:AA manual compliance<br/>
+    **Untested** Supported browsers tested</p>
+  </div>
+</details>
 
 Style guide: Tables.3 Accessibility
 */

--- a/assets/sass/_tables.scss
+++ b/assets/sass/_tables.scss
@@ -22,6 +22,22 @@ Basic table
 
 Markup: templates/table-examples.hbs
 
+<details data-label="accordion-accessibility" aria-expanded="false">
+  <summary>Accessibility & browser testing</summary>
+  <div class="accordion-panel">
+  <strong>Passed</strong>:
+    <ul>
+      <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
+      <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
+    </ul>
+  <strong>Untested</strong>:
+    <ul>
+      <li>WCAG:AA manual</li>
+      <li>Browser support &mdash; automated and manual</li>
+    </ul>
+  </div>
+</details>
+
 Style guide: Tables.1 Basic tables
 */
 
@@ -59,6 +75,22 @@ table {
 Calendar table
 
 Markup: templates/table-calendar.hbs
+
+<details data-label="accordion-accessibility" aria-expanded="false">
+  <summary>Accessibility & browser testing</summary>
+  <div class="accordion-panel">
+  <strong>Passed</strong>:
+    <ul>
+      <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
+      <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
+    </ul>
+  <strong>Untested</strong>:
+    <ul>
+      <li>WCAG:AA manual</li>
+      <li>Browser support &mdash; automated and manual</li>
+    </ul>
+  </div>
+</details>
 
 Style guide: Tables.2 Calendar table variant
 */
@@ -145,22 +177,6 @@ Avoid tables with multiple header levels and spanned cells.
 Title tables using the <a href="https://www.w3.org/wiki/HTML/Elements/caption" rel="external">`<caption>` element</a> inside the `<table>` element.
 
 Row and column headers should be set with the <a href="https://www.w3.org/TR/html401/struct/tables.html#adef-scope" rel="external">`scope` attribute</a>.
-
-<details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility & browser testing</summary>
-  <div class="accordion-panel">
-  <strong>Passed</strong>:
-    <ul>
-      <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
-      <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
-    </ul>
-  <strong>Untested</strong>:
-    <ul>
-      <li>WCAG:AA manual</li>
-      <li>Browser support &mdash; automated and manual</li>
-    </ul>
-  </div>
-</details>
 
 Style guide: Tables.3 Accessibility
 */

--- a/assets/sass/_tables.scss
+++ b/assets/sass/_tables.scss
@@ -23,7 +23,7 @@ Basic table
 Markup: templates/table-examples.hbs
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility & browser testing</summary>
+  <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
     <ul>
@@ -77,7 +77,7 @@ Calendar table
 Markup: templates/table-calendar.hbs
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility & browser testing</summary>
+  <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
     <ul>

--- a/assets/sass/_tables.scss
+++ b/assets/sass/_tables.scss
@@ -147,13 +147,18 @@ Title tables using the <a href="https://www.w3.org/wiki/HTML/Elements/caption" r
 Row and column headers should be set with the <a href="https://www.w3.org/TR/html401/struct/tables.html#adef-scope" rel="external">`scope` attribute</a>.
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility notes</summary>
+  <summary>Accessibility & browser testing</summary>
   <div class="accordion-panel">
-
-    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-    **Untested** WCAG:AA manual compliance<br/>
-    **Untested** Supported browsers tested</p>
+  <strong>Passed</strong>:
+    <ul>
+      <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
+      <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
+    </ul>
+  <strong>Untested</strong>:
+    <ul>
+      <li>WCAG:AA manual</li>
+      <li>Browser support &mdash; automated and manual</li>
+    </ul>
   </div>
 </details>
 

--- a/assets/sass/_tables.scss
+++ b/assets/sass/_tables.scss
@@ -146,5 +146,13 @@ Title tables using the <a href="https://www.w3.org/wiki/HTML/Elements/caption" r
 
 Row and column headers should be set with the <a href="https://www.w3.org/TR/html401/struct/tables.html#adef-scope" rel="external">`scope` attribute</a>.
 
+<div class="guide-micro-callout">
+  <h3> Accessibility notes:​</h3>
+  **Pass** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
+  **Pass** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
+  **Untested** WCAG:AA manual compliance<br/>
+  **Untested** Supported browsers tested
+</div>
+
 Style guide: Tables.3 Accessibility
 */

--- a/assets/sass/_typography.scss
+++ b/assets/sass/_typography.scss
@@ -394,7 +394,7 @@ Use the <a href="http://w3c.github.io/html/textlevel-semantics.html#the-kbd-elem
 Markup: Copy text to clipboard using <kbd>Ctrl</kbd> + <kbd>C</kbd>.
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility & browser testing</summary>
+  <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
     <ul>
@@ -561,7 +561,7 @@ You can use these on paragraphs (`<p>`), or on a wrapping element, like a `<div>
 Markup: templates/callouts-examples.hbs
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility & browser testing</summary>
+  <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
     <ul>
@@ -636,7 +636,7 @@ There is styling for badges to indicate status.
 Markup: templates/badges.hbs
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility & browser testing</summary>
+  <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
     <ul>
@@ -694,7 +694,7 @@ There are 2 ways of using quotes:
 Markup: templates/quotation-examples.hbs
 
 <details data-label="accordion-accessibility" aria-expanded="false">
-  <summary>Accessibility & browser testing</summary>
+  <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
     <ul>

--- a/kss-builder/kss-assets/kss.scss
+++ b/kss-builder/kss-assets/kss.scss
@@ -309,16 +309,3 @@ code {
     color: $light-blue;
   }
 }
-
-
-.guide-micro-callout {
-  font-size: rem(14);
-  margin-bottom: $base-spacing;
-  background-color: $non-white;
-  padding: $small-spacing;
-
-  h3 {
-    font-size: rem(17);
-    margin-top: 0;
-  }
-}

--- a/kss-builder/kss-assets/kss.scss
+++ b/kss-builder/kss-assets/kss.scss
@@ -309,3 +309,16 @@ code {
     color: $light-blue;
   }
 }
+
+
+.guide-micro-callout {
+  font-size: rem(14);
+  margin-bottom: $base-spacing;
+  background-color: $non-white;
+  padding: $small-spacing;
+
+  h3 {
+    font-size: rem(17);
+    margin-top: 0;
+  }
+}


### PR DESCRIPTION
# Accessibility test notes for each feature
## Description

As a user of the guide, at any time, I can understand the level of accessibility compliance offered by any component.
## Definition of Done
- [x] Content/documentation reviewed by Julian or someone in the Content Team
- [x] UX reviewed by Gary or someone the Design team
- [x] Code reviewed by one of the core developers
- [x] Acceptance Testing
  - [x] HTML5 validation (CircleCI)
- [x] Stakeholder/PO review

Not sure if this should live in every feature, it seems a bit over the
top? But maybe it just seems weird right now while all the features
have the same level of testing done?

---

![Uploading Screen Shot 2016-08-11 at 2.14.59 PM.png…]()
