### PR TITLE
Gives unique data-labels for KSS a11y accordion info.

### DIFF
--- a/assets/sass/_accordions.scss
+++ b/assets/sass/_accordions.scss
@@ -30,7 +30,7 @@ When implementing accordions:
 - For multiple accordion elements each `details` element must have its own `data-label` attribute.
 - This framework allows a text/string search of accordion content, even when collapsed (string itself remains hidden until opened).
 
-<details data-label="accordion-accessibility" aria-expanded="false">
+<details data-label="accordions-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:

--- a/assets/sass/_buttons.scss
+++ b/assets/sass/_buttons.scss
@@ -28,7 +28,7 @@ Do not apply styles to disabled buttons.
 
 Markup: templates/buttons-examples.hbs
 
-<details data-label="accordion-accessibility" aria-expanded="false">
+<details data-label="buttons-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:

--- a/assets/sass/_colours.scss
+++ b/assets/sass/_colours.scss
@@ -206,7 +206,7 @@ The <a href="http://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-con
 <p class="guide-colour-block bg-light-yellow">non-black on light-yellow <span class="invert">AA</span></p>
 <p class="guide-colour-block bg-light-blue">non-black on light-blue <span class="invert">AA</span></p>
 
-<details data-label="accordion-accessibility" aria-expanded="false">
+<details data-label="colour-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:

--- a/assets/sass/_forms.scss
+++ b/assets/sass/_forms.scss
@@ -21,7 +21,7 @@ They can be limited to number input only by setting the `type` attribute to `num
 
 Markup: templates/text-input-single-line.hbs
 
-<details data-label="accordion-accessibility" aria-expanded="false">
+<details data-label="text-input-single-line-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
@@ -111,7 +111,7 @@ form {
     <textarea name="texta" id="texta"></textarea>
   </form>
 
-  <details data-label="accordion-accessibility" aria-expanded="false">
+  <details data-label="text-area-input-accessibility" aria-expanded="false">
     <summary>Accessibility &amp; browser testing</summary>
     <div class="accordion-panel">
     <strong>Passed</strong>:
@@ -203,7 +203,7 @@ form {
     </fieldset>
   </form>
 
-  <details data-label="accordion-accessibility" aria-expanded="false">
+  <details data-label="radio-button-accessibility" aria-expanded="false">
     <summary>Accessibility &amp; browser testing</summary>
     <div class="accordion-panel">
     <strong>Passed</strong>:
@@ -276,7 +276,7 @@ Markup:
   </fieldset>
 </form>
 
-<details data-label="accordion-accessibility" aria-expanded="false">
+<details data-label="checkbox-input-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:

--- a/assets/sass/_grid-layout.scss
+++ b/assets/sass/_grid-layout.scss
@@ -226,7 +226,7 @@ Long lines reduce legibility. Lines of text should be no longer than 75 characte
 
 Low-vision users should be able to increase the size of the text by up to 200 per cent without breaking the layout.
 
-<details data-label="accordion-accessibility" aria-expanded="false">
+<details data-label="grid-text-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:

--- a/assets/sass/_links.scss
+++ b/assets/sass/_links.scss
@@ -19,7 +19,7 @@ Link to external sites using `rel="external"`.
 
 Markup: templates/basic-links.hbs
 
-<details data-label="accordion-accessibility" aria-expanded="false">
+<details data-label="basic-links-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
@@ -96,7 +96,7 @@ Style guide: Link styles.1 Hover links
 
     Markup: <a class="see-more" href="#">See more</a>
 
-    <details data-label="accordion-accessibility" aria-expanded="false">
+    <details data-label="placeholder-link-accessibility" aria-expanded="false">
       <summary>Accessibility &amp; browser testing</summary>
       <div class="accordion-panel">
       <strong>Passed</strong>:

--- a/assets/sass/_lists.scss
+++ b/assets/sass/_lists.scss
@@ -17,7 +17,7 @@ Horizontal style provides a single column of list items.
 
 Markup: templates/lists-horizontal.hbs
 
-<details data-label="accordion-accessibility" aria-expanded="false">
+<details data-label="horizontal-list-styles-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
@@ -50,7 +50,7 @@ For <a href="http://caniuse.com/#feat=flexbox" rel="external">browsers that don'
 
 Markup: templates/lists-vertical.hbs
 
-<details data-label="accordion-accessibility" aria-expanded="false">
+<details data-label="vertical-list-styles-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
@@ -76,7 +76,7 @@ Use small list style for large groups of list items.
 
 Markup: templates/lists-small.hbs
 
-<details data-label="accordion-accessibility" aria-expanded="false">
+<details data-label="small-list-styles-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
@@ -102,7 +102,7 @@ Use highlighted words style for a list with repeating phrases.
 
 Markup: templates/lists-highlighted.hbs
 
-<details data-label="accordion-accessibility" aria-expanded="false">
+<details data-label="highlighted-list-styles-accessibility" aria-expanded="false">
   <summary>Accessibility notes</summary>
   <div class="accordion-panel">
 

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -19,7 +19,7 @@ Older browsers (IE8 and lower) and those without JavaScript will get an expanded
 
 Markup: templates/global-navigation.hbs
 
-<details data-label="accordion-accessibility" aria-expanded="false">
+<details data-label="global-nav-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
@@ -53,7 +53,7 @@ Use active state to show where the user is. Use `class="is-active"` for each cli
 
 Markup: templates/local-navigation.hbs
 
-<details data-label="accordion-accessibility" aria-expanded="false">
+<details data-label="local-nav-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
@@ -81,7 +81,7 @@ They appear directly under a page header or hero, from `$tablet` breakpoint upwa
 
 Markup: templates/breadcrumbs.hbs
 
-<details data-label="accordion-accessibility" aria-expanded="false">
+<details data-label="breadcrumb-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
@@ -111,7 +111,7 @@ Users with modern browsers will see a smooth scroll down the page.
 
 Markup: templates/index-links.hbs
 
-<details data-label="accordion-accessibility" aria-expanded="false">
+<details data-label="index-links-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
@@ -137,7 +137,7 @@ You can present a list of links as a horizontal block using an unsorted list wit
 
 Markup: templates/inline-links.hbs
 
-<details data-label="accordion-accessibility" aria-expanded="false">
+<details data-label="inline-links-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
@@ -169,7 +169,7 @@ This framework uses CSS Flexboxes to manage columns. It provides:
 
 Markup: templates/footer-navigation.hbs
 
-<details data-label="accordion-accessibility" aria-expanded="false">
+<details data-label="footer-nav-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
@@ -552,7 +552,7 @@ Include skip links between the opening of the `<body>` and the page `<header>`.
 
 Markup: templates/skip-link.hbs
 
-<details data-label="accordion-accessibility" aria-expanded="false">
+<details data-label="skip-links-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
@@ -667,7 +667,7 @@ You can use groups of links:
 
 Markup: templates/groups-links.hbs
 
-<details data-label="accordion-accessibility" aria-expanded="false">
+<details data-label="group-links-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:

--- a/assets/sass/_tables.scss
+++ b/assets/sass/_tables.scss
@@ -22,7 +22,7 @@ Basic table
 
 Markup: templates/table-examples.hbs
 
-<details data-label="accordion-accessibility" aria-expanded="false">
+<details data-label="table-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
@@ -76,7 +76,7 @@ Calendar table
 
 Markup: templates/table-calendar.hbs
 
-<details data-label="accordion-accessibility" aria-expanded="false">
+<details data-label="table-calendar-style-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:

--- a/assets/sass/_typography.scss
+++ b/assets/sass/_typography.scss
@@ -393,7 +393,7 @@ Use the <a href="http://w3c.github.io/html/textlevel-semantics.html#the-kbd-elem
 
 Markup: Copy text to clipboard using <kbd>Ctrl</kbd> + <kbd>C</kbd>.
 
-<details data-label="accordion-accessibility" aria-expanded="false">
+<details data-label="kbd-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
@@ -560,7 +560,7 @@ You can use these on paragraphs (`<p>`), or on a wrapping element, like a `<div>
 
 Markup: templates/callouts-examples.hbs
 
-<details data-label="accordion-accessibility" aria-expanded="false">
+<details data-label="callouts-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
@@ -635,7 +635,7 @@ There is styling for badges to indicate status.
 
 Markup: templates/badges.hbs
 
-<details data-label="accordion-accessibility" aria-expanded="false">
+<details data-label="badges-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:
@@ -693,7 +693,7 @@ There are 2 ways of using quotes:
 
 Markup: templates/quotation-examples.hbs
 
-<details data-label="accordion-accessibility" aria-expanded="false">
+<details data-label="blockquote-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
   <strong>Passed</strong>:


### PR DESCRIPTION
Adds unique `data-label` for each accordion that provides a11y info in the KSS.
## Definition of Done
- [x] Code reviewed by one of the core developers
- [x] Acceptance Testing
  - [x] HTML5 validation (CircleCI)
  - [x] Accessibility testing & WCAG2 compliance (`node test/pa11y.js`)
