### PR TITLE
Disabled link styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 Added automated accessibility testing (WCAG2.0 AA) using [Pa11y CLI](https://github.com/pa11y/pa11y) and [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) (run with `node test/pa11y.js`).
 
+#### UI-Kit changes
+
+- Support to grey out disabled/non-functional anchors/links (largely for prototyping) via `.placeholder-link` (documented under *§ Link styles*).
+
 ### 1.7.3 2016-08-08
 
 #### UI-Kit changes

--- a/assets/sass/_links.scss
+++ b/assets/sass/_links.scss
@@ -178,7 +178,7 @@ Style guide: Link styles.1 Hover links
   // Specifying a span here explicitly to avoid a.placeholder-link usage.
   span.placeholder-link {
     color: $link-disabled-colour;
-    border-bottom: solid 1px transparentize($hover-bg-colour, 0.4);
+    border-bottom: none;
     cursor: not-allowed;
 
     &:hover {

--- a/assets/sass/_links.scss
+++ b/assets/sass/_links.scss
@@ -3,7 +3,7 @@ Link styles
 
 Styling for types and classes of links.
 
-There are other styles documented elsewhere (eg tag cloud links).
+There are other link styles documented elsewhere (for example [tags in list styles](http://gov-au-ui-kit.apps.staging.digital.gov.au/section-list-styles.html)).
 
 Style guide: Link styles
 */
@@ -145,13 +145,16 @@ Style guide: Link styles.1 Hover links
   }
 
   /*
-  Placeholder link (prototyping)
+  Placeholder links (prototyping)
 
-  Placeholder links are ‘greyed-out’ to visually distinguish non-functional links.
+  Use placeholder links (greyed out links) to show actions that users can't currently take.
 
-  <p class="callout">You can’t apply this class to an anchor (`<a>`) element; instead apply it to a `<span>`.</p>
+  Your content should explain why the action isn't available and when it will be.
 
-  Markup: <span class="placeholder-link">Non-existent functionality</span>
+  <p class="callout">Placeholders only work in `<span>` tags; not `<a>`.</p>
+
+  Markup: <p><span class="placeholder-link">Draft news item</span></p>
+  <p><a href="#">News item</a><p>
 
   <details data-label="placeholder-links-accessibility" aria-expanded="false">
     <summary>Accessibility &amp; browser testing</summary>
@@ -169,7 +172,7 @@ Style guide: Link styles.1 Hover links
     </div>
   </details>
 
-  Style guide: Link styles.3 Placeholder link
+  Style guide: Link styles.3 Placeholder links
   */
 
   // Specifying a span here explicitly to avoid a.placeholder-link usage.

--- a/assets/sass/_links.scss
+++ b/assets/sass/_links.scss
@@ -175,7 +175,7 @@ Style guide: Link styles.1 Hover links
   // Specifying a span here explicitly to avoid a.placeholder-link usage.
   span.placeholder-link {
     color: $link-disabled-colour;
-    border-bottom: solid 1px $hover-bg-colour;
+    border-bottom: solid 1px transparentize($hover-bg-colour, 0.4);
     cursor: not-allowed;
 
     &:hover {

--- a/assets/sass/_links.scss
+++ b/assets/sass/_links.scss
@@ -53,7 +53,7 @@ Style guide: Link styles.1 Hover links
 }
 
 @mixin link-colours($text-colour, $hover-bg-colour, $hover-text-colour: $text-colour) {
-  $link-disabled-color: rgba($text-colour, 0.5);
+  $link-disabled-colour: transparentize($text-colour, 0.4);
   color: $text-colour;
 
   a {
@@ -142,14 +142,48 @@ Style guide: Link styles.1 Hover links
         color: $hover-text-colour;
       }
     }
-  }
 
-  &.disabled {
-    outline: none;
-    color: $link-disabled-color;
-    text-decoration: none;
-    border-bottom: solid 1px;
-    outline-color: transparent;
+    /*
+    Disabled link (prototyping)
+
+    Apply the `.disabled` class to 'grey-out' a link as not functional.
+
+    Because the link is still technically functional it's advised this class is only used during prototyping and testing; do not use this for production.
+
+    Markup: <a class="disabled" href="#">Non-existent functionality</a>
+
+    <details data-label="accordion-accessibility" aria-expanded="false">
+      <summary>Accessibility &amp; browser testing</summary>
+      <div class="accordion-panel">
+      <strong>Passed</strong>:
+        <ul>
+          <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
+          <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
+        </ul>
+      <strong>Untested</strong>:
+        <ul>
+          <li>WCAG:AA manual</li>
+          <li>Browser support &mdash; automated and manual</li>
+        </ul>
+      </div>
+    </details>
+
+    Style guide: Link styles.3 Disabled link
+    */
+
+    &.disabled {
+      outline: none;
+      color: $link-disabled-colour;
+      text-decoration: none;
+      border-bottom: solid 1px;
+      outline-color: transparent;
+      cursor: not-allowed;;
+
+      &:hover,
+      &:focus {
+        background-color: transparent;
+      }
+    }
   }
 }
 

--- a/assets/sass/_links.scss
+++ b/assets/sass/_links.scss
@@ -142,47 +142,44 @@ Style guide: Link styles.1 Hover links
         color: $hover-text-colour;
       }
     }
+  }
 
-    /*
-    Disabled link (prototyping)
+  /*
+  Placeholder link (prototyping)
 
-    Apply the `.disabled` class to 'grey-out' a link as not functional.
+  Placeholder links are ‘greyed-out’ to visually distinguish non-functional links.
 
-    Because the link is still technically functional it's advised this class is only used during prototyping and testing; do not use this for production.
+  <p class="callout">You can’t apply this class to an anchor (`<a>`) element; instead apply it to a `<span>`.</p>
 
-    Markup: <a class="disabled" href="#">Non-existent functionality</a>
+  Markup: <span class="placeholder-link">Non-existent functionality</span>
 
-    <details data-label="accordion-accessibility" aria-expanded="false">
-      <summary>Accessibility &amp; browser testing</summary>
-      <div class="accordion-panel">
-      <strong>Passed</strong>:
-        <ul>
-          <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
-          <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
-        </ul>
-      <strong>Untested</strong>:
-        <ul>
-          <li>WCAG:AA manual</li>
-          <li>Browser support &mdash; automated and manual</li>
-        </ul>
-      </div>
-    </details>
+  <details data-label="placeholder-links-accessibility" aria-expanded="false">
+    <summary>Accessibility &amp; browser testing</summary>
+    <div class="accordion-panel">
+    <strong>Passed</strong>:
+      <ul>
+        <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
+        <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
+      </ul>
+    <strong>Untested</strong>:
+      <ul>
+        <li>WCAG:AA manual</li>
+        <li>Browser support &mdash; automated and manual</li>
+      </ul>
+    </div>
+  </details>
 
-    Style guide: Link styles.3 Disabled link
-    */
+  Style guide: Link styles.3 Placeholder link
+  */
 
-    &.disabled {
-      outline: none;
-      color: $link-disabled-colour;
-      text-decoration: none;
-      border-bottom: solid 1px;
-      outline-color: transparent;
-      cursor: not-allowed;;
+  // Specifying a span here explicitly to avoid a.placeholder-link usage.
+  span.placeholder-link {
+    color: $link-disabled-colour;
+    border-bottom: solid 1px $hover-bg-colour;
+    cursor: not-allowed;
 
-      &:hover,
-      &:focus {
-        background-color: transparent;
-      }
+    &:hover {
+      cursor: not-allowed;
     }
   }
 }

--- a/examples/govau-home.html
+++ b/examples/govau-home.html
@@ -70,8 +70,8 @@
             <li><a href="#content">Broadband</a></li>
             <li><a href="#content">Elections</a></li>
             <li><a href="#content">Television reception</a></li>
-            <li><a href="#content">School holiday dates</a></li>
-            <li><a href="#content">Government jobs</a></li>
+            <li><span class="placeholder-link">School holiday dates</span></li>
+            <li><span class="placeholder-link">Government jobs</span></li>
           </ul>
         </div>
 
@@ -193,7 +193,7 @@
         </li>
         <li>
           <article>
-            <h3><a href="javascript:void(0)">About Government</a></h3>
+            <h3><span class="placeholder-link">About Government</span></h3>
             <p>Government structure, elections, Budget, Australian Public Service.</p>
           </article>
         </li>
@@ -352,8 +352,8 @@
           </ul>
           <ul>
             <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
+            <li><span class="placeholder-link">This is a footer link</span></li>
+            <li><span class="placeholder-link">This is a footer link</span></li>
             <li><a href="#content">This is a footer link</a></li>
             <li><a href="#content">This is a footer link</a></li>
           </ul>
@@ -384,7 +384,7 @@
               <li><a href="#content">Example global link</a></li>
               <li><a href="#content">Example global link</a></li>
               <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
+              <li><span class="placeholder-link">Example global link</span></li>
             </ul>
           </nav>
           <p>&copy; Commonwealth of Australia <br>


### PR DESCRIPTION
## Description

Makes the `.disabled` anchor style available (it was previously inside `_links.scss` but outside the link colour mixin for styles to be applied).

Also added documentation under _§ Link styles_ in the KSS.
## Additional information

Screenshot of the docs:

![screen shot 2016-08-15 at 3 32 33 pm](https://cloud.githubusercontent.com/assets/52766/17656533/703bd27e-62fe-11e6-8430-7c89f9ff65a7.png)
## Definition of Done
- [x] Content/documentation reviewed by Julian or someone in the Content Team
- [x] UX reviewed by Gary or someone the Design team
- [x] Code reviewed by one of the core developers
- [x] Acceptance Testing
  - [x] HTML5 validation (CircleCI)
  - [x] Accessibility testing & WCAG2 compliance (`node test/pa11y.js`)
- [x] Stakeholder/PO review
- [x] CHANGELOG updated
