### PR TITLE
Wrap all HTML Example files in a common layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Added automated accessibility testing (WCAG2.0 AA) using [Pa11y CLI](https://git
 #### UI-Kit changes
 
 - Support to grey out disabled/non-functional anchors/links (largely for prototyping) via `.placeholder-link` (documented under *§ Link styles*).
+- Source files for Examples now use a common layout file (`examples/layouts/default.html`)
 
 ### 1.7.3 2016-08-08
 

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -26,8 +26,8 @@ var paths = {
     scssDir: './assets/sass/**/*.scss',
     kssScssDir: './kss-builder/kss-assets/*.scss',
     kssCssDir: './kss-builder/kss-assets',
-    examplesDir: './examples/**/*.html',
-    examplesLayoutsDir: './examples/layouts/*.html',
+    examplesDir: './examples/*.html',
+    examplesTemplatesDir: './examples/layouts',
     kssBuilderDir: './kss-builder/**/*.*',
     images: './assets/img/**/*.+(png|svg|jpg)',
     scss: './assets/sass/ui-kit.scss',
@@ -135,7 +135,7 @@ gulp.task('svg2png', ['ui-kit.img'], function () {
 
 gulp.task('examples', function () {
     return gulp.src(paths.examplesDir)
-      .pipe(wrap({ src: paths.examplesLayoutsDir + 'default.html' }))
+      .pipe(wrap({ src: paths.examplesTemplatesDir + '/default.html' }))
       .pipe(gulp.dest(paths.outputHTML + '/examples')).pipe(connect.reload());
 });
 
@@ -211,7 +211,7 @@ gulp.task('watch.build', function () {
     gulp.watch([
             paths.assets,
             paths.examplesDir,
-            paths.examplesLayoutsDir,
+            paths.examplesTemplatesDir,
             paths.readme,
             paths.kssBuilderDir,
             '!./kss-builder/kss-assets/kss.css'

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -136,7 +136,7 @@ gulp.task('svg2png', ['ui-kit.img'], function () {
 gulp.task('examples', function () {
     return gulp.src(paths.examplesDir)
       .pipe(wrap({ src: paths.examplesTemplatesDir + '/default.html' }))
-      .pipe(gulp.dest(paths.outputHTML + '/latest/examples')).pipe(connect.reload());
+      .pipe(gulp.dest(paths.outputHTML + '/examples')).pipe(connect.reload());
 });
 
 gulp.task('markdown', function () {
@@ -231,6 +231,6 @@ gulp.task('livereload', function () {
 gulp.task('webserver', function () {
     connect.server({
         livereload: true,
-        root: ['.', 'build']
+        root: 'build'
     });
 });

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -16,7 +16,8 @@ var gulp = require('gulp'),
     connect = require('gulp-connect'),
     svg2png = require('gulp-svg2png'),
     webpack = require('webpack-stream'),
-    zip = require('gulp-zip')
+    zip = require('gulp-zip'),
+    wrap = require('gulp-wrap')
     ;
 
 var paths = {
@@ -132,8 +133,9 @@ gulp.task('svg2png', ['ui-kit.img'], function () {
 });
 
 gulp.task('examples', function () {
-    return gulp.src(paths.examplesDir)
-        .pipe(gulp.dest(paths.outputHTML + '/examples')).pipe(connect.reload());
+    return gulp.src('./examples/*.html')
+      .pipe(wrap({ src: 'examples/layouts/default.html' }))
+      .pipe(gulp.dest(paths.outputHTML + '/examples')).pipe(connect.reload());
 });
 
 gulp.task('markdown', function () {

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -26,7 +26,8 @@ var paths = {
     scssDir: './assets/sass/**/*.scss',
     kssScssDir: './kss-builder/kss-assets/*.scss',
     kssCssDir: './kss-builder/kss-assets',
-    examplesDir: './examples/**/*.*',
+    examplesDir: './examples/**/*.html',
+    examplesLayoutsDir: './examples/layouts/*.html',
     kssBuilderDir: './kss-builder/**/*.*',
     images: './assets/img/**/*.+(png|svg|jpg)',
     scss: './assets/sass/ui-kit.scss',
@@ -133,8 +134,8 @@ gulp.task('svg2png', ['ui-kit.img'], function () {
 });
 
 gulp.task('examples', function () {
-    return gulp.src('./examples/*.html')
-      .pipe(wrap({ src: 'examples/layouts/default.html' }))
+    return gulp.src(paths.examplesDir)
+      .pipe(wrap({ src: paths.examplesLayoutsDir + 'default.html' }))
       .pipe(gulp.dest(paths.outputHTML + '/examples')).pipe(connect.reload());
 });
 
@@ -210,6 +211,7 @@ gulp.task('watch.build', function () {
     gulp.watch([
             paths.assets,
             paths.examplesDir,
+            paths.examplesLayoutsDir,
             paths.readme,
             paths.kssBuilderDir,
             '!./kss-builder/kss-assets/kss.css'

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -136,7 +136,7 @@ gulp.task('svg2png', ['ui-kit.img'], function () {
 gulp.task('examples', function () {
     return gulp.src(paths.examplesDir)
       .pipe(wrap({ src: paths.examplesTemplatesDir + '/default.html' }))
-      .pipe(gulp.dest(paths.outputHTML + '/examples')).pipe(connect.reload());
+      .pipe(gulp.dest(paths.outputHTML + '/latest/examples')).pipe(connect.reload());
 });
 
 gulp.task('markdown', function () {

--- a/examples/agency-contact.html
+++ b/examples/agency-contact.html
@@ -1,297 +1,185 @@
-<!DOCTYPE html>
-<!--[if IE]><![endif]-->
-<!--[if lt IE 7 ]>
-<html lang="en" class="ie6 no-js">    <![endif]-->
-<!--[if IE 7 ]>
-<html lang="en" class="ie7 no-js">    <![endif]-->
-<!--[if IE 8 ]>
-<html lang="en" class="ie8 no-js">    <![endif]-->
-<!--[if IE 9 ]>
-<html lang="en" class="ie9 no-js">    <![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!-->
-<html lang="en" class="no-js"><!--<![endif]-->
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <!-- viewport declaration must be included in <head> for media queries to work correctly on real devices -->
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Contact page</title>
-
-  <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.16/webfont.js"></script>
-  <script>
-    WebFont.load({
-      google: {
-        families: ['Open+Sans:400italic,700,400:latin,latin-ext']
-      }
-    });
-  </script>
-
-  <link rel="stylesheet" type="text/css" href="../latest/ui-kit.css"/>
-
-  <!--[if lt IE 9]>
-  <script src="//code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ="
-          crossorigin="anonymous"></script>
-  <script type="text/javascript"
-          src="//cdnjs.cloudflare.com/ajax/libs/corysimmons-selectivizr2/1.0.8/selectivizr2.min.js"></script>
-  <![endif]-->
-  <!--[if lte IE 9]>
-  <script type='text/javascript' src='//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js'></script>
-  <script type='text/javascript'
-          src='//cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.3/jquery.xdomainrequest.min.js'></script>
-  <![endif]-->
-
-  <script type="text/javascript" src="../latest/ui-kit.js"></script>
-
-</head>
-<body>
-
-  <nav class="skip-to">
-    <a href="#content">Skip to main content</a> <a href="#nav">Skip to section navigation</a>
-  </nav>
-
-
-  <!-- ========== Page header ========== -->
-  <header role="banner">
-    <section class="prerelease-govau--header">
-      <div class="wrapper">
-        <div class="govau--logo">
-          <img src="../latest/img/icons/logo-govau-full-2x.png" alt="gov.au crest logo" width="270"/>
-
-          <div id="test" class="brandbar default"><!--ID is temp for example-->
-            <div class="b1"></div>
-            <div class="b2"></div>
-          </div>
-        </div>
-
-        <div class="feedback" tabindex="1">
-          <a href="#content" class="button--feedback">Give feedback</a>
-        </div>
-
-      </div><!--wrapper-->
-
-      <nav class="breadcrumbs--inverted" aria-label="breadcrumb">
-        <div class="wrapper">
-          <ul>
-            <li><a href="#content">Home</a></li>
-            <li><a href="#content">Department of Communications and the Arts</a></li>
-            <li class="current">Contact us</li>
-          </ul>
-        </div>
-      </nav>
-
-    </section>
-  </header>
-
-
-  <!-- ========== Hero ========== -->
-  <div class="hero-sml corporate">
+<!-- ========== Page header ========== -->
+<header role="banner">
+  <section class="prerelease-govau--header">
     <div class="wrapper">
-      <p>Department of Communications and the Arts</p>
-    </div>
-  </div>
+      <div class="govau--logo">
+        <img src="../latest/img/icons/logo-govau-full-2x.png" alt="gov.au crest logo" width="270"/>
 
-  <!-- ========== Main page row ========== -->
-  <main role="main">
-    <aside class="sidebar" id="nav">
+        <div id="test" class="brandbar default"><!--ID is temp for example-->
+          <div class="b1"></div>
+          <div class="b2"></div>
+        </div>
+      </div>
 
-      <!-- ========== Nav ========== -->
-      <nav class="local-nav" aria-label="main navigation">
-        <h1 class="is-visuallyhidden">Menu</h1>
+      <div class="feedback" tabindex="1">
+        <a href="#content" class="button--feedback">Give feedback</a>
+      </div>
+
+    </div><!--wrapper-->
+
+    <nav class="breadcrumbs--inverted" aria-label="breadcrumb">
+      <div class="wrapper">
         <ul>
-          <li><a class="is-active" href="agency-landing.html">Department of Communications and the Arts</a>
-            <ul>
-              <li><a href="#content">Our role</a></li>
-              <li><a href="#content">People and structure</a></li>
-              <li><a href="#content">Consultations</a></li>
-              <li><a href="agency-content.html">Careers</a></li>
-              <li><a href="#content">News</a></li>
-              <li><a href="#content">Performance reports</a></li>
-              <li><a href="#content">Budget and plans</a></li>
-              <li><a href="#content">Grants and tenders</a></li>
-              <li><a class="is-active is-current" href="#content">Contact us</a></li>
-            </ul>
-          </li>
+          <li><a href="#content">Home</a></li>
+          <li><a href="#content">Department of Communications and the Arts</a></li>
+          <li class="current">Contact us</li>
+        </ul>
+      </div>
+    </nav>
+
+  </section>
+</header>
+
+
+<!-- ========== Hero ========== -->
+<div class="hero-sml corporate">
+  <div class="wrapper">
+    <p>Department of Communications and the Arts</p>
+  </div>
+</div>
+
+<!-- ========== Main page row ========== -->
+<main role="main">
+  <aside class="sidebar" id="nav">
+
+    <!-- ========== Nav ========== -->
+    <nav class="local-nav" aria-label="main navigation">
+      <h1 class="is-visuallyhidden">Menu</h1>
+      <ul>
+        <li><a class="is-active" href="agency-landing.html">Department of Communications and the Arts</a>
+          <ul>
+            <li><a href="#content">Our role</a></li>
+            <li><a href="#content">People and structure</a></li>
+            <li><a href="#content">Consultations</a></li>
+            <li><a href="agency-content.html">Careers</a></li>
+            <li><a href="#content">News</a></li>
+            <li><a href="#content">Performance reports</a></li>
+            <li><a href="#content">Budget and plans</a></li>
+            <li><a href="#content">Grants and tenders</a></li>
+            <li><a class="is-active is-current" href="#content">Contact us</a></li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+
+  </aside>
+
+
+  <!-- ========== Content ========== -->
+  <article id="content" class="content-main">
+    <header>
+      <h1> Contact us</h1>
+      <div class="abstract">
+        <p>You can contact us in a number of ways.</p>
+      </div>
+
+      <nav class="index-links">
+        <h2>On this page</h2>
+        <ul>
+          <li><a href="#email">Email</a></li>
+          <li><a href="#phone">Phone</a></li>
+          <li><a href="#locations-and-opening-hours">Locations and opening hours</a></li>
+          <li><a href="#postal-address">Postal address</a></li>
+          <li><a href="#social-media">Social media</a></li>
+          <li><a href="#how-we-handle-enquiries">How we handle enquiries</a></li>
         </ul>
       </nav>
+    </header>
 
-    </aside>
+    <h2 id="email">Email</h2>
+    <dl>
+      <dt>General inquiries</dt>
+      <dd>__________@communications.gov.au</dd>
 
+      <dt>Copyright enquiries</dt>
+      <dd><a href="mailto:copyright@communications.gov.au">copyright@communications.gov.au</a></dd>
 
-    <!-- ========== Content ========== -->
-    <article id="content" class="content-main">
-      <header>
-        <h1> Contact us</h1>
-        <div class="abstract">
-          <p>You can contact us in a number of ways.</p>
-        </div>
+      <dt>Media enquiries</dt>
+      <dd><a href="mailto:media@communications.gov.au">media@communications.gov.au</a></dd>
+    </dl>
 
-        <nav class="index-links">
-          <h2>On this page</h2>
-          <ul>
-            <li><a href="#email">Email</a></li>
-            <li><a href="#phone">Phone</a></li>
-            <li><a href="#locations-and-opening-hours">Locations and opening hours</a></li>
-            <li><a href="#postal-address">Postal address</a></li>
-            <li><a href="#social-media">Social media</a></li>
-            <li><a href="#how-we-handle-enquiries">How we handle enquiries</a></li>
-          </ul>
-        </nav>
-      </header>
+    <p>There is also <strong><a href="https://www.communications.gov.au/who-we-are/contact-us/form" rel="external">an online Contact form</a></strong>.</p>
 
-      <h2 id="email">Email</h2>
-      <dl>
-        <dt>General inquiries</dt>
-        <dd>__________@communications.gov.au</dd>
+    <h2 id="phone">Phone</h2>
+    <p>If you have a hearing or speech impairment, use the <a href="http://relayservice.gov.au/" rel="external">National Relay Service</a> to access any of our listed phone numbers.</p>
 
-        <dt>Copyright enquiries</dt>
-        <dd><a href="mailto:copyright@communications.gov.au">copyright@communications.gov.au</a></dd>
+    <dl>
+      <dt>National Relay Service telephone</dt>
+      <dd><a href="tel:1300555727">1300 555 727</a></dd>
 
-        <dt>Media enquiries</dt>
-        <dd><a href="mailto:media@communications.gov.au">media@communications.gov.au</a></dd>
-      </dl>
+      <dt>General enquiries</dt>
+      <dd><a href="tel:+61262711000">02 6271 1000</a></dd>
+      <dd>Free call: <a href="tel:1800254649">1800 254 649</a><br />
+        9am &ndash; 5pm Australian Eastern Standard Time (<abbr title="Australian Eastern Standard Time">AEST</abbr>)<br />
+        Monday to Friday excluding <abbr title="Australian Capital Territory">ACT</abbr> public holidays
+      <dd>
 
-      <p>There is also <strong><a href="https://www.communications.gov.au/who-we-are/contact-us/form" rel="external">an online Contact form</a></strong>.</p>
+      <dt>Media enquiries</dt>
+      <dd><a href="tel:+61262711777">02 6271 1777</a><br />
+        9am &ndash; 5pm <abbr title="Australian Eastern Standard Time">AEST</abbr><br />
+        Monday to Friday excluding <abbr title="Australian Capital Territory">ACT</abbr> public holidays
+      </dd>
+    </dl>
 
-      <h2 id="phone">Phone</h2>
-      <p>If you have a hearing or speech impairment, use the <a href="http://relayservice.gov.au/" rel="external">National Relay Service</a> to access any of our listed phone numbers.</p>
-
-      <dl>
-        <dt>National Relay Service telephone</dt>
-        <dd><a href="tel:1300555727">1300 555 727</a></dd>
-
-        <dt>General enquiries</dt>
-        <dd><a href="tel:+61262711000">02 6271 1000</a></dd>
-        <dd>Free call: <a href="tel:1800254649">1800 254 649</a><br />
-          9am &ndash; 5pm Australian Eastern Standard Time (<abbr title="Australian Eastern Standard Time">AEST</abbr>)<br />
-          Monday to Friday excluding <abbr title="Australian Capital Territory">ACT</abbr> public holidays
-        <dd>
-
-        <dt>Media enquiries</dt>
-        <dd><a href="tel:+61262711777">02 6271 1777</a><br />
-          9am &ndash; 5pm <abbr title="Australian Eastern Standard Time">AEST</abbr><br />
-          Monday to Friday excluding <abbr title="Australian Capital Territory">ACT</abbr> public holidays
-        </dd>
-      </dl>
-
-      <h2 id="locations-and-opening-hours">Locations and opening hours</h2>
-      <div id="office-address" class="vcard">
-        <div class="org">Department of Communications and the Arts</div>
-        <div class="adr">
-          <div class="street-address">38 Sydney Avenue</div>
-            <span class="locality">Forrest</span>,
-            <span class="region">ACT</span>,
-            <span class="postal-code">2608</span>
-        </div>
+    <h2 id="locations-and-opening-hours">Locations and opening hours</h2>
+    <div id="office-address" class="vcard">
+      <div class="org">Department of Communications and the Arts</div>
+      <div class="adr">
+        <div class="street-address">38 Sydney Avenue</div>
+          <span class="locality">Forrest</span>,
+          <span class="region">ACT</span>,
+          <span class="postal-code">2608</span>
       </div>
-
-      <p>9am &ndash; 5pm <abbr title="Australian Eastern Standard Time">AEST</abbr><br />
-        Monday to Friday excluding <abbr title="Australian Capital Territory">ACT</abbr> public holidays </p>
-
-      <h2 id="postal-address">Postal address</h2>
-      <div id="office-postal-address" class="vcard">
-        <div class="org">Department of Communications and the Arts</div>
-        <div class="adr">
-          <div class="street-address">GPO Box 2154</div>
-            <span class="locality">Canberra</span>,
-            <span class="region">ACT</span>,
-            <span class="postal-code">2601</span>
-        </div>
-      </div>
-
-      <h2 id="social-media">Social media</h2>
-      <dl>
-        <dt>Linkedin<dt>
-        <dd><a href="https://www.linkedin.com/company/commsau" rel="external">Department of Communications and the Arts</a></dd>
-
-        <dt>Twitter</dt>
-        <dd><a href="https://twitter.com/CommsAu" rel="external">@CommsAu</a></dd>
-        <dd><a href="https://twitter.com/ArtsCultureGov" rel="external">@ArtsCultureGov</a></dd>
-
-        <dt>Youtube</dt>
-        <dd><a href="https://www.youtube.com/user/DeptCommsAu" rel="external">Department of Communications and the Arts</a></dd>
-      </dl>
-
-      <h2 id="how-we-handle-enquiries">How we handle enquiries</h2>
-      <dl>
-        <dt><a href="#content">Client Service Charter</a></dt>
-        <dd>We aim to provide you with a high level of service.</dd>
-
-        <dt><a href="#content">Complaints Handling Policy</a></dt>
-        <dd>How to complain about us and have your concerns addressed.</dd>
-
-        <dt><a href="#content">Privacy Policy</a></dt>
-        <dd>How we handle personal and sensitive information.</dd>
-
-        <dt><a href="#content">Reporting Fraud Policy</a></dt>
-        <dd>You are strongly encouraged to report any suspected fraud incidents against us.</dd>
-
-        <dt><a href="#content">Public Interest Disclosure</a></dt>
-        <dd>How to report serious wrongdoing in the Commonwealth public sector.</dd>
-
-        <dt><a href="#content">Freedom of Information (FOI) requests</a></dt>
-        <dd>Learn more about our FOI obligations and how to make a request.</dd>
-      </dl>
-
-    </article>
-    <!-- ========== end Content ========== -->
-  </main>
-
-
-  <!-- ========== Page footer ========== -->
-  <footer role="contentinfo">
-    <div class="wrapper">
-      <section class="footer-top">
-        <nav>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-        </nav>
-      </section>
-      <section>
-        <div class="footer-logo">
-          <img alt="Australian Government Coat of Arms" src="../latest/img/coat-of-arms.png">
-        </div>
-        <div class="footer-links">
-          <nav>
-            <ul>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-            </ul>
-          </nav>
-          <p>&copy; Commonwealth of Australia <br />
-          <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE.md">Licensed under the MIT License.</a></p>
-        </div>
-      </section>
     </div>
-  </footer>
 
-</body>
-</html>
+    <p>9am &ndash; 5pm <abbr title="Australian Eastern Standard Time">AEST</abbr><br />
+      Monday to Friday excluding <abbr title="Australian Capital Territory">ACT</abbr> public holidays </p>
+
+    <h2 id="postal-address">Postal address</h2>
+    <div id="office-postal-address" class="vcard">
+      <div class="org">Department of Communications and the Arts</div>
+      <div class="adr">
+        <div class="street-address">GPO Box 2154</div>
+          <span class="locality">Canberra</span>,
+          <span class="region">ACT</span>,
+          <span class="postal-code">2601</span>
+      </div>
+    </div>
+
+    <h2 id="social-media">Social media</h2>
+    <dl>
+      <dt>Linkedin<dt>
+      <dd><a href="https://www.linkedin.com/company/commsau" rel="external">Department of Communications and the Arts</a></dd>
+
+      <dt>Twitter</dt>
+      <dd><a href="https://twitter.com/CommsAu" rel="external">@CommsAu</a></dd>
+      <dd><a href="https://twitter.com/ArtsCultureGov" rel="external">@ArtsCultureGov</a></dd>
+
+      <dt>Youtube</dt>
+      <dd><a href="https://www.youtube.com/user/DeptCommsAu" rel="external">Department of Communications and the Arts</a></dd>
+    </dl>
+
+    <h2 id="how-we-handle-enquiries">How we handle enquiries</h2>
+    <dl>
+      <dt><a href="#content">Client Service Charter</a></dt>
+      <dd>We aim to provide you with a high level of service.</dd>
+
+      <dt><a href="#content">Complaints Handling Policy</a></dt>
+      <dd>How to complain about us and have your concerns addressed.</dd>
+
+      <dt><a href="#content">Privacy Policy</a></dt>
+      <dd>How we handle personal and sensitive information.</dd>
+
+      <dt><a href="#content">Reporting Fraud Policy</a></dt>
+      <dd>You are strongly encouraged to report any suspected fraud incidents against us.</dd>
+
+      <dt><a href="#content">Public Interest Disclosure</a></dt>
+      <dd>How to report serious wrongdoing in the Commonwealth public sector.</dd>
+
+      <dt><a href="#content">Freedom of Information (FOI) requests</a></dt>
+      <dd>Learn more about our FOI obligations and how to make a request.</dd>
+    </dl>
+
+  </article>
+  <!-- ========== end Content ========== -->
+</main>

--- a/examples/agency-content.html
+++ b/examples/agency-content.html
@@ -1,311 +1,200 @@
-<!DOCTYPE html>
-<!--[if IE]><![endif]-->
-<!--[if lt IE 7 ]>
-<html lang="en" class="ie6 no-js">    <![endif]-->
-<!--[if IE 7 ]>
-<html lang="en" class="ie7 no-js">    <![endif]-->
-<!--[if IE 8 ]>
-<html lang="en" class="ie8 no-js">    <![endif]-->
-<!--[if IE 9 ]>
-<html lang="en" class="ie9 no-js">    <![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!-->
-<html lang="en" class="no-js"><!--<![endif]-->
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <!-- viewport declaration must be included in <head> for media queries to work correctly on real devices -->
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Agency content</title>
+<!-- ========== Page header ========== -->
+<header role="banner">
+  <section class="prerelease-govau--header">
+    <div class="wrapper">
+      <div class="govau--logo">
+        <img src="../latest/img/icons/logo-govau-full-2x.png" alt="gov.au crest logo" width="270"/>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.16/webfont.js"></script>
-  <script>
-    WebFont.load({
-      google: {
-        families: ['Open+Sans:400italic,700,400:latin,latin-ext']
-      }
-    });
-  </script>
+        <div id="test" class="brandbar default"><!--ID is temp for example-->
+          <div class="b1"></div>
+          <div class="b2"></div>
+        </div>
+      </div>
 
-  <link rel="stylesheet" type="text/css" href="../latest/ui-kit.css"/>
+      <div class="feedback" tabindex="1">
+        <a href="#content" class="button--feedback">Give feedback</a>
+      </div>
 
-  <!--[if lt IE 9]>
-  <script src="//code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ="
-          crossorigin="anonymous"></script>
-  <script type="text/javascript"
-          src="//cdnjs.cloudflare.com/ajax/libs/corysimmons-selectivizr2/1.0.8/selectivizr2.min.js"></script>
-  <![endif]-->
-  <!--[if lte IE 9]>
-  <script type='text/javascript' src='//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js'></script>
-  <script type='text/javascript'
-          src='//cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.3/jquery.xdomainrequest.min.js'></script>
-  <![endif]-->
+    </div><!--wrapper-->
 
-  <script type="text/javascript" src="../latest/ui-kit.js"></script>
-
-</head>
-<body>
-
-  <nav class="skip-to">
-    <a href="#content">Skip to main content</a> <a href="#nav">Skip to section navigation</a>
-  </nav>
-
-  <!-- ========== Page header ========== -->
-  <header role="banner">
-    <section class="prerelease-govau--header">
+    <nav class="breadcrumbs--inverted" aria-label="breadcrumb">
       <div class="wrapper">
-        <div class="govau--logo">
-          <img src="../latest/img/icons/logo-govau-full-2x.png" alt="gov.au crest logo" width="270"/>
+      <ul>
+          <li><a href="#content">Home</a></li>
+          <li><a href="#content">Department of Communications and the Arts</a></li>
+          <li class="current">Careers</li>
+      </ul>
+      </div>
+    </nav>
 
-          <div id="test" class="brandbar default"><!--ID is temp for example-->
-            <div class="b1"></div>
-            <div class="b2"></div>
-          </div>
-        </div>
-
-        <div class="feedback" tabindex="1">
-          <a href="#content" class="button--feedback">Give feedback</a>
-        </div>
-
-      </div><!--wrapper-->
-
-      <nav class="breadcrumbs--inverted" aria-label="breadcrumb">
-        <div class="wrapper">
-        <ul>
-            <li><a href="#content">Home</a></li>
-            <li><a href="#content">Department of Communications and the Arts</a></li>
-            <li class="current">Careers</li>
-        </ul>
-        </div>
-      </nav>
-
-    </section>
-  </header>
+  </section>
+</header>
 
 
-  <!-- ========== Hero ========== -->
-  <div class="hero-sml corporate">
-    <div class="wrapper">
-      <p>Department of Communications and the Arts</p>
-    </div>
+<!-- ========== Hero ========== -->
+<div class="hero-sml corporate">
+  <div class="wrapper">
+    <p>Department of Communications and the Arts</p>
   </div>
+</div>
 
 
-  <!-- ========== Main Page Row ========== -->
-  <main role="main">
+<!-- ========== Main Page Row ========== -->
+<main role="main">
 
-    <!-- ========== Nav ========== -->
-    <aside class="sidebar" id="nav">
+  <!-- ========== Nav ========== -->
+  <aside class="sidebar" id="nav">
 
-      <nav class="local-nav" aria-label="main navigation">
-        <h1 class="is-visuallyhidden">Menu</h1>
+    <nav class="local-nav" aria-label="main navigation">
+      <h1 class="is-visuallyhidden">Menu</h1>
+      <ul>
+        <li><a class="is-active" href="agency-landing.html">Department of Communications and the Arts</a>
+          <ul>
+            <li><a href="#content">Our role</a></li>
+            <li><a href="#content">People and structure</a></li>
+            <li><a href="#content">Consultations</a></li>
+            <li><a class="is-active is-current" href="#content">Careers</a></li>
+            <li><a href="#content">News</a></li>
+            <li><a href="#content">Performance reports</a></li>
+            <li><a href="#content">Budget and plans</a></li>
+            <li><a href="#content">Grants and tenders</a></li>
+            <li><a href="agency-contact.html">Contact us</a></li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+
+  </aside>
+
+
+  <!-- ========== Content ========== -->
+  <article id="content" class="content-main">
+    <header>
+      <h1>Careers</h1>
+
+      <div class="abstract">
+        <p>Information on current vacancies, the benefits of working at our department and how to apply for a job.</p>
+      </div>
+
+      <nav class="index-links">
+        <h2>On this page</h2>
         <ul>
-          <li><a class="is-active" href="agency-landing.html">Department of Communications and the Arts</a>
-            <ul>
-              <li><a href="#content">Our role</a></li>
-              <li><a href="#content">People and structure</a></li>
-              <li><a href="#content">Consultations</a></li>
-              <li><a class="is-active is-current" href="#content">Careers</a></li>
-              <li><a href="#content">News</a></li>
-              <li><a href="#content">Performance reports</a></li>
-              <li><a href="#content">Budget and plans</a></li>
-              <li><a href="#content">Grants and tenders</a></li>
-              <li><a href="agency-contact.html">Contact us</a></li>
-            </ul>
-          </li>
+          <li><a href="#what-we-work-on">What we work on</a></li>
+          <li><a href="#jobs">Jobs</a></li>
+          <li><a href="#the-benefits-of-working-here">The benefits of working here</a></li>
+          <li><a href="#employment-agreement-information">Employment agreement information</a></li>
+          <li><a href="#how-to-apply">How to apply</a></li>
         </ul>
       </nav>
+    </header>
 
-    </aside>
+    <h2 id="what-we-work-on">What we work on</h2>
+    <p>We promote an innovative and competitive communications sector by undertaking analysis, providing advice and delivering programs.</p>
 
+    <p>We also manage programs that encourage excellence in art, support for cultural heritage and public access to arts and culture.</p>
 
-    <!-- ========== Content ========== -->
-    <article id="content" class="content-main">
-      <header>
-        <h1>Careers</h1>
+    <p><a class="see-more" href="#content">Learn more about what we do</a></p>
 
-        <div class="abstract">
-          <p>Information on current vacancies, the benefits of working at our department and how to apply for a job.</p>
-        </div>
+    <h2 id="jobs">Jobs</h2>
+    <dl>
+      <dt><a href="https://communications.nga.net.au" rel="external">Current job vacancies</a></dt>
+      <dd>See what roles we have available now.</dd>
 
-        <nav class="index-links">
-          <h2>On this page</h2>
-          <ul>
-            <li><a href="#what-we-work-on">What we work on</a></li>
-            <li><a href="#jobs">Jobs</a></li>
-            <li><a href="#the-benefits-of-working-here">The benefits of working here</a></li>
-            <li><a href="#employment-agreement-information">Employment agreement information</a></li>
-            <li><a href="#how-to-apply">How to apply</a></li>
-          </ul>
-        </nav>
-      </header>
+      <dt><a href="#content">Graduate Program</a></dt>
+      <dd>Graduate employment opportunities are usually advertised between February and June.</dd>
+    </dl>
 
-      <h2 id="what-we-work-on">What we work on</h2>
-      <p>We promote an innovative and competitive communications sector by undertaking analysis, providing advice and delivering programs.</p>
+    <h2 id="the-benefits-of-working-here">The benefits of working here</h2>
+    <p>Working with us can give you a rewarding and exciting career.</p>
 
-      <p>We also manage programs that encourage excellence in art, support for cultural heritage and public access to arts and culture.</p>
+    <p>For more details on any of the items below, please see our <a href="#content">Enterprise agreement</a>.</p>
 
-      <p><a class="see-more" href="#content">Learn more about what we do</a></p>
+    <h3 id="location">Location</h3>
+    <p>We are centrally located in Canberra, with offices around the country.</p>
 
-      <h2 id="jobs">Jobs</h2>
-      <dl>
-        <dt><a href="https://communications.nga.net.au" rel="external">Current job vacancies</a></dt>
-        <dd>See what roles we have available now.</dd>
+    <p>A range of on-site facilities help staff to balance their work and personal needs including:</p>
 
-        <dt><a href="#content">Graduate Program</a></dt>
-        <dd>Graduate employment opportunities are usually advertised between February and June.</dd>
-      </dl>
+    <ul>
+      <li>Carers’ rooms.</li>
+      <li>Access to new technology to support flexible work arrangements including laptops, Wi-Fi and remote network access.</li>
+    </ul>
 
-      <h2 id="the-benefits-of-working-here">The benefits of working here</h2>
-      <p>Working with us can give you a rewarding and exciting career.</p>
+    <h3 id="competitive-remuneration-package">Competitive remuneration package</h3>
 
-      <p>For more details on any of the items below, please see our <a href="#content">Enterprise agreement</a>.</p>
+    <p>We offer a good salary, generous leave conditions, vacation care and an attractive superannuation scheme.</p>
 
-      <h3 id="location">Location</h3>
-      <p>We are centrally located in Canberra, with offices around the country.</p>
+    <h3 id="flexible-working-arrangements">Flexible working arrangements</h3>
+    <p>We provide access to new technology to support flexible work arrangements (such as the ability to work off-site) as well as flexible working hours.</p>
 
-      <p>A range of on-site facilities help staff to balance their work and personal needs including:</p>
+    <h3 id="wellbeing-program-and-social-club">Wellbeing Program and social club</h3>
+    <p>The Wellbeing Program includes seminars and activities that focus on the social, mental and physical health of employees. It includes:</p>
 
-      <ul>
-        <li>Carers’ rooms.</li>
-        <li>Access to new technology to support flexible work arrangements including laptops, Wi-Fi and remote network access.</li>
-      </ul>
+    <ul>
+      <li>free influenza vaccinations</li>
+      <li>a carer’s room</li>
+      <li>health seminars</li>
+      <li>quit smoking assistance</li>
+      <li>annual health checks</li>
+      <li>cooking demonstrations</li>
+      <li>physical activities such as lunchtime walking groups.</li>
+    </ul>
 
-      <h3 id="competitive-remuneration-package">Competitive remuneration package</h3>
+    <h3 id="learning-and-development">Learning and development</h3>
+    <p>Our employees have opportunities for learning and development throughout their careers including:</p>
 
-      <p>We offer a good salary, generous leave conditions, vacation care and an attractive superannuation scheme.</p>
+    <ul>
+      <li>an induction program for new employees</li>
+      <li>a core training program with short courses for business skills and knowledge</li>
+      <li>in-house capability development programs</li>
+      <li>development programs to build management and leadership skills</li>
+      <li>a staff job rotation program and portfolio agency secondment program to help our employees broaden their skills and knowledge</li>
+      <li>access to mentoring programs.</li>
+    </ul>
 
-      <h3 id="flexible-working-arrangements">Flexible working arrangements</h3>
-      <p>We provide access to new technology to support flexible work arrangements (such as the ability to work off-site) as well as flexible working hours.</p>
+    <h3 id="study-assistance">Study assistance</h3>
+    <p>Studybank is our study assistance program. It helps our employees develop their work-related skills through access to:</p>
 
-      <h3 id="wellbeing-program-and-social-club">Wellbeing Program and social club</h3>
-      <p>The Wellbeing Program includes seminars and activities that focus on the social, mental and physical health of employees. It includes:</p>
+    <ul>
+      <li>up to 75 hours paid leave per semester for study</li>
+      <li>financial assistance of up to $5000 per calendar year as per the <a href="#content">Enterprise Agreement</a>.</li>
+    </ul>
 
-      <ul>
-        <li>free influenza vaccinations</li>
-        <li>a carer’s room</li>
-        <li>health seminars</li>
-        <li>quit smoking assistance</li>
-        <li>annual health checks</li>
-        <li>cooking demonstrations</li>
-        <li>physical activities such as lunchtime walking groups.</li>
-      </ul>
+    <h3 id="employee-assistance-program-eap">Employee Assistance Program (<abbr>EAP</abbr>)</h3>
+    <p>The <abbr>EAP</abbr> is a confidential, professional short-term counselling service. It is a free service for our employees and their immediate families.</p>
 
-      <h3 id="learning-and-development">Learning and development</h3>
-      <p>Our employees have opportunities for learning and development throughout their careers including:</p>
+    <h3 id="smoke-free-workplace">Smoke-free workplace</h3>
+    <p>As an employer, we have a duty of care to protect our staff from passive smoking while they are working. We provide financial assistance to staff and members of their immediate families who want to quit smoking. There are designated smoking areas.</p>
 
-      <ul>
-        <li>an induction program for new employees</li>
-        <li>a core training program with short courses for business skills and knowledge</li>
-        <li>in-house capability development programs</li>
-        <li>development programs to build management and leadership skills</li>
-        <li>a staff job rotation program and portfolio agency secondment program to help our employees broaden their skills and knowledge</li>
-        <li>access to mentoring programs.</li>
-      </ul>
+    <h3 id="support-for-carers">Support for carers</h3>
+    <p>We offer services to support carers including:</p>
 
-      <h3 id="study-assistance">Study assistance</h3>
-      <p>Studybank is our study assistance program. It helps our employees develop their work-related skills through access to:</p>
+    <ul>
+      <li>The Vacation Childcare Subsidisation Program&mdash;for children aged between five and 12 years. To qualify, children must attend a registered child care service during the school holidays.</li>
+      <li>Carers’ room&mdash;available for staff who need to take care of immediate family members in an emergency. It gives people an alternative to using leave. Conditions of use apply.</li>
+    </ul>
 
-      <ul>
-        <li>up to 75 hours paid leave per semester for study</li>
-        <li>financial assistance of up to $5000 per calendar year as per the <a href="#content">Enterprise Agreement</a>.</li>
-      </ul>
+    <h3 id="eldercare">Eldercare</h3>
+    <p>Our eldercare information kit contains information on eldercare issues and how to deal with them. The kit is a national resource that has information on all states and territories.</p>
 
-      <h3 id="employee-assistance-program-eap">Employee Assistance Program (<abbr>EAP</abbr>)</h3>
-      <p>The <abbr>EAP</abbr> is a confidential, professional short-term counselling service. It is a free service for our employees and their immediate families.</p>
+    <h2 id="employment-agreement-information">Employment agreement information</h2>
+    <p>Our enterprise agreement sets the terms and conditions for our employees:</p>
 
-      <h3 id="smoke-free-workplace">Smoke-free workplace</h3>
-      <p>As an employer, we have a duty of care to protect our staff from passive smoking while they are working. We provide financial assistance to staff and members of their immediate families who want to quit smoking. There are designated smoking areas.</p>
+    <ul>
+      <li><a href="#content">Department of Communications Enterprise Agreement 2015-18</a></li>
+      <li><a href="#content">Enterprise Agreement pay scale</a></li>
+      <li><a href="#content">Enterprise Agreement s24(1) determination</a></li>
+    </ul>
 
-      <h3 id="support-for-carers">Support for carers</h3>
-      <p>We offer services to support carers including:</p>
+    <h2 id="how-to-apply">How to apply</h2>
+    <p>Visit our <a href="#content">How to apply</a> page to learn more about:</p>
 
-      <ul>
-        <li>The Vacation Childcare Subsidisation Program&mdash;for children aged between five and 12 years. To qualify, children must attend a registered child care service during the school holidays.</li>
-        <li>Carers’ room&mdash;available for staff who need to take care of immediate family members in an emergency. It gives people an alternative to using leave. Conditions of use apply.</li>
-      </ul>
-
-      <h3 id="eldercare">Eldercare</h3>
-      <p>Our eldercare information kit contains information on eldercare issues and how to deal with them. The kit is a national resource that has information on all states and territories.</p>
-
-      <h2 id="employment-agreement-information">Employment agreement information</h2>
-      <p>Our enterprise agreement sets the terms and conditions for our employees:</p>
-
-      <ul>
-        <li><a href="#content">Department of Communications Enterprise Agreement 2015-18</a></li>
-        <li><a href="#content">Enterprise Agreement pay scale</a></li>
-        <li><a href="#content">Enterprise Agreement s24(1) determination</a></li>
-      </ul>
-
-      <h2 id="how-to-apply">How to apply</h2>
-      <p>Visit our <a href="#content">How to apply</a> page to learn more about:</p>
-
-      <ul>
-        <li>how to prepare your application</li>
-        <li>our engagement conditions</li>
-        <li>the selection process.</li>
-      </ul>
+    <ul>
+      <li>how to prepare your application</li>
+      <li>our engagement conditions</li>
+      <li>the selection process.</li>
+    </ul>
 
 
-    </article>
-    <!-- ========== end Content ========== -->
-  </main>
-
-
-  <!-- ========== Page footer ========== -->
-  <footer role="contentinfo">
-    <div class="wrapper">
-      <section class="footer-top">
-        <nav>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-        </nav>
-      </section>
-      <section>
-        <div class="footer-logo">
-          <img alt="Australian Government Coat of Arms" src="../latest/img/coat-of-arms.png">
-        </div>
-        <div class="footer-links">
-          <nav>
-            <ul>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-            </ul>
-          </nav>
-          <p>&copy; Commonwealth of Australia <br>
-          <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE.md">Licensed under the MIT License.</a></p>
-        </div>
-      </section>
-    </div>
-  </footer>
-
-</body>
-</html>
+  </article>
+  <!-- ========== end Content ========== -->
+</main>

--- a/examples/agency-landing.html
+++ b/examples/agency-landing.html
@@ -1,256 +1,202 @@
-<!DOCTYPE html>
-<!--[if IE]><![endif]-->
-<!--[if lt IE 7 ]>
-<html lang="en" class="ie6 no-js">    <![endif]-->
-<!--[if IE 7 ]>
-<html lang="en" class="ie7 no-js">    <![endif]-->
-<!--[if IE 8 ]>
-<html lang="en" class="ie8 no-js">    <![endif]-->
-<!--[if IE 9 ]>
-<html lang="en" class="ie9 no-js">    <![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!-->
-<html lang="en" class="no-js"><!--<![endif]-->
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <!-- viewport declaration must be included in <head> for media queries to work correctly on real devices -->
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Agency landing page</title>
-
-  <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.16/webfont.js"></script>
-  <script>
-    WebFont.load({
-      google: {
-        families: ['Open+Sans:400italic,700,400:latin,latin-ext']
-      }
-    });
-  </script>
-
-  <link rel="stylesheet" type="text/css" href="../latest/ui-kit.css"/>
-
-  <!--[if lt IE 9]>
-  <script src="//code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ="
-          crossorigin="anonymous"></script>
-  <script type="text/javascript"
-          src="//cdnjs.cloudflare.com/ajax/libs/corysimmons-selectivizr2/1.0.8/selectivizr2.min.js"></script>
-  <![endif]-->
-  <!--[if lte IE 9]>
-  <script type='text/javascript' src='//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js'></script>
-  <script type='text/javascript'
-          src='//cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.3/jquery.xdomainrequest.min.js'></script>
-  <![endif]-->
-
-  <script type="text/javascript" src="../latest/ui-kit.js"></script>
-
-</head>
-<body>
-
-  <nav class="skip-to">
-    <a href="#content">Skip to main content</a> <a href="#nav">Skip to section navigation</a>
-  </nav>
-
-  <!-- ========== Page header ========== -->
-  <header role="banner">
-    <section class="prerelease-govau--header">
-      <div class="wrapper">
-        <div class="govau--logo">
-          <img src="../latest/img/icons/logo-govau-full-2x.png" alt="gov.au crest logo" width="270"/>
-
-          <div id="test" class="brandbar default"><!--ID is temp for example-->
-            <div class="b1"></div>
-            <div class="b2"></div>
-          </div>
-        </div>
-
-        <div class="feedback" tabindex="1">
-          <a href="#content" class="button--feedback">Give feedback</a>
-        </div>
-
-      </div><!--wrapper-->
-
-      <nav class="breadcrumbs--inverted" aria-label="breadcrumb">
-        <div class="wrapper">
-          <ul>
-              <li><a href="#content">Home</a></li>
-              <li class="current">Department of Communications and the Arts</li>
-          </ul>
-        </div>
-      </nav>
-
-    </section>
-  </header>
-
-
-  <!-- ========== Hero ========== -->
-  <div class="hero-med corporate">
+<!-- ========== Page header ========== -->
+<header role="banner">
+  <section class="prerelease-govau--header">
     <div class="wrapper">
-      <h1>Department of Communications and the Arts</h1>
-      <p>We provide advice and develop programs to help you enjoy communication services, the arts and culture.</p>
-    </div>
-  </div>
+      <div class="govau--logo">
+        <img src="../latest/img/icons/logo-govau-full-2x.png" alt="gov.au crest logo" width="270"/>
 
+        <div id="test" class="brandbar default"><!--ID is temp for example-->
+          <div class="b1"></div>
+          <div class="b2"></div>
+        </div>
+      </div>
 
-  <!-- ========== Main Page Row ========== -->
-  <main role="main">
-    <aside class="sidebar" id="nav">
+      <div class="feedback" tabindex="1">
+        <a href="#content" class="button--feedback">Give feedback</a>
+      </div>
 
-      <!-- ========== Nav ========== -->
-      <nav class="local-nav" aria-label="main navigation">
-        <h1 class="is-visuallyhidden">Menu</h1>
+    </div><!--wrapper-->
+
+    <nav class="breadcrumbs--inverted" aria-label="breadcrumb">
+      <div class="wrapper">
         <ul>
-          <li><a class="is-active is-current" href="#content">Department of Communications and the Arts</a>
-            <ul>
-                <li><a href="#content">Our role</a></li>
-                <li><a href="#content">People and structure</a></li>
-                <li><a href="#content">Consultations</a></li>
-                <li><a href="agency-content.html">Careers</a></li>
-                <li><a href="#content">News</a></li>
-                <li><a href="#content">Performance reports</a></li>
-                <li><a href="#content">Budget and plans</a></li>
-                <li><a href="#content">Grants and tenders</a></li>
-                <li><a href="agency-contact.html">Contact us</a></li>
-            </ul>
-          </li>
+            <li><a href="#content">Home</a></li>
+            <li class="current">Department of Communications and the Arts</li>
+        </ul>
+      </div>
+    </nav>
+
+  </section>
+</header>
+
+
+<!-- ========== Hero ========== -->
+<div class="hero-med corporate">
+  <div class="wrapper">
+    <h1>Department of Communications and the Arts</h1>
+    <p>We provide advice and develop programs to help you enjoy communication services, the arts and culture.</p>
+  </div>
+</div>
+
+
+<!-- ========== Main Page Row ========== -->
+<main role="main">
+  <aside class="sidebar" id="nav">
+
+    <!-- ========== Nav ========== -->
+    <nav class="local-nav" aria-label="main navigation">
+      <h1 class="is-visuallyhidden">Menu</h1>
+      <ul>
+        <li><a class="is-active is-current" href="#content">Department of Communications and the Arts</a>
+          <ul>
+              <li><a href="#content">Our role</a></li>
+              <li><a href="#content">People and structure</a></li>
+              <li><a href="#content">Consultations</a></li>
+              <li><a href="agency-content.html">Careers</a></li>
+              <li><a href="#content">News</a></li>
+              <li><a href="#content">Performance reports</a></li>
+              <li><a href="#content">Budget and plans</a></li>
+              <li><a href="#content">Grants and tenders</a></li>
+              <li><a href="agency-contact.html">Contact us</a></li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+
+  </aside>
+
+
+  <!-- ========== Content ========== -->
+  <article id="content" class="content-main">
+
+    <h2>Information and services</h2>
+    <p>The internet, television, phones, the arts and more.</p>
+
+    <ul class="list-vertical--thirds">
+      <li>
+        <figure>
+            <img alt="Television reception" src="http://placehold.it/350x250">
+        </figure>
+        <article>
+            <h3><a href="topic-landing.html">Television reception</a></h3>
+        </article>
+      </li>
+      <li>
+        <figure>
+            <img alt="Online safety" src="http://placehold.it/350x250">
+        </figure>
+        <article>
+            <h3><a href="#content">Online safety</a></h3>
+        </article>
+      </li>
+      <li>
+        <figure>
+            <img alt="Arts" src="http://placehold.it/350x250">
+        </figure>
+        <article>
+            <h3><a href="#content">Arts</a></h3>
+        </article>
+      </li>
+    </ul>
+
+    <p><a class="see-more" href="#content">All information and services</a></p>
+
+    <h2>News</h2>
+    <p>Announcements, media releases, interviews, speeches and more.</p>
+    <ul class="list-vertical--thirds">
+      <li>
+        <article>
+          <h3><a href="#content">Aged under 15: what does it mean for classifications?</a></h3>
+          <div class="meta">06 May 2016</div>
+        </article>
+      </li>
+        <li>
+          <article>
+            <h3><a href="#content">nbn satellite service opens for business</a></h3>
+            <div class="meta">29 April 2016</div>
+          </article>
+        </li>
+        <li>
+          <article>
+            <h3><a href="#content">2016 Prime Minister's Literary Awards now open</a></h3>
+            <div class="meta">20 April 2016</div>
+          </article>
+        </li>
+    </ul>
+    <p><a class="see-more" href="#content">More news</a></p>
+
+
+    <h2>Our ministers</h2>
+    <ul class="list-horizontal">
+      <li>
+        <figure>
+          <img src="https://raw.githubusercontent.com/AusDTO/gov-au-images/master/ministers/mitch-fifield-260x140.png" alt="Photo of Minister Mitch Fifield">
+        </figure>
+        <article>
+          <h3><a href="ministers-landing.html">Minister for Communications</a></h3>
+          <p><strong>Senator the Hon Mitch Fifield</strong></p>
+        </article>
+      </li>
+    </ul>
+
+
+  </article>
+  <!-- ========== end Content ========== -->
+</main>
+
+
+<!-- ========== Page footer ========== -->
+<footer role="contentinfo">
+  <div class="wrapper">
+    <section class="footer-top">
+      <nav>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
         </ul>
       </nav>
-
-    </aside>
-
-
-    <!-- ========== Content ========== -->
-    <article id="content" class="content-main">
-
-      <h2>Information and services</h2>
-      <p>The internet, television, phones, the arts and more.</p>
-
-      <ul class="list-vertical--thirds">
-        <li>
-          <figure>
-              <img alt="Television reception" src="http://placehold.it/350x250">
-          </figure>
-          <article>
-              <h3><a href="topic-landing.html">Television reception</a></h3>
-          </article>
-        </li>
-        <li>
-          <figure>
-              <img alt="Online safety" src="http://placehold.it/350x250">
-          </figure>
-          <article>
-              <h3><a href="#content">Online safety</a></h3>
-          </article>
-        </li>
-        <li>
-          <figure>
-              <img alt="Arts" src="http://placehold.it/350x250">
-          </figure>
-          <article>
-              <h3><a href="#content">Arts</a></h3>
-          </article>
-        </li>
-      </ul>
-
-      <p><a class="see-more" href="#content">All information and services</a></p>
-
-      <h2>News</h2>
-      <p>Announcements, media releases, interviews, speeches and more.</p>
-      <ul class="list-vertical--thirds">
-        <li>
-          <article>
-            <h3><a href="#content">Aged under 15: what does it mean for classifications?</a></h3>
-            <div class="meta">06 May 2016</div>
-          </article>
-        </li>
-          <li>
-            <article>
-              <h3><a href="#content">nbn satellite service opens for business</a></h3>
-              <div class="meta">29 April 2016</div>
-            </article>
-          </li>
-          <li>
-            <article>
-              <h3><a href="#content">2016 Prime Minister's Literary Awards now open</a></h3>
-              <div class="meta">20 April 2016</div>
-            </article>
-          </li>
-      </ul>
-      <p><a class="see-more" href="#content">More news</a></p>
-
-
-      <h2>Our ministers</h2>
-      <ul class="list-horizontal">
-        <li>
-          <figure>
-            <img src="https://raw.githubusercontent.com/AusDTO/gov-au-images/master/ministers/mitch-fifield-260x140.png" alt="Photo of Minister Mitch Fifield">
-          </figure>
-          <article>
-            <h3><a href="ministers-landing.html">Minister for Communications</a></h3>
-            <p><strong>Senator the Hon Mitch Fifield</strong></p>
-          </article>
-        </li>
-      </ul>
-
-
-    </article>
-    <!-- ========== end Content ========== -->
-  </main>
-
-
-  <!-- ========== Page footer ========== -->
-  <footer role="contentinfo">
-    <div class="wrapper">
-      <section class="footer-top">
+    </section>
+    <section>
+      <div class="footer-logo">
+        <img alt="Australian Government Coat of Arms" src="../latest/img/coat-of-arms.png">
+      </div>
+      <div class="footer-links">
         <nav>
           <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
           </ul>
         </nav>
-      </section>
-      <section>
-        <div class="footer-logo">
-          <img alt="Australian Government Coat of Arms" src="../latest/img/coat-of-arms.png">
-        </div>
-        <div class="footer-links">
-          <nav>
-            <ul>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-            </ul>
-          </nav>
-          <p>&copy; Commonwealth of Australia <br>
-          <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE.md">Licensed under the MIT License.</a></p>
-        </div>
-      </section>
-    </div>
-  </footer>
-
-</body>
-</html>
+        <p>&copy; Commonwealth of Australia <br>
+        <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE.md">Licensed under the MIT License.</a></p>
+      </div>
+    </section>
+  </div>
+</footer>

--- a/examples/agency-listing.html
+++ b/examples/agency-listing.html
@@ -1,183 +1,128 @@
-<!DOCTYPE html>
-<!--[if IE]><![endif]-->
-<!--[if lt IE 7 ]>
-<html lang="en" class="ie6 no-js">    <![endif]-->
-<!--[if IE 7 ]>
-<html lang="en" class="ie7 no-js">    <![endif]-->
-<!--[if IE 8 ]>
-<html lang="en" class="ie8 no-js">    <![endif]-->
-<!--[if IE 9 ]>
-<html lang="en" class="ie9 no-js">    <![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!-->
-<html lang="en" class="no-js"><!--<![endif]-->
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <!-- viewport declaration must be included in <head> for media queries to work correctly on real devices -->
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Agency listing</title>
+<!-- ========== Page header ========== -->
+<header role="banner">
+  <section class="prerelease-govau--header">
+    <div class="wrapper">
+      <div class="govau--logo">
+        <img src="../latest/img/icons/logo-govau-full-2x.png" alt="gov.au crest logo" width="270"/>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.16/webfont.js"></script>
-  <script>
-    WebFont.load({
-      google: {
-        families: ['Open+Sans:400italic,700,400:latin,latin-ext']
-      }
-    });
-  </script>
+        <div id="test" class="brandbar default"><!--ID is temp for example-->
+          <div class="b1"></div>
+          <div class="b2"></div>
+        </div>
+      </div>
 
-  <link rel="stylesheet" type="text/css" href="../latest/ui-kit.css"/>
+      <div class="feedback" tabindex="1">
+        <a href="#content" class="button--feedback">Give feedback</a>
+      </div>
 
-  <!--[if lt IE 9]>
-  <script src="//code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ="
-          crossorigin="anonymous"></script>
-  <script type="text/javascript"
-          src="//cdnjs.cloudflare.com/ajax/libs/corysimmons-selectivizr2/1.0.8/selectivizr2.min.js"></script>
-  <![endif]-->
-  <!--[if lte IE 9]>
-  <script type='text/javascript' src='//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js'></script>
-  <script type='text/javascript'
-          src='//cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.3/jquery.xdomainrequest.min.js'></script>
-  <![endif]-->
+    </div><!--wrapper-->
 
-  <script type="text/javascript" src="../latest/ui-kit.js"></script>
-
-</head>
-<body>
-
-  <nav class="skip-to">
-    <a href="#content">Skip to main content</a> <a href="#nav">Skip to section navigation</a>
-  </nav>
-
-
-  <!-- ========== Page header ========== -->
-  <header role="banner">
-    <section class="prerelease-govau--header">
+    <nav class="breadcrumbs--inverted" aria-label="breadcrumb">
       <div class="wrapper">
-        <div class="govau--logo">
-          <img src="../latest/img/icons/logo-govau-full-2x.png" alt="gov.au crest logo" width="270"/>
+        <ul>
+            <li><a href="#content">Home</a></li>
+            <li class="current">Departments</li>
+        </ul>
+      </div>
+    </nav>
 
-          <div id="test" class="brandbar default"><!--ID is temp for example-->
-            <div class="b1"></div>
-            <div class="b2"></div>
-          </div>
-        </div>
-
-        <div class="feedback" tabindex="1">
-          <a href="#content" class="button--feedback">Give feedback</a>
-        </div>
-
-      </div><!--wrapper-->
-
-      <nav class="breadcrumbs--inverted" aria-label="breadcrumb">
-        <div class="wrapper">
-          <ul>
-              <li><a href="#content">Home</a></li>
-              <li class="current">Departments</li>
-          </ul>
-        </div>
-      </nav>
-
-    </section>
-  </header>
+  </section>
+</header>
 
 
-  <!-- ========== Hero ========== -->
-  <div class="hero-med corporate">
-    <div class="wrapper">
-      <h1>Departments</h1>
-      <p>The Australian Government has 18 departments and 189 agencies.</p>
-    </div>
+<!-- ========== Hero ========== -->
+<div class="hero-med corporate">
+  <div class="wrapper">
+    <h1>Departments</h1>
+    <p>The Australian Government has 18 departments and 189 agencies.</p>
   </div>
+</div>
 
 
-  <!-- ========== Main page row ========== -->
-  <main role="main">
+<!-- ========== Main page row ========== -->
+<main role="main">
 
-    <!-- ========== Content ========== -->
-    <article id="content" class="content-main">
+  <!-- ========== Content ========== -->
+  <article id="content" class="content-main">
 
-      <ul class="list-highlighted">
-        <li><a href="agency-landing.html">Attorney-General’s Department</a></li>
-        <li><a href="agency-landing.html"><span> Department of</span> Agriculture and Water Resources</a></li>
-        <li><a href="agency-landing.html"><span> Department of</span> Communications and the Arts</a></li>
-        <li><a href="agency-landing.html"><span> Department of</span> Defence</a></li>
-        <li><a href="agency-landing.html"><span> Department of</span> Education and Training</a></li>
-        <li><a href="agency-landing.html"><span> Department of</span> Employment</a></li>
-        <li><a href="agency-landing.html"><span> Department of</span> Finance</a></li>
-        <li><a href="agency-landing.html"><span> Department of</span> Foreign Affairs and Trade </a></li>
-        <li><a href="agency-landing.html"><span> Department of</span> Health</a></li>
-        <li><a href="agency-landing.html"><span> Department of</span> Human Services</a></li>
-        <li><a href="agency-landing.html"><span> Department of</span> Immigration and Border Protection</a></li>
-        <li><a href="agency-landing.html"><span> Department of</span> Industry, Innovation and Science</a></li>
-        <li><a href="agency-landing.html"><span> Department of</span> Infrastructure and Regional Development</a></li>
-        <li><a href="agency-landing.html"><span> Department of</span> Social Services</a></li>
-        <li><a href="agency-landing.html"><span> Department of the</span> Environment and Energy</a></li>
-        <li><a href="agency-landing.html"><span> Department of the</span> Prime Minister and Cabinet</a></li>
-        <li><a href="agency-landing.html"><span> Department of the</span> Treasury</a></li>
-        <li><a href="agency-landing.html"><span>Department of</span> Veterans’ Affairs</a></li>
-      </ul>
+    <ul class="list-highlighted">
+      <li><a href="agency-landing.html">Attorney-General’s Department</a></li>
+      <li><a href="agency-landing.html"><span> Department of</span> Agriculture and Water Resources</a></li>
+      <li><a href="agency-landing.html"><span> Department of</span> Communications and the Arts</a></li>
+      <li><a href="agency-landing.html"><span> Department of</span> Defence</a></li>
+      <li><a href="agency-landing.html"><span> Department of</span> Education and Training</a></li>
+      <li><a href="agency-landing.html"><span> Department of</span> Employment</a></li>
+      <li><a href="agency-landing.html"><span> Department of</span> Finance</a></li>
+      <li><a href="agency-landing.html"><span> Department of</span> Foreign Affairs and Trade </a></li>
+      <li><a href="agency-landing.html"><span> Department of</span> Health</a></li>
+      <li><a href="agency-landing.html"><span> Department of</span> Human Services</a></li>
+      <li><a href="agency-landing.html"><span> Department of</span> Immigration and Border Protection</a></li>
+      <li><a href="agency-landing.html"><span> Department of</span> Industry, Innovation and Science</a></li>
+      <li><a href="agency-landing.html"><span> Department of</span> Infrastructure and Regional Development</a></li>
+      <li><a href="agency-landing.html"><span> Department of</span> Social Services</a></li>
+      <li><a href="agency-landing.html"><span> Department of the</span> Environment and Energy</a></li>
+      <li><a href="agency-landing.html"><span> Department of the</span> Prime Minister and Cabinet</a></li>
+      <li><a href="agency-landing.html"><span> Department of the</span> Treasury</a></li>
+      <li><a href="agency-landing.html"><span>Department of</span> Veterans’ Affairs</a></li>
+    </ul>
 
-    </article>
-    <!-- ========== end Content ========== -->
-  </main>
+  </article>
+  <!-- ========== end Content ========== -->
+</main>
 
 
-  <!-- ========== Page footer ========== -->
-  <footer role="contentinfo">
-    <div class="wrapper">
-      <section class="footer-top">
+<!-- ========== Page footer ========== -->
+<footer role="contentinfo">
+  <div class="wrapper">
+    <section class="footer-top">
+      <nav>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+      </nav>
+    </section>
+    <section>
+      <div class="footer-logo">
+        <img alt="Australian Government Coat of Arms" src="../latest/img/coat-of-arms.png">
+      </div>
+      <div class="footer-links">
         <nav>
           <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
           </ul>
         </nav>
-      </section>
-      <section>
-        <div class="footer-logo">
-          <img alt="Australian Government Coat of Arms" src="../latest/img/coat-of-arms.png">
-        </div>
-        <div class="footer-links">
-          <nav>
-            <ul>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-            </ul>
-          </nav>
-          <p>&copy; Commonwealth of Australia <br>
-          <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE.md">Licensed under the MIT License.</a></p>
-        </div>
-      </section>
-    </div>
-  </footer>
-
-</body>
-</html>
+        <p>&copy; Commonwealth of Australia <br>
+        <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE.md">Licensed under the MIT License.</a></p>
+      </div>
+    </section>
+  </div>
+</footer>

--- a/examples/govau-home.html
+++ b/examples/govau-home.html
@@ -1,398 +1,343 @@
-<!DOCTYPE html>
-<!--[if IE]><![endif]-->
-<!--[if lt IE 7 ]>
-<html lang="en" class="ie6 no-js">    <![endif]-->
-<!--[if IE 7 ]>
-<html lang="en" class="ie7 no-js">    <![endif]-->
-<!--[if IE 8 ]>
-<html lang="en" class="ie8 no-js">    <![endif]-->
-<!--[if IE 9 ]>
-<html lang="en" class="ie9 no-js">    <![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!-->
-<html lang="en" class="no-js"><!--<![endif]-->
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <!-- viewport declaration must be included in <head> for media queries to work correctly on real devices -->
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Home page (GOV.AU)</title>
-
-  <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.16/webfont.js"></script>
-  <script>
-    WebFont.load({
-      google: {
-        families: ['Open+Sans:400italic,700,400:latin,latin-ext']
-      }
-    });
-  </script>
-
-  <link rel="stylesheet" type="text/css" href="../latest/ui-kit.css"/>
-
-  <!--[if lt IE 9]>
-  <script src="//code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ="
-          crossorigin="anonymous"></script>
-  <script type="text/javascript"
-          src="//cdnjs.cloudflare.com/ajax/libs/corysimmons-selectivizr2/1.0.8/selectivizr2.min.js"></script>
-  <![endif]-->
-  <!--[if lte IE 9]>
-  <script type='text/javascript' src='//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js'></script>
-  <script type='text/javascript'
-          src='//cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.3/jquery.xdomainrequest.min.js'></script>
-  <![endif]-->
-
-  <script type="text/javascript" src="../latest/ui-kit.js"></script>
-
-</head>
-<body>
-
-  <nav class="skip-to">
-    <a href="#content">Skip to main content</a>
-  </nav>
-
-  <header role="banner">
-
-    <section class="prerelease-govau--header">
-      <div class="wrapper">
-        <div class="govau--logo">
-          <img src="../latest/img/icons/logo-crest-2x.png" alt="gov.au crest logo" width="65"/>
-        </div>
-
-        <div class="homeintro">
-            <h1><span class="govau--text"></span><span class="is-visuallyhidden">GOV.AU homepage</span></h1>
-            <p>Your guide to finding and using Australian Government services.</p>
-        </div>
-
-        <div class="links-group">
-          <h2>Popular links</h2>
-          <ul>
-            <li><a href="#content">Dates and times</a></li>
-            <li><a href="#content">Tax returns</a></li>
-            <li><a href="#content">Broadband</a></li>
-            <li><a href="#content">Elections</a></li>
-            <li><a href="#content">Television reception</a></li>
-            <li><span class="placeholder-link">School holiday dates</span></li>
-            <li><span class="placeholder-link">Government jobs</span></li>
-          </ul>
-        </div>
-
-      </div><!--wrapper-->
-
-    </section>
-  </header>
-
-  <div id="test" class="brandbar default"><!--ID is temp for example-->
-    <div class="b1"></div>
-    <div class="b2"></div>
-  </div>
-
-
-  <!-- ========== Main page row ========== -->
-  <main id="content">
-
-
-    <!--<article id="content" class="content-main">-->
-    <!-- ========== Content ========== -->
-
-      <h2>Information and services</h2>
-      <ul class="list-vertical--thirds">
-        <li>
-          <article>
-            <h3><a href="javascript:void(0)">Business and industry</a></h3>
-            <p> ABNs, grants, non-profits, small business, import, export.</p>
-          </article>
-        </li>
-        <li>
-          <article>
-            <h3><a href="javascript:void(0)">Crime, justice and the law</a></h3>
-            <p> Consumer protection, fraud, emergency services, police, rights.</p>
-          </article>
-        </li>
-        <li>
-          <article>
-            <h3><a href="javascript:void(0)">Culture, sport and the arts</a></h3>
-            <p> Indigenous heritage, arts grants, cultural institutions, awards.</p>
-          </article>
-        </li>
-        <li>
-          <article>
-            <h3><a href="javascript:void(0)">Education</a></h3>
-            <p> Early childhood, school, higher education, skills recognition, VET.</p>
-          </article>
-        </li>
-        <li>
-          <article>
-            <h3><a href="javascript:void(0)">Emergencies and disasters</a></h3>
-            <p> Triple Zero (000), natural disasters, health emergencies.</p>
-          </article>
-        </li>
-        <li>
-          <article>
-            <h3><a href="javascript:void(0)">Environment and agriculture</a></h3>
-            <p> Energy efficiency, environmental management, biodiversity, grants.</p>
-          </article>
-        </li>
-        <li>
-          <article>
-            <h3><a href="javascript:void(0)">Health and family</a></h3>
-            <p> Workplace health and safety, insurance, mental health, sport.</p>
-          </article>
-        </li>
-        <li>
-          <article>
-            <h3><a href="javascript:void(0)">Immigration, visas and citizenship</a></h3>
-            <p> Australian citizenship, customs, visas, migration and tourism.</p>
-          </article>
-        </li>
-        <li>
-          <article>
-            <h3><a href="/categories/infrastructure-and-telecommunications">Infrastructure and telecommunications</a></h3>
-            <p> Transport safety, television reception, telecommunications.</p>
-          </article>
-        </li>
-        <li>
-          <article>
-            <h3><a href="javascript:void(0)">Jobs and work</a></h3>
-            <p> Government jobs, employment services, working conditions.</p>
-          </article>
-        </li>
-        <li>
-          <article>
-            <h3><a href="javascript:void(0)">Money, tax and super</a></h3>
-            <p> Tax returns, ABNs, superannuation, personal finance, financial regulation.</p>
-          </article>
-        </li>
-        <li>
-          <article>
-            <h3><a href="javascript:void(0)">Science</a></h3>
-            <p> Science grants and awards, National Measurement Institute.</p>
-          </article>
-        </li>
-        <li>
-          <article>
-            <h3><a href="javascript:void(0)">Security and defence</a></h3>
-            <p> National security, cyber security, ADF, military history, commemoration.</p>
-          </article>
-        </li>
-        <li>
-          <article>
-            <h3><a href="javascript:void(0)">Trade and international</a></h3>
-            <p> Importing, exporting, free trade, foreign investment, foreign aid.</p>
-          </article>
-        </li>
-        <li>
-          <article>
-            <h3><a href="javascript:void(0)">Travelling overseas</a></h3>
-            <p> Customs and quarantine, embassies and consulates, travelling overseas.</p>
-          </article>
-        </li>
-        <li>
-          <article>
-            <h3><a href="javascript:void(0)">About Australia</a></h3>
-            <p>Currency, national archives, Australian honours, the constitution.</p>
-          </article>
-        </li>
-        <li>
-          <article>
-            <h3><span class="placeholder-link">About Government</span></h3>
-            <p>Government structure, elections, Budget, Australian Public Service.</p>
-          </article>
-        </li>
-      </ul>
-
-      <h2>About Australia</h2>
-      <img src="http://placehold.it/1200x450" alt="Placeholder image, 1200x450"/>
-      <a href="#content" class="see-more">More about Australia</a>
-
-      <h2>Life changes</h2>
-      <ul class="list-vertical--thirds">
-        <li>
-          <article>
-            <h3><a href="#content">Just had a baby?</a></h3>
-            <p>Get your baby on your Medicare card, registered for child care payments and immunised.</p>
-            <a href="#content" role="button">Get started</a>
-          </article>
-        </li>
-        <li>
-          <article>
-            <h3><a href="#content">Helping an older person?</a></h3>
-            <p>Find support for older Australians wanting to stay at home or needing other living arrangements.</p>
-            <a href="#content" role="button">Get started</a>
-          </article>
-        </li>
-        <li>
-          <article>
-            <h3><a href="#content">Starting a business?</a></h3>
-            <p>Tell us about your business idea and we'll match the right government information to your set-up.</p>
-            <a href="#content" role="button">Get started</a>
-          </article>
-        </li>
-      </ul>
-
-
-      <h2>News</h2>
-      <ul class="list-vertical--fourths">
-        <li>
-          <article>
-            <h3><a href="#content">Sky News First Edition interview with Senator Mathias Cormann</a></h3>
-            <div class="meta">2016-07-29</div>
-          </article>
-        </li>
-        <li>
-          <article>
-            <h3><a href="#content">Minister for Health and Aged Care welcomes Whitecoat joint venture</a></h3>
-            <div class="meta">2016-07-29</div>
-          </article>
-        </li>
-        <li>
-          <article>
-            <h3><a href="#content">Border clearance advice for religious pilgrims</a></h3>
-            <div class="meta">2016-07-29</div>
-          </article>
-        </li>
-        <li>
-          <article>
-            <h3><a href="#content">Nola Marino re-appointed as Chief Government Whip</a></h3>
-            <div class="meta">2016-07-29</div>
-          </article>
-        </li>
-        <li>
-          <article>
-            <h3><a href="#content">Royal commission into the child protection and youth detention systems of the Northern Territory</a></h3>
-            <div class="meta">2016-07-28</div>
-          </article>
-        </li>
-        <li>
-          <article>
-            <h3><a href="#content">Cabinet remarks 28 July 2016</a></h3>
-            <div class="meta">2016-07-28</div>
-          </article>
-        </li>
-        <li>
-          <article>
-            <h3><a href="#content">Thousands of Australians now free of Hepatitis C</a></h3>
-            <div class="meta">2016-07-28</div>
-          </article>
-        </li>
-        <li>
-          <article>
-            <h3><a href="#content">Operation Sovereign Borders: no successful people-smuggling boats in two years</a></h3>
-            <div class="meta">2016-07-27</div>
-          </article>
-        </li>
-      </ul>
-
-      <h2>Australian Government</h2>
-      <ul>
-        <li><a href="#content"><span>18</span> Departments</a></li>
-        <li><a href="#content"><span>0</span> Agencies</a></li>
-        <li><a href="#content"><span>29</span> Ministers</a></li>
-      </ul>
-
-      <h2>State and territory governments</h2>
-      <ul class="list-vertical">
-          <li class="nsw">
-            <img src="http://placehold.it/120x120" alt="Placeholder image, 120x120"/>
-            <h3 class="state-title">New South Wales</h3>
-            <a href="https://www.nsw.gov.au/">www.nsw.gov.au</a>
-          </li>
-          <li class="vic">
-            <img src="http://placehold.it/120x120" alt="Placeholder image, 120x120"/>
-            <h3 class="state-title">Victoria</h3>
-            <a href="http://www.vic.gov.au/">www.vic.gov.au</a>
-          </li>
-          <li class="qld">
-            <img src="http://placehold.it/120x120" alt="Placeholder image, 120x120"/>
-            <h3 class="state-title">Queensland</h3>
-            <a href="http://www.qld.gov.au/">www.qld.gov.au</a>
-          </li>
-          <li class="sa">
-            <img src="http://placehold.it/120x120" alt="Placeholder image, 120x120"/>
-            <h3 class="state-title">South Australia</h3>
-            <a href="http://www.sa.gov.au/">www.sa.gov.au</a>
-          </li>
-          <li class="wa">
-            <img src="http://placehold.it/120x120" alt="Placeholder image, 120x120"/>
-            <h3 class="state-title">Western Australia</h3>
-            <a href="https://www.wa.gov.au/">www.wa.gov.au</a>
-          </li>
-          <li class="tas">
-            <img src="http://placehold.it/120x120" alt="Placeholder image, 120x120"/>
-            <h3 class="state-title">Tasmania</h3>
-            <a href="http://www.tas.gov.au/">www.tas.gov.au</a>
-          </li>
-          <li class="nt">
-            <img src="http://placehold.it/120x120" alt="Placeholder image, 120x120"/>
-            <h3 class="state-title">Northern Territory</h3>
-            <a href="https://nt.gov.au/">www.nt.gov.au</a>
-          </li>
-          <li class="act">
-            <img src="http://placehold.it/120x120" alt="Placeholder image, 120x120"/>
-            <h3 class="state-title">Australian Capital Territory</h3>
-            <a href="http://www.act.gov.au/">www.act.gov.au</a>
-          </li>
-      </ul>
-
-
-    <!-- ========== end Content ========== -->
-    <!--</article>-->
-  </main>
-
-
-  <!-- ========== Page footer ========== -->
-  <footer role="contentinfo">
+<header role="banner">
+  <section class="prerelease-govau--header">
     <div class="wrapper">
-      <section class="footer-top">
+      <div class="govau--logo">
+        <img src="../latest/img/icons/logo-crest-2x.png" alt="gov.au crest logo" width="65"/>
+      </div>
+
+      <div class="homeintro">
+          <h1><span class="govau--text"></span><span class="is-visuallyhidden">GOV.AU homepage</span></h1>
+          <p>Your guide to finding and using Australian Government services.</p>
+      </div>
+
+      <div class="links-group">
+        <h2>Popular links</h2>
+        <ul>
+          <li><a href="#content">Dates and times</a></li>
+          <li><a href="#content">Tax returns</a></li>
+          <li><a href="#content">Broadband</a></li>
+          <li><a href="#content">Elections</a></li>
+          <li><a href="#content">Television reception</a></li>
+          <li><a href="#content">School holiday dates</a></li>
+          <li><a href="#content">Government jobs</a></li>
+        </ul>
+      </div>
+
+    </div><!--wrapper-->
+
+  </section>
+</header>
+
+<div id="test" class="brandbar default"><!--ID is temp for example-->
+  <div class="b1"></div>
+  <div class="b2"></div>
+</div>
+
+
+<!-- ========== Main page row ========== -->
+<main id="content">
+
+
+  <!--<article id="content" class="content-main">-->
+  <!-- ========== Content ========== -->
+
+    <h2>Information and services</h2>
+    <ul class="list-vertical--thirds">
+      <li>
+        <article>
+          <h3><a href="javascript:void(0)">Business and industry</a></h3>
+          <p> ABNs, grants, non-profits, small business, import, export.</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h3><a href="javascript:void(0)">Crime, justice and the law</a></h3>
+          <p> Consumer protection, fraud, emergency services, police, rights.</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h3><a href="javascript:void(0)">Culture, sport and the arts</a></h3>
+          <p> Indigenous heritage, arts grants, cultural institutions, awards.</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h3><a href="javascript:void(0)">Education</a></h3>
+          <p> Early childhood, school, higher education, skills recognition, VET.</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h3><a href="javascript:void(0)">Emergencies and disasters</a></h3>
+          <p> Triple Zero (000), natural disasters, health emergencies.</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h3><a href="javascript:void(0)">Environment and agriculture</a></h3>
+          <p> Energy efficiency, environmental management, biodiversity, grants.</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h3><a href="javascript:void(0)">Health and family</a></h3>
+          <p> Workplace health and safety, insurance, mental health, sport.</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h3><a href="javascript:void(0)">Immigration, visas and citizenship</a></h3>
+          <p> Australian citizenship, customs, visas, migration and tourism.</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h3><a href="/categories/infrastructure-and-telecommunications">Infrastructure and telecommunications</a></h3>
+          <p> Transport safety, television reception, telecommunications.</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h3><a href="javascript:void(0)">Jobs and work</a></h3>
+          <p> Government jobs, employment services, working conditions.</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h3><a href="javascript:void(0)">Money, tax and super</a></h3>
+          <p> Tax returns, ABNs, superannuation, personal finance, financial regulation.</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h3><a href="javascript:void(0)">Science</a></h3>
+          <p> Science grants and awards, National Measurement Institute.</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h3><a href="javascript:void(0)">Security and defence</a></h3>
+          <p> National security, cyber security, ADF, military history, commemoration.</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h3><a href="javascript:void(0)">Trade and international</a></h3>
+          <p> Importing, exporting, free trade, foreign investment, foreign aid.</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h3><a href="javascript:void(0)">Travelling overseas</a></h3>
+          <p> Customs and quarantine, embassies and consulates, travelling overseas.</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h3><a href="javascript:void(0)">About Australia</a></h3>
+          <p>Currency, national archives, Australian honours, the constitution.</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h3><a href="javascript:void(0)">About Government</a></h3>
+          <p>Government structure, elections, Budget, Australian Public Service.</p>
+        </article>
+      </li>
+    </ul>
+
+    <h2>About Australia</h2>
+    <img src="http://placehold.it/1200x450" alt="Placeholder image, 1200x450"/>
+    <a href="#content" class="see-more">More about Australia</a>
+
+    <h2>Life changes</h2>
+    <ul class="list-vertical--thirds">
+      <li>
+        <article>
+          <h3><a href="#content">Just had a baby?</a></h3>
+          <p>Get your baby on your Medicare card, registered for child care payments and immunised.</p>
+          <a href="#content" role="button">Get started</a>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h3><a href="#content">Helping an older person?</a></h3>
+          <p>Find support for older Australians wanting to stay at home or needing other living arrangements.</p>
+          <a href="#content" role="button">Get started</a>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h3><a href="#content">Starting a business?</a></h3>
+          <p>Tell us about your business idea and we'll match the right government information to your set-up.</p>
+          <a href="#content" role="button">Get started</a>
+        </article>
+      </li>
+    </ul>
+
+
+    <h2>News</h2>
+    <ul class="list-vertical--fourths">
+      <li>
+        <article>
+          <h3><a href="#content">Sky News First Edition interview with Senator Mathias Cormann</a></h3>
+          <div class="meta">2016-07-29</div>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h3><a href="#content">Minister for Health and Aged Care welcomes Whitecoat joint venture</a></h3>
+          <div class="meta">2016-07-29</div>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h3><a href="#content">Border clearance advice for religious pilgrims</a></h3>
+          <div class="meta">2016-07-29</div>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h3><a href="#content">Nola Marino re-appointed as Chief Government Whip</a></h3>
+          <div class="meta">2016-07-29</div>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h3><a href="#content">Royal commission into the child protection and youth detention systems of the Northern Territory</a></h3>
+          <div class="meta">2016-07-28</div>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h3><a href="#content">Cabinet remarks 28 July 2016</a></h3>
+          <div class="meta">2016-07-28</div>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h3><a href="#content">Thousands of Australians now free of Hepatitis C</a></h3>
+          <div class="meta">2016-07-28</div>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h3><a href="#content">Operation Sovereign Borders: no successful people-smuggling boats in two years</a></h3>
+          <div class="meta">2016-07-27</div>
+        </article>
+      </li>
+    </ul>
+
+    <h2>Australian Government</h2>
+    <ul>
+      <li><a href="#content"><span>18</span> Departments</a></li>
+      <li><a href="#content"><span>0</span> Agencies</a></li>
+      <li><a href="#content"><span>29</span> Ministers</a></li>
+    </ul>
+
+    <h2>State and territory governments</h2>
+    <ul class="list-vertical">
+        <li class="nsw">
+          <img src="http://placehold.it/120x120" alt="Placeholder image, 120x120"/>
+          <h3 class="state-title">New South Wales</h3>
+          <a href="https://www.nsw.gov.au/">www.nsw.gov.au</a>
+        </li>
+        <li class="vic">
+          <img src="http://placehold.it/120x120" alt="Placeholder image, 120x120"/>
+          <h3 class="state-title">Victoria</h3>
+          <a href="http://www.vic.gov.au/">www.vic.gov.au</a>
+        </li>
+        <li class="qld">
+          <img src="http://placehold.it/120x120" alt="Placeholder image, 120x120"/>
+          <h3 class="state-title">Queensland</h3>
+          <a href="http://www.qld.gov.au/">www.qld.gov.au</a>
+        </li>
+        <li class="sa">
+          <img src="http://placehold.it/120x120" alt="Placeholder image, 120x120"/>
+          <h3 class="state-title">South Australia</h3>
+          <a href="http://www.sa.gov.au/">www.sa.gov.au</a>
+        </li>
+        <li class="wa">
+          <img src="http://placehold.it/120x120" alt="Placeholder image, 120x120"/>
+          <h3 class="state-title">Western Australia</h3>
+          <a href="https://www.wa.gov.au/">www.wa.gov.au</a>
+        </li>
+        <li class="tas">
+          <img src="http://placehold.it/120x120" alt="Placeholder image, 120x120"/>
+          <h3 class="state-title">Tasmania</h3>
+          <a href="http://www.tas.gov.au/">www.tas.gov.au</a>
+        </li>
+        <li class="nt">
+          <img src="http://placehold.it/120x120" alt="Placeholder image, 120x120"/>
+          <h3 class="state-title">Northern Territory</h3>
+          <a href="https://nt.gov.au/">www.nt.gov.au</a>
+        </li>
+        <li class="act">
+          <img src="http://placehold.it/120x120" alt="Placeholder image, 120x120"/>
+          <h3 class="state-title">Australian Capital Territory</h3>
+          <a href="http://www.act.gov.au/">www.act.gov.au</a>
+        </li>
+    </ul>
+
+
+  <!-- ========== end Content ========== -->
+  <!--</article>-->
+</main>
+
+
+<!-- ========== Page footer ========== -->
+<footer role="contentinfo">
+  <div class="wrapper">
+    <section class="footer-top">
+      <nav>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+      </nav>
+    </section>
+    <section>
+      <div class="footer-logo">
+        <img alt="Australian Government Coat of Arms" src="../latest/img/coat-of-arms.png">
+      </div>
+      <div class="footer-links">
         <nav>
           <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><span class="placeholder-link">This is a footer link</span></li>
-            <li><span class="placeholder-link">This is a footer link</span></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
           </ul>
         </nav>
-      </section>
-      <section>
-        <div class="footer-logo">
-          <img alt="Australian Government Coat of Arms" src="../latest/img/coat-of-arms.png">
-        </div>
-        <div class="footer-links">
-          <nav>
-            <ul>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><span class="placeholder-link">Example global link</span></li>
-            </ul>
-          </nav>
-          <p>&copy; Commonwealth of Australia <br>
-          <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE.md">Licensed under the MIT License.</a></p>
-        </div>
-      </section>
-    </div>
-  </footer>
-
-</body>
-</html>
+        <p>&copy; Commonwealth of Australia <br>
+        <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE.md">Licensed under the MIT License.</a></p>
+      </div>
+    </section>
+  </div>
+</footer>

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,106 +1,55 @@
-<!DOCTYPE html>
-<!--[if IE]><![endif]-->
-<!--[if lt IE 7 ]>
-<html lang="en" class="ie6 no-js">    <![endif]-->
-<!--[if IE 7 ]>
-<html lang="en" class="ie7 no-js">    <![endif]-->
-<!--[if IE 8 ]>
-<html lang="en" class="ie8 no-js">    <![endif]-->
-<!--[if IE 9 ]>
-<html lang="en" class="ie9 no-js">    <![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!-->
-<html lang="en" class="no-js"><!--<![endif]-->
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <!-- viewport declaration must be included in <head> for media queries to work correctly on real devices -->
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Example Pages</title>
+<main role="main" class="wrapper" id="content">
+  <nav id="nav" class="local-nav" aria-label="main navigation">
+    <h1>Examples</h1>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.16/webfont.js"></script>
-  <script>
-    WebFont.load({
-      google: {
-        families: ['Open+Sans:400italic,700,400:latin,latin-ext']
-      }
-    });
-  </script>
+    <ul>
+      <li><a href="govau-home.html">Home page (GOV.AU)</a>
+        <ul>
 
-  <link rel="stylesheet" type="text/css" href="../latest/ui-kit.css"/>
+          <li><a href="topic-category.html">Category page <!--/categories/infrastructure-and-telecommunications--></a>
+            <ul>
+              <li><a href="topic-landing.html">Topic landing page <!--/television-tv-reception--></a>
+                <ul>
+                  <li><a href="topic-content.html">Topic content  <!--/television-tv-reception/setting-up-digital-tv--></a></li>
+                </ul>
+              </li>
+            </ul>
+          </li>
 
-  <!--[if lt IE 9]>
-  <script src="//code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ="
-          crossorigin="anonymous"></script>
-  <script type="text/javascript"
-          src="//cdnjs.cloudflare.com/ajax/libs/corysimmons-selectivizr2/1.0.8/selectivizr2.min.js"></script>
-  <![endif]-->
-  <!--[if lte IE 9]>
-  <script type='text/javascript' src='//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js'></script>
-  <script type='text/javascript'
-          src='//cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.3/jquery.xdomainrequest.min.js'></script>
-  <![endif]-->
+          <li><a href="agency-listing.html">Agency listing <!--/departments--></a>
+            <ul>
+              <li><a href="agency-landing.html">Agency landing page <!--/department-of-communications-and-the-arts--></a>
+                <ul>
+                  <li><a href="agency-content.html">Agency content <!--/department-of-communications-and-the-arts/our-role--></a></li>
+                  <li><a href="agency-contact.html">Contact page <!--/department-of-communications-and-the-arts/contact-us--></a></li>
+                </ul>
+              </li>
+            </ul>
+          </li>
 
-  <script type="text/javascript" src="../latest/ui-kit.js"></script>
+          <li><a href="ministers-listing.html">Ministers listing <!--/ministers--></a>
+            <ul>
+              <li><a href="ministers-landing.html">Ministers landing page  <!--/minister-for-communications--></a>
+                <ul>
+                  <li><a href="ministers-content.html">Ministers content <!--/minister-for-communications/responsibilities--></a></li>
+                  <li><a href="profile.html">Profile  <!--/prime-minister/about-the-prime-minister--></a></li>
+                </ul>
+              </li>
+            </ul>
+          </li>
 
-</head>
-<body>
+          <li><a href="news-listing.html">News listing (global) <!--/news--></a></li>
+          <li><a href="news-section-listing.html">News listing section <!--/television-tv-reception/news--></a>
+            <ul>
+              <li><a href="news-article.html">News article <!--/minister-for-communications/news/2013-11-13-sydney-final-countdown-to-digital-only-tv-has-begun--></a></li>
+            </ul>
+          </li>
 
-  <nav class="skip-to">
-    <a href="#content">Skip to main content</a> <a href="#nav">Skip to section navigation</a>
+        </ul>
+      </li>
+    </ul>
   </nav>
-
-  <main role="main" class="wrapper" id="content">
-    <nav id="nav" class="local-nav" aria-label="main navigation">
-      <h1>Examples</h1>
-
-      <ul>
-        <li><a href="govau-home.html">Home page (GOV.AU)</a>
-          <ul>
-
-            <li><a href="topic-category.html">Category page <!--/categories/infrastructure-and-telecommunications--></a>
-              <ul>
-                <li><a href="topic-landing.html">Topic landing page <!--/television-tv-reception--></a>
-                  <ul>
-                    <li><a href="topic-content.html">Topic content  <!--/television-tv-reception/setting-up-digital-tv--></a></li>
-                  </ul>
-                </li>
-              </ul>
-            </li>
-
-            <li><a href="agency-listing.html">Agency listing <!--/departments--></a>
-              <ul>
-                <li><a href="agency-landing.html">Agency landing page <!--/department-of-communications-and-the-arts--></a>
-                  <ul>
-                    <li><a href="agency-content.html">Agency content <!--/department-of-communications-and-the-arts/our-role--></a></li>
-                    <li><a href="agency-contact.html">Contact page <!--/department-of-communications-and-the-arts/contact-us--></a></li>
-                  </ul>
-                </li>
-              </ul>
-            </li>
-
-            <li><a href="ministers-listing.html">Ministers listing <!--/ministers--></a>
-              <ul>
-                <li><a href="ministers-landing.html">Ministers landing page  <!--/minister-for-communications--></a>
-                  <ul>
-                    <li><a href="ministers-content.html">Ministers content <!--/minister-for-communications/responsibilities--></a></li>
-                    <li><a href="profile.html">Profile  <!--/prime-minister/about-the-prime-minister--></a></li>
-                  </ul>
-                </li>
-              </ul>
-            </li>
-
-            <li><a href="news-listing.html">News listing (global) <!--/news--></a></li>
-            <li><a href="news-section-listing.html">News listing section <!--/television-tv-reception/news--></a>
-              <ul>
-                <li><a href="news-article.html">News article <!--/minister-for-communications/news/2013-11-13-sydney-final-countdown-to-digital-only-tv-has-begun--></a></li>
-              </ul>
-            </li>
-
-          </ul>
-        </li>
-      </ul>
-    </nav>
-  </main>
+</main>
 
 <!--
   Future:
@@ -111,6 +60,3 @@
   - Team page?
   - Org Chart
 -->
-
-</body>
-</html>

--- a/examples/layouts/default.html
+++ b/examples/layouts/default.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<!--[if lt IE 7 ]>
+<html lang="en" class="ie6 no-js">    <![endif]-->
+<!--[if IE 7 ]>
+<html lang="en" class="ie7 no-js">    <![endif]-->
+<!--[if IE 8 ]>
+<html lang="en" class="ie8 no-js">    <![endif]-->
+<!--[if IE 9 ]>
+<html lang="en" class="ie9 no-js">    <![endif]-->
+<!--[if (gt IE 9)|!(IE)]><!-->
+<html lang="en" class="no-js"><!--<![endif]-->
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="x-ua-compatible" content="ie=edge">
+  <!-- viewport declaration must be included in <head> for media queries to work correctly on real devices -->
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Topic landing page</title>
+
+  <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.16/webfont.js"></script>
+  <script>
+    WebFont.load({
+      google: {
+        families: ['Open+Sans:400italic,700,400:latin,latin-ext']
+      }
+    });
+  </script>
+
+  <link rel="stylesheet" type="text/css" href="../latest/ui-kit.css"/>
+
+  <!--[if lt IE 9]>
+  <script src="//code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ="
+          crossorigin="anonymous"></script>
+  <script type="text/javascript"
+          src="//cdnjs.cloudflare.com/ajax/libs/corysimmons-selectivizr2/1.0.8/selectivizr2.min.js"></script>
+  <![endif]-->
+  <!--[if lte IE 9]>
+  <script type='text/javascript' src='//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js'></script>
+  <script type='text/javascript'
+          src='//cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.3/jquery.xdomainrequest.min.js'></script>
+  <![endif]-->
+
+  <script type="text/javascript" src="../latest/ui-kit.js"></script>
+
+</head>
+<body>
+
+  <nav class="skip-to">
+    <a href="#content">Skip to main content</a> <a href="#nav">Skip to section navigation</a>
+  </nav>
+
+  <%= contents %>
+
+</body>
+</html>

--- a/examples/ministers-content.html
+++ b/examples/ministers-content.html
@@ -1,201 +1,147 @@
-<!DOCTYPE html>
-<!--[if IE]><![endif]-->
-<!--[if lt IE 7 ]>
-<html lang="en" class="ie6 no-js">    <![endif]-->
-<!--[if IE 7 ]>
-<html lang="en" class="ie7 no-js">    <![endif]-->
-<!--[if IE 8 ]>
-<html lang="en" class="ie8 no-js">    <![endif]-->
-<!--[if IE 9 ]>
-<html lang="en" class="ie9 no-js">    <![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!-->
-<html lang="en" class="no-js"><!--<![endif]-->
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <!-- viewport declaration must be included in <head> for media queries to work correctly on real devices -->
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Ministers content</title>
-
-  <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.16/webfont.js"></script>
-  <script>
-    WebFont.load({
-      google: {
-        families: ['Open+Sans:400italic,700,400:latin,latin-ext']
-      }
-    });
-  </script>
-
-  <link rel="stylesheet" type="text/css" href="../latest/ui-kit.css"/>
-
-  <!--[if lt IE 9]>
-  <script src="//code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ="
-          crossorigin="anonymous"></script>
-  <script type="text/javascript"
-          src="//cdnjs.cloudflare.com/ajax/libs/corysimmons-selectivizr2/1.0.8/selectivizr2.min.js"></script>
-  <![endif]-->
-  <!--[if lte IE 9]>
-  <script type='text/javascript' src='//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js'></script>
-  <script type='text/javascript'
-          src='//cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.3/jquery.xdomainrequest.min.js'></script>
-  <![endif]-->
-
-  <script type="text/javascript" src="../latest/ui-kit.js"></script>
-
-</head>
-<body>
-
-  <nav class="skip-to">
-    <a href="#content">Skip to main content</a> <a href="#nav">Skip to section navigation</a>
-  </nav>
-
-  <!-- ========== Page header ========== -->
-  <header role="banner">
-    <section class="prerelease-govau--header">
-      <div class="wrapper">
-        <div class="govau--logo">
-          <img src="../latest/img/icons/logo-govau-full-2x.png" alt="gov.au crest logo" width="270"/>
-
-          <div id="test" class="brandbar default"><!--ID is temp for example-->
-            <div class="b1"></div>
-            <div class="b2"></div>
-          </div>
-        </div>
-
-        <div class="feedback" tabindex="1">
-          <a href="#content" class="button--feedback">Give feedback</a>
-        </div>
-
-      </div><!--wrapper-->
-
-      <nav class="breadcrumbs--inverted" aria-label="breadcrumb">
-        <div class="wrapper">
-          <ul>
-            <li><a href="#content">Home</a></li>
-            <li><a href="ministers-landing.html">Minister for Communications</a></li>
-            <li class="current">Responsibilities</li>
-          </ul>
-        </div>
-      </nav>
-
-    </section>
-  </header>
-
-
-  <!-- ========== Hero ========== -->
-  <div class="hero-sml corporate">
+<!-- ========== Page header ========== -->
+<header role="banner">
+  <section class="prerelease-govau--header">
     <div class="wrapper">
-      <p>Minister for Communications</p>
-    </div>
-  </div>
+      <div class="govau--logo">
+        <img src="../latest/img/icons/logo-govau-full-2x.png" alt="gov.au crest logo" width="270"/>
 
+        <div id="test" class="brandbar default"><!--ID is temp for example-->
+          <div class="b1"></div>
+          <div class="b2"></div>
+        </div>
+      </div>
 
-  <!-- ========== Main page row ========== -->
-  <main role="main">
-    <aside class="sidebar" id="nav">
+      <div class="feedback" tabindex="1">
+        <a href="#content" class="button--feedback">Give feedback</a>
+      </div>
 
-      <!-- ========== Nav ========== -->
-      <nav class="local-nav" aria-label="main navigation">
-        <h1 class="is-visuallyhidden">Menu</h1>
+    </div><!--wrapper-->
+
+    <nav class="breadcrumbs--inverted" aria-label="breadcrumb">
+      <div class="wrapper">
         <ul>
-          <li> <a class="is-active" href="ministers-landing.html">Minister for Communications</a>
-            <ul>
-              <li> <a href="#content" class="is-active is-current"> Responsibilities </a> </li>
-              <li> <a href="profile.html"> About the minister </a> </li>
-              <li> <a href="news-section-listing.html"> News </a> </li>
-              <li> <a href="#content"> Contact </a> </li>
-            </ul>
-          </li>
+          <li><a href="#content">Home</a></li>
+          <li><a href="ministers-landing.html">Minister for Communications</a></li>
+          <li class="current">Responsibilities</li>
+        </ul>
+      </div>
+    </nav>
+
+  </section>
+</header>
+
+
+<!-- ========== Hero ========== -->
+<div class="hero-sml corporate">
+  <div class="wrapper">
+    <p>Minister for Communications</p>
+  </div>
+</div>
+
+
+<!-- ========== Main page row ========== -->
+<main role="main">
+  <aside class="sidebar" id="nav">
+
+    <!-- ========== Nav ========== -->
+    <nav class="local-nav" aria-label="main navigation">
+      <h1 class="is-visuallyhidden">Menu</h1>
+      <ul>
+        <li> <a class="is-active" href="ministers-landing.html">Minister for Communications</a>
+          <ul>
+            <li> <a href="#content" class="is-active is-current"> Responsibilities </a> </li>
+            <li> <a href="profile.html"> About the minister </a> </li>
+            <li> <a href="news-section-listing.html"> News </a> </li>
+            <li> <a href="#content"> Contact </a> </li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+
+  </aside>
+
+  <!-- ========== Content ========== -->
+  <article id="content" class="content-main">
+    <header>
+      <h1>Responsibilities</h1>
+      <div class="abstract">
+        <p>The Minister for Communications develops policies and laws to improve communication services such as television, internet and phones.</p>
+      </div>
+    </header>
+
+    <p>The minister leads the <a href="agency-landing.html">Department of Communications and the Arts</a> and other government agencies within the Communications portfolio.</p>
+    <p>Ministers are members of the Australian Government who have been allocated an area of responsibility for how Australia is run. This area of responsibility is known as a portfolio.</p>
+    <p>The department and agencies provide information and deliver services related to various portfolio responsibilities such as <a href="#content">television, radio, internet, phones and more.</a> </p>
+    <p>The minister works with their department, agencies, community organisations and professional associations to:</p>
+
+    <ul>
+      <li>Develop policies related to communication issues. A policy states the government’s plans for an issue and how to achieve them.</li>
+      <li>Prepare new laws.</li>
+      <li>Change existing laws that need updating or improving.</li>
+      <li>Introduce bills (suggestions for new or changed laws) into parliament and explain why they are necessary and how they will solve communication problems. If a bill becomes a law, the minister and their department are responsible for putting that law into action.</li>
+    </ul>
+
+    <footer>
+      <p>Information sources: <cite>Department of Communications website</cite> and the <cite>Parliamentary Education Office website</cite>.</p>
+    </footer>
+
+  </article>
+  <!-- ========== end Content ========== -->
+</main>
+
+
+<!-- ========== Page footer ========== -->
+<footer role="contentinfo">
+  <div class="wrapper">
+    <section class="footer-top">
+      <nav>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
         </ul>
       </nav>
-
-    </aside>
-
-    <!-- ========== Content ========== -->
-    <article id="content" class="content-main">
-      <header>
-        <h1>Responsibilities</h1>
-        <div class="abstract">
-          <p>The Minister for Communications develops policies and laws to improve communication services such as television, internet and phones.</p>
-        </div>
-      </header>
-
-      <p>The minister leads the <a href="agency-landing.html">Department of Communications and the Arts</a> and other government agencies within the Communications portfolio.</p>
-      <p>Ministers are members of the Australian Government who have been allocated an area of responsibility for how Australia is run. This area of responsibility is known as a portfolio.</p>
-      <p>The department and agencies provide information and deliver services related to various portfolio responsibilities such as <a href="#content">television, radio, internet, phones and more.</a> </p>
-      <p>The minister works with their department, agencies, community organisations and professional associations to:</p>
-
-      <ul>
-        <li>Develop policies related to communication issues. A policy states the government’s plans for an issue and how to achieve them.</li>
-        <li>Prepare new laws.</li>
-        <li>Change existing laws that need updating or improving.</li>
-        <li>Introduce bills (suggestions for new or changed laws) into parliament and explain why they are necessary and how they will solve communication problems. If a bill becomes a law, the minister and their department are responsible for putting that law into action.</li>
-      </ul>
-
-      <footer>
-        <p>Information sources: <cite>Department of Communications website</cite> and the <cite>Parliamentary Education Office website</cite>.</p>
-      </footer>
-
-    </article>
-    <!-- ========== end Content ========== -->
-  </main>
-
-
-  <!-- ========== Page footer ========== -->
-  <footer role="contentinfo">
-    <div class="wrapper">
-      <section class="footer-top">
+    </section>
+    <section>
+      <div class="footer-logo">
+        <img alt="Australian Government Coat of Arms" src="../latest/img/coat-of-arms.png">
+      </div>
+      <div class="footer-links">
         <nav>
           <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
           </ul>
         </nav>
-      </section>
-      <section>
-        <div class="footer-logo">
-          <img alt="Australian Government Coat of Arms" src="../latest/img/coat-of-arms.png">
-        </div>
-        <div class="footer-links">
-          <nav>
-            <ul>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-            </ul>
-          </nav>
-          <p>&copy; Commonwealth of Australia <br>
-          <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE.md">Licensed under the MIT License.</a></p>
-        </div>
-      </section>
-    </div>
-  </footer>
-
-</body>
-</html>
+        <p>&copy; Commonwealth of Australia <br>
+        <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE.md">Licensed under the MIT License.</a></p>
+      </div>
+    </section>
+  </div>
+</footer>

--- a/examples/ministers-landing.html
+++ b/examples/ministers-landing.html
@@ -1,235 +1,180 @@
-<!DOCTYPE html>
-<!--[if IE]><![endif]-->
-<!--[if lt IE 7 ]>
-<html lang="en" class="ie6 no-js">    <![endif]-->
-<!--[if IE 7 ]>
-<html lang="en" class="ie7 no-js">    <![endif]-->
-<!--[if IE 8 ]>
-<html lang="en" class="ie8 no-js">    <![endif]-->
-<!--[if IE 9 ]>
-<html lang="en" class="ie9 no-js">    <![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!-->
-<html lang="en" class="no-js"><!--<![endif]-->
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <!-- viewport declaration must be included in <head> for media queries to work correctly on real devices -->
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Ministers landing page</title>
-
-  <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.16/webfont.js"></script>
-  <script>
-    WebFont.load({
-      google: {
-        families: ['Open+Sans:400italic,700,400:latin,latin-ext']
-      }
-    });
-  </script>
-
-  <link rel="stylesheet" type="text/css" href="../latest/ui-kit.css"/>
-
-  <!--[if lt IE 9]>
-  <script src="//code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ="
-          crossorigin="anonymous"></script>
-  <script type="text/javascript"
-          src="//cdnjs.cloudflare.com/ajax/libs/corysimmons-selectivizr2/1.0.8/selectivizr2.min.js"></script>
-  <![endif]-->
-  <!--[if lte IE 9]>
-  <script type='text/javascript' src='//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js'></script>
-  <script type='text/javascript'
-          src='//cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.3/jquery.xdomainrequest.min.js'></script>
-  <![endif]-->
-
-  <script type="text/javascript" src="../latest/ui-kit.js"></script>
-
-</head>
-<body>
-
-  <nav class="skip-to">
-    <a href="#content">Skip to main content</a> <a href="#nav">Skip to section navigation</a>
-  </nav>
-
-
-  <!-- ========== Page header ========== -->
-  <header role="banner">
-    <section class="prerelease-govau--header">
-      <div class="wrapper">
-        <div class="govau--logo">
-          <img src="../latest/img/icons/logo-govau-full-2x.png" alt="gov.au crest logo" width="270"/>
-
-          <div id="test" class="brandbar default"><!--ID is temp for example-->
-            <div class="b1"></div>
-            <div class="b2"></div>
-          </div>
-        </div>
-
-        <div class="feedback" tabindex="1">
-          <a href="#content" class="button--feedback">Give feedback</a>
-        </div>
-
-      </div><!--wrapper-->
-
-      <nav class="breadcrumbs--inverted" aria-label="breadcrumb">
-        <div class="wrapper">
-          <ul>
-            <li><a href="#content">Home</a></li>
-            <li class="current">Minister for Communications</li>
-          </ul>
-        </div>
-      </nav>
-
-    </section>
-  </header>
-
-
-  <!-- ========== Hero ========== -->
-  <div class="hero-med corporate">
+<!-- ========== Page header ========== -->
+<header role="banner">
+  <section class="prerelease-govau--header">
     <div class="wrapper">
-      <h1>Minister for Communications</h1>
-      <p>The minister advises the Australian Government about communication services and technologies.</p>
-    </div>
-  </div>
+      <div class="govau--logo">
+        <img src="../latest/img/icons/logo-govau-full-2x.png" alt="gov.au crest logo" width="270"/>
 
+        <div id="test" class="brandbar default"><!--ID is temp for example-->
+          <div class="b1"></div>
+          <div class="b2"></div>
+        </div>
+      </div>
 
-  <!-- ========== Main page row ========== -->
-  <main role="main">
-    <aside class="sidebar" id="nav">
+      <div class="feedback" tabindex="1">
+        <a href="#content" class="button--feedback">Give feedback</a>
+      </div>
 
-      <!-- ========== Nav ========== -->
-      <nav class="local-nav" aria-label="main navigation">
-        <h1 class="is-visuallyhidden">Menu</h1>
+    </div><!--wrapper-->
+
+    <nav class="breadcrumbs--inverted" aria-label="breadcrumb">
+      <div class="wrapper">
         <ul>
-          <li><a class="is-active is-current" href="#content">Minister for Communications</a>
-            <ul>
-              <li><a href="ministers-content.html">Responsibilities </a></li>
-              <li><a href="profile.html">About the minister</a></li>
-              <li><a href="news-section-listing.html">News</a></li>
-              <li><a href="#content">Contact</a></li>
-            </ul>
-          </li>
+          <li><a href="#content">Home</a></li>
+          <li class="current">Minister for Communications</li>
         </ul>
-      </nav>
+      </div>
+    </nav>
 
-    </aside>
+  </section>
+</header>
 
-    <!-- ========== Content ========== -->
-    <article id="content" class="content-main">
-      <header>
-        <h2 id="about-the-minister">About the minister</h2>
-        <p>
-          <img src="https://raw.githubusercontent.com/AusDTO/gov-au-images/master/ministers/mitch-fifield-hero.jpg" alt="Senator the Hon Mitch Fifield">
-        </p>
-      </header>
 
-      <h3>Senator the Hon Mitch Fifield</h3>
-      <p>Liberal Party of Australia</p>
-      <p>Senator Fifield was appointed Minister for Communications and Minister for the Arts on 21 September 2015.</p>
-      <p><a class="see-more" href="profile.html">More about the minister</a></p>
+<!-- ========== Hero ========== -->
+<div class="hero-med corporate">
+  <div class="wrapper">
+    <h1>Minister for Communications</h1>
+    <p>The minister advises the Australian Government about communication services and technologies.</p>
+  </div>
+</div>
 
-      <h2 id="responsibilities">Responsibilities</h2>
-      <p>The minister leads the <a href="agency-landing.html">Department of Communications and the Arts</a> and other agencies within the government's Communications portfolio.</p>
-      <p>The minister works with the community, government organisations and professional associations to create and update communication laws.</p>
-      <p><a class="see-more" href="ministers-content.html">More about responsibilities</a></p>
 
-      <h2 id="contact">Contact</h2>
-      <p>Parliament Office:</p>
+<!-- ========== Main page row ========== -->
+<main role="main">
+  <aside class="sidebar" id="nav">
 
-      <dl>
-        <dt>Email</dt>
-        <dd><a href="mailto:minister@communications.gov.au">minister@communications.gov.au</a></dd>
-
-        <dt>Phone</dt>
-        <dd><a href="tel:0262777480">02 6277 7480</a></dd>
-      </dl>
-
-      <p><a class="see-more" href="#content">More contact details</a></p>
-
-      <h2 id="news">News</h2>
-      <p>Announcements, media releases, interviews, speeches and more.</p>
-
-      <ul class="list-vertical--thirds">
-        <li>
-          <article>
-            <h3><a href="#content">Australian Government support for Confluence: Festival of India 2016</a></h3>
-            <div class="meta">26 July 2016</div>
-          </article>
-        </li>
-        <li>
-          <article>
-            <h3><a href="#content">Year of achievement for Children’s eSafety Commissioner</a></h3>
-            <div class="meta">26 July 2016</div>
-          </article>
-        </li>
-        <li>
-          <article>
-            <h3><a href="#content">Sydney&mdash;final countdown to digital-only TV has begun</a></h3>
-            <div class="meta">13 November 2013</div>
-          </article>
+    <!-- ========== Nav ========== -->
+    <nav class="local-nav" aria-label="main navigation">
+      <h1 class="is-visuallyhidden">Menu</h1>
+      <ul>
+        <li><a class="is-active is-current" href="#content">Minister for Communications</a>
+          <ul>
+            <li><a href="ministers-content.html">Responsibilities </a></li>
+            <li><a href="profile.html">About the minister</a></li>
+            <li><a href="news-section-listing.html">News</a></li>
+            <li><a href="#content">Contact</a></li>
+          </ul>
         </li>
       </ul>
+    </nav>
 
-      <p><a class="see-more" href="news-section-listing.html">More news</a></p>
+  </aside>
 
-      <!-- ========== end Content ========== -->
-    </article>
-  </main>
+  <!-- ========== Content ========== -->
+  <article id="content" class="content-main">
+    <header>
+      <h2 id="about-the-minister">About the minister</h2>
+      <p>
+        <img src="https://raw.githubusercontent.com/AusDTO/gov-au-images/master/ministers/mitch-fifield-hero.jpg" alt="Senator the Hon Mitch Fifield">
+      </p>
+    </header>
+
+    <h3>Senator the Hon Mitch Fifield</h3>
+    <p>Liberal Party of Australia</p>
+    <p>Senator Fifield was appointed Minister for Communications and Minister for the Arts on 21 September 2015.</p>
+    <p><a class="see-more" href="profile.html">More about the minister</a></p>
+
+    <h2 id="responsibilities">Responsibilities</h2>
+    <p>The minister leads the <a href="agency-landing.html">Department of Communications and the Arts</a> and other agencies within the government's Communications portfolio.</p>
+    <p>The minister works with the community, government organisations and professional associations to create and update communication laws.</p>
+    <p><a class="see-more" href="ministers-content.html">More about responsibilities</a></p>
+
+    <h2 id="contact">Contact</h2>
+    <p>Parliament Office:</p>
+
+    <dl>
+      <dt>Email</dt>
+      <dd><a href="mailto:minister@communications.gov.au">minister@communications.gov.au</a></dd>
+
+      <dt>Phone</dt>
+      <dd><a href="tel:0262777480">02 6277 7480</a></dd>
+    </dl>
+
+    <p><a class="see-more" href="#content">More contact details</a></p>
+
+    <h2 id="news">News</h2>
+    <p>Announcements, media releases, interviews, speeches and more.</p>
+
+    <ul class="list-vertical--thirds">
+      <li>
+        <article>
+          <h3><a href="#content">Australian Government support for Confluence: Festival of India 2016</a></h3>
+          <div class="meta">26 July 2016</div>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h3><a href="#content">Year of achievement for Children’s eSafety Commissioner</a></h3>
+          <div class="meta">26 July 2016</div>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h3><a href="#content">Sydney&mdash;final countdown to digital-only TV has begun</a></h3>
+          <div class="meta">13 November 2013</div>
+        </article>
+      </li>
+    </ul>
+
+    <p><a class="see-more" href="news-section-listing.html">More news</a></p>
+
+    <!-- ========== end Content ========== -->
+  </article>
+</main>
 
 
-  <!-- ========== Page footer ========== -->
-  <footer role="contentinfo">
-    <div class="wrapper">
-      <section class="footer-top">
+<!-- ========== Page footer ========== -->
+<footer role="contentinfo">
+  <div class="wrapper">
+    <section class="footer-top">
+      <nav>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+      </nav>
+    </section>
+    <section>
+      <div class="footer-logo">
+        <img alt="Australian Government Coat of Arms" src="../latest/img/coat-of-arms.png">
+      </div>
+      <div class="footer-links">
         <nav>
           <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
           </ul>
         </nav>
-      </section>
-      <section>
-        <div class="footer-logo">
-          <img alt="Australian Government Coat of Arms" src="../latest/img/coat-of-arms.png">
-        </div>
-        <div class="footer-links">
-          <nav>
-            <ul>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-            </ul>
-          </nav>
-          <p>&copy; Commonwealth of Australia <br>
-          <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE.md">Licensed under the MIT License.</a></p>
-        </div>
-      </section>
-    </div>
-  </footer>
-
-</body>
-</html>
+        <p>&copy; Commonwealth of Australia <br>
+        <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE.md">Licensed under the MIT License.</a></p>
+      </div>
+    </section>
+  </div>
+</footer>

--- a/examples/ministers-listing.html
+++ b/examples/ministers-listing.html
@@ -1,193 +1,138 @@
-<!DOCTYPE html>
-<!--[if IE]><![endif]-->
-<!--[if lt IE 7 ]>
-<html lang="en" class="ie6 no-js">    <![endif]-->
-<!--[if IE 7 ]>
-<html lang="en" class="ie7 no-js">    <![endif]-->
-<!--[if IE 8 ]>
-<html lang="en" class="ie8 no-js">    <![endif]-->
-<!--[if IE 9 ]>
-<html lang="en" class="ie9 no-js">    <![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!-->
-<html lang="en" class="no-js"><!--<![endif]-->
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <!-- viewport declaration must be included in <head> for media queries to work correctly on real devices -->
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Ministers listing</title>
+<!-- ========== Page header ========== -->
+<header role="banner">
+  <section class="prerelease-govau--header">
+    <div class="wrapper">
+      <div class="govau--logo">
+        <img src="../latest/img/icons/logo-govau-full-2x.png" alt="gov.au crest logo" width="270"/>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.16/webfont.js"></script>
-  <script>
-    WebFont.load({
-      google: {
-        families: ['Open+Sans:400italic,700,400:latin,latin-ext']
-      }
-    });
-  </script>
+        <div id="test" class="brandbar default"><!--ID is temp for example-->
+          <div class="b1"></div>
+          <div class="b2"></div>
+        </div>
+      </div>
 
-  <link rel="stylesheet" type="text/css" href="../latest/ui-kit.css"/>
+      <div class="feedback" tabindex="1">
+        <a href="#content" class="button--feedback">Give feedback</a>
+      </div>
 
-  <!--[if lt IE 9]>
-  <script src="//code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ="
-          crossorigin="anonymous"></script>
-  <script type="text/javascript"
-          src="//cdnjs.cloudflare.com/ajax/libs/corysimmons-selectivizr2/1.0.8/selectivizr2.min.js"></script>
-  <![endif]-->
-  <!--[if lte IE 9]>
-  <script type='text/javascript' src='//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js'></script>
-  <script type='text/javascript'
-          src='//cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.3/jquery.xdomainrequest.min.js'></script>
-  <![endif]-->
+    </div><!--wrapper-->
 
-  <script type="text/javascript" src="../latest/ui-kit.js"></script>
-
-</head>
-<body>
-
-  <nav class="skip-to">
-    <a href="#content">Skip to main content</a> <a href="#nav">Skip to section navigation</a>
-  </nav>
-
-
-  <!-- ========== Page header ========== -->
-  <header role="banner">
-    <section class="prerelease-govau--header">
+    <nav class="breadcrumbs--inverted" aria-label="breadcrumb">
       <div class="wrapper">
-        <div class="govau--logo">
-          <img src="../latest/img/icons/logo-govau-full-2x.png" alt="gov.au crest logo" width="270"/>
+        <ul>
+            <li><a href="#content">Home</a></li>
+            <li class="current">Ministers</li>
+        </ul>
+      </div>
+    </nav>
 
-          <div id="test" class="brandbar default"><!--ID is temp for example-->
-            <div class="b1"></div>
-            <div class="b2"></div>
-          </div>
-        </div>
-
-        <div class="feedback" tabindex="1">
-          <a href="#content" class="button--feedback">Give feedback</a>
-        </div>
-
-      </div><!--wrapper-->
-
-      <nav class="breadcrumbs--inverted" aria-label="breadcrumb">
-        <div class="wrapper">
-          <ul>
-              <li><a href="#content">Home</a></li>
-              <li class="current">Ministers</li>
-          </ul>
-        </div>
-      </nav>
-
-    </section>
-  </header>
+  </section>
+</header>
 
 
-  <!-- ========== Hero ========== -->
-  <div class="hero-med corporate">
-    <div class="wrapper">
-      <h1>Cabinet Ministers</h1>
-      <p>The Australian Government's ministers include Cabinet ministers, outer ministers, assistant ministers, ministers assisting and parliamentary secretaries.</p>
-    </div>
+<!-- ========== Hero ========== -->
+<div class="hero-med corporate">
+  <div class="wrapper">
+    <h1>Cabinet Ministers</h1>
+    <p>The Australian Government's ministers include Cabinet ministers, outer ministers, assistant ministers, ministers assisting and parliamentary secretaries.</p>
   </div>
+</div>
 
 
-  <!-- ========== Main page row ========== -->
-  <main role="main">
+<!-- ========== Main page row ========== -->
+<main role="main">
 
-    <!-- ========== Content ========== -->
-    <article id="content" class="content-main">
-      <ul class="list-highlighted">
-        <li><a href="#content">Prime Minister</a></li>
-        <li><a href="#content"><span> Minister for</span> Agriculture and Water Resources</a></li>
-        <li><a href="#content"><span> Minister for the</span> Arts</a></li>
-        <li><a href="#content">Attorney-General</a></li>
-        <li><a href="#content">Cabinet Secretary</a></li>
-        <li><a href="ministers-landing.html"> <span> Minister for</span> Communications</a></li>
-        <li><a href="#content"><span> Minister for</span> Defence</a></li>
-        <li><a href="#content"><span> Minister for</span> Defence Industry</a></li>
-        <li><a href="#content">Deputy Prime Minister</a></li>
-        <li><a href="#content"><span> Minister for</span> Education and Training </a></li>
-        <li><a href="#content"><span> Minister for</span> Employment</a></li>
-        <li><a href="#content"><span> Minister for the</span> Environment and Energy</a></li>
-        <li><a href="#content"><span> Minister for</span> Finance</a></li>
-        <li><a href="#content"><span> Minister for</span> Foreign Affairs </a></li>
-        <li><a href="#content"><span> Minister for</span> Health and Aged Care</a></li>
-        <li><a href="#content"><span> Minister for</span> Immigration and Border Protection</a></li>
-        <li><a href="#content"><span> Minister for</span> Indigenous Affairs</a></li>
-        <li><a href="#content"><span> Minister for</span> Industry, Innovation and Science</a></li>
-        <li><a href="#content"><span> Minister for</span> Infrastructure and Transport</a></li>
-        <li><a href="#content"><span> Minister for</span> Local Government and Territories</a></li>
-        <li><a href="#content"><span> Minister for</span> Regional Communications</a></li>
-        <li><a href="#content"><span> Minister for</span> Regional Development</a></li>
-        <li><a href="#content"><span> Minister for</span> Resources and Northern Australia</a></li>
-        <li><a href="#content"><span> Minister for</span> Revenue and Financial Services</a></li>
-        <li><a href="#content"><span> Minister for</span> Social Services</a></li>
-        <li><a href="#content"><span> Minister for</span> Sport</a></li>
-        <li><a href="#content"><span> Minister for</span> Trade, Tourism and Investment</a></li>
-        <li><a href="#content">Treasurer</a></li>
-        <li><a href="#content"><span> Minister for</span> Women</a></li>
-      </ul>
+  <!-- ========== Content ========== -->
+  <article id="content" class="content-main">
+    <ul class="list-highlighted">
+      <li><a href="#content">Prime Minister</a></li>
+      <li><a href="#content"><span> Minister for</span> Agriculture and Water Resources</a></li>
+      <li><a href="#content"><span> Minister for the</span> Arts</a></li>
+      <li><a href="#content">Attorney-General</a></li>
+      <li><a href="#content">Cabinet Secretary</a></li>
+      <li><a href="ministers-landing.html"> <span> Minister for</span> Communications</a></li>
+      <li><a href="#content"><span> Minister for</span> Defence</a></li>
+      <li><a href="#content"><span> Minister for</span> Defence Industry</a></li>
+      <li><a href="#content">Deputy Prime Minister</a></li>
+      <li><a href="#content"><span> Minister for</span> Education and Training </a></li>
+      <li><a href="#content"><span> Minister for</span> Employment</a></li>
+      <li><a href="#content"><span> Minister for the</span> Environment and Energy</a></li>
+      <li><a href="#content"><span> Minister for</span> Finance</a></li>
+      <li><a href="#content"><span> Minister for</span> Foreign Affairs </a></li>
+      <li><a href="#content"><span> Minister for</span> Health and Aged Care</a></li>
+      <li><a href="#content"><span> Minister for</span> Immigration and Border Protection</a></li>
+      <li><a href="#content"><span> Minister for</span> Indigenous Affairs</a></li>
+      <li><a href="#content"><span> Minister for</span> Industry, Innovation and Science</a></li>
+      <li><a href="#content"><span> Minister for</span> Infrastructure and Transport</a></li>
+      <li><a href="#content"><span> Minister for</span> Local Government and Territories</a></li>
+      <li><a href="#content"><span> Minister for</span> Regional Communications</a></li>
+      <li><a href="#content"><span> Minister for</span> Regional Development</a></li>
+      <li><a href="#content"><span> Minister for</span> Resources and Northern Australia</a></li>
+      <li><a href="#content"><span> Minister for</span> Revenue and Financial Services</a></li>
+      <li><a href="#content"><span> Minister for</span> Social Services</a></li>
+      <li><a href="#content"><span> Minister for</span> Sport</a></li>
+      <li><a href="#content"><span> Minister for</span> Trade, Tourism and Investment</a></li>
+      <li><a href="#content">Treasurer</a></li>
+      <li><a href="#content"><span> Minister for</span> Women</a></li>
+    </ul>
 
-    </article>
-    <!-- ========== end Content ========== -->
-  </main>
+  </article>
+  <!-- ========== end Content ========== -->
+</main>
 
 
-  <!-- ========== Page footer ========== -->
-  <footer role="contentinfo">
-    <div class="wrapper">
-      <section class="footer-top">
+<!-- ========== Page footer ========== -->
+<footer role="contentinfo">
+  <div class="wrapper">
+    <section class="footer-top">
+      <nav>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+      </nav>
+    </section>
+    <section>
+      <div class="footer-logo">
+        <img alt="Australian Government Coat of Arms" src="../latest/img/coat-of-arms.png">
+      </div>
+      <div class="footer-links">
         <nav>
           <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
           </ul>
         </nav>
-      </section>
-      <section>
-        <div class="footer-logo">
-          <img alt="Australian Government Coat of Arms" src="../latest/img/coat-of-arms.png">
-        </div>
-        <div class="footer-links">
-          <nav>
-            <ul>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-            </ul>
-          </nav>
-          <p>&copy; Commonwealth of Australia <br>
-          <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE.md" rel="license">Licensed under the MIT License.</a></p>
-        </div>
-      </section>
-    </div>
-  </footer>
-
-</body>
-</html>
+        <p>&copy; Commonwealth of Australia <br>
+        <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE.md" rel="license">Licensed under the MIT License.</a></p>
+      </div>
+    </section>
+  </div>
+</footer>

--- a/examples/news-article.html
+++ b/examples/news-article.html
@@ -1,242 +1,187 @@
-<!DOCTYPE html>
-<!--[if IE]><![endif]-->
-<!--[if lt IE 7 ]>
-<html lang="en" class="ie6 no-js">    <![endif]-->
-<!--[if IE 7 ]>
-<html lang="en" class="ie7 no-js">    <![endif]-->
-<!--[if IE 8 ]>
-<html lang="en" class="ie8 no-js">    <![endif]-->
-<!--[if IE 9 ]>
-<html lang="en" class="ie9 no-js">    <![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!-->
-<html lang="en" class="no-js"><!--<![endif]-->
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <!-- viewport declaration must be included in <head> for media queries to work correctly on real devices -->
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>News article</title>
+<!-- ========== Page header ========== -->
+<header role="banner">
 
-  <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.16/webfont.js"></script>
-  <script>
-    WebFont.load({
-      google: {
-        families: ['Open+Sans:400italic,700,400:latin,latin-ext']
-      }
-    });
-  </script>
+  <section class="prerelease-govau--header">
+    <div class="wrapper">
+      <div class="govau--logo">
+        <img src="../latest/img/icons/logo-govau-full-2x.png" alt="gov.au crest logo" width="270"/>
 
-  <link rel="stylesheet" type="text/css" href="../latest/ui-kit.css"/>
+        <div id="test" class="brandbar default"><!--ID is temp for example-->
+          <div class="b1"></div>
+          <div class="b2"></div>
+        </div>
+      </div>
 
-  <!--[if lt IE 9]>
-  <script src="//code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ="
-          crossorigin="anonymous"></script>
-  <script type="text/javascript"
-          src="//cdnjs.cloudflare.com/ajax/libs/corysimmons-selectivizr2/1.0.8/selectivizr2.min.js"></script>
-  <![endif]-->
-  <!--[if lte IE 9]>
-  <script type='text/javascript' src='//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js'></script>
-  <script type='text/javascript'
-          src='//cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.3/jquery.xdomainrequest.min.js'></script>
-  <![endif]-->
+      <div class="feedback" tabindex="1">
+        <a href="#" class="button--feedback">Give feedback</a>
+      </div>
 
-  <script type="text/javascript" src="../latest/ui-kit.js"></script>
+    </div><!--wrapper-->
 
-</head>
-<body>
-
-  <nav class="skip-to">
-    <a href="#content">Skip to main content</a> <a href="#nav">Skip to section navigation</a>
-  </nav>
-
-
-  <!-- ========== Page header ========== -->
-  <header role="banner">
-
-    <section class="prerelease-govau--header">
+    <nav class="breadcrumbs--inverted" aria-label="breadcrumb">
       <div class="wrapper">
-        <div class="govau--logo">
-          <img src="../latest/img/icons/logo-govau-full-2x.png" alt="gov.au crest logo" width="270"/>
-
-          <div id="test" class="brandbar default"><!--ID is temp for example-->
-            <div class="b1"></div>
-            <div class="b2"></div>
-          </div>
-        </div>
-
-        <div class="feedback" tabindex="1">
-          <a href="#" class="button--feedback">Give feedback</a>
-        </div>
-
-      </div><!--wrapper-->
-
-      <nav class="breadcrumbs--inverted" aria-label="breadcrumb">
-        <div class="wrapper">
-          <ul>
-            <li><a href="#content">Home</a></li>
-            <li><a href="news-listing.html">News</a></li>
-            <li class="current">A warm reception for viewers in the Hunter</li>
-          </ul>
-        </div>
-      </nav>
-
-    </section>
-  </header>
-
-
-  <!-- ========== Hero ========== -->
-  <div class="hero-sml">
-    <div class="wrapper">
-      <p>Television (TV) reception</p>
-    </div>
-  </div>
-
-  <!-- ========== Main page row ========== -->
-  <main role="main">
-    <aside class="sidebar" id="nav">
-
-      <!-- ========== Nav ========== -->
-      <nav class="local-nav" aria-label="main navigation">
-        <div class="tags">
-          <dl>
-            <dt>Topics:</dt>
-              <dd><a href="#content">Television (TV) reception</a></dd>
-              <dd><a href="#content">Tag Name</a></dd>
-          </dl>
-        </div>
-      </nav>
-
-    </aside>
-
-    <!-- ========== Content ========== -->
-    <article id="content" class="content-main">
-      <header>
-        <h1> A warm reception for viewers in the Hunter </h1>
-        <div class="abstract">
-          <p> Broadcasters have come up with an initiative to improve TV reception in some parts of the Hunter region.</p>
-        </div>
-
-        <ul class="announcement-info">
-          <li>Published date: 22 July 2016</li>
-          <li> Published by: <a href="topic-landing.html">Television (TV) reception</a></li>
+        <ul>
+          <li><a href="#content">Home</a></li>
+          <li><a href="news-listing.html">News</a></li>
+          <li class="current">A warm reception for viewers in the Hunter</li>
         </ul>
-      </header>
+      </div>
+    </nav>
 
-      <p><img src="https://placehold.it/800x450" alt="This is a 800 by 450 pixel placeholder image"/></p>
+  </section>
+</header>
 
-      <p>In early 2016, viewers should have new and upgraded services, as a result of investment in new infrastructure that provides an alternative TV source.</p>
-      <p>While these initiatives will go a long way to improve reception for many viewers, due to the complex nature of TV reception in the Hunter, there will still be some areas where TV reception problems continue.</p>
 
-      <h2 id="what-s-been-the-problem">What’s been the problem?</h2>
-      <p>TV reception in the Hunter area has always been unusually challenging, with mother nature throwing in a few curve balls. The hilly countryside means that a large number of TV tower sites are needed to provide adequate television coverage, and the addition of a weather phenomenon called ‘seasonal ducting’ (see below) has also played a part.</p>
-      <p>Apart from these things we can’t control, poor antenna installation and cabling, wrongly located antennas, and incorrect receiver tuning are also to blame for reception difficulties.</p>
+<!-- ========== Hero ========== -->
+<div class="hero-sml">
+  <div class="wrapper">
+    <p>Television (TV) reception</p>
+  </div>
+</div>
 
-      <h3 id="seasonal-ducting-what-is-it">Seasonal ducting&mdash;what is it?</h3>
-      <p>Even with correct antenna installation, some viewers in the Hunter region may still have experienced poor TV reception because of the natural phenomenon known as atmospheric or signal ducting.</p>
-      <p>Atmospheric ducting of TV signals happens when distinctive weather conditions—especially high-pressure systems and still conditions—causes distant broadcast signals to travel further than planned. These unintended ‘rogue’ signals then interfere with local signals because antennas and receivers can’t differentiate between the local signals and those being ducted from distant TV towers. Ducting interference affects mainly households in the townships north of Newcastle that receive services from Mount Sugarloaf, as Mount Sugarloaf services operate on the same channels as the high power transmission site that serves the Illawarra area to the south of Sydney.</p>
-      <p>Summer is the most common time for ducting to occur, but it can happen at any time if conditions are right. You may be able to tell it’s ducting if your TV reception is affected in the late afternoon or early evening.</p>
+<!-- ========== Main page row ========== -->
+<main role="main">
+  <aside class="sidebar" id="nav">
 
-      <h2 id="so-what-s-the-fix">So, what’s the fix?</h2>
-      <h3 id="new-infrastructure">New infrastructure</h3>
-      <p>The regional TV commercial broadcasters have put forward a plan that the Federal Government is supporting towards alleviating this ducting issue and improve coverage in some parts. They will do this by investing in new transmission infrastructure at three sites identified by the broadcasters:</p>
+    <!-- ========== Nav ========== -->
+    <nav class="local-nav" aria-label="main navigation">
+      <div class="tags">
+        <dl>
+          <dt>Topics:</dt>
+            <dd><a href="#content">Television (TV) reception</a></dd>
+            <dd><a href="#content">Tag Name</a></dd>
+        </dl>
+      </div>
+    </nav>
 
-      <ul>
-        <li>Port Stephens residents will have their existing TV tower upgraded to increase power and extend coverage</li>
-        <li>Bulahdelah residents will have a new TV tower established</li>
-        <li>Medowie, Salt Ash and the lower Tilligerry Peninsula residents will have a new TV tower established at Wallaroo.</li>
+  </aside>
+
+  <!-- ========== Content ========== -->
+  <article id="content" class="content-main">
+    <header>
+      <h1> A warm reception for viewers in the Hunter </h1>
+      <div class="abstract">
+        <p> Broadcasters have come up with an initiative to improve TV reception in some parts of the Hunter region.</p>
+      </div>
+
+      <ul class="announcement-info">
+        <li>Published date: 22 July 2016</li>
+        <li> Published by: <a href="topic-landing.html">Television (TV) reception</a></li>
       </ul>
+    </header>
 
-      <p>By using different channels, these towers (as well as Anna Bay) will provide an alternative TV source that is reliable and not affected by the ducting.</p>
+    <p><img src="https://placehold.it/800x450" alt="This is a 800 by 450 pixel placeholder image"/></p>
 
-      <p>The new and upgraded services are all expected to be in operation by early 2016.</p>
+    <p>In early 2016, viewers should have new and upgraded services, as a result of investment in new infrastructure that provides an alternative TV source.</p>
+    <p>While these initiatives will go a long way to improve reception for many viewers, due to the complex nature of TV reception in the Hunter, there will still be some areas where TV reception problems continue.</p>
 
-      <h2 id="the-hills-are-alive-is-there-another-alternative">The hills are alive&mdash;is there another alternative?</h2>
-      <p>Those pesky trees&hellip; While the TV tower upgrades are expected to improve the TV reception, some households will still have trouble (even if they have proper antenna equipment and installation) because TV signals get obstructed by the hilly countryside, trees or buildings. If you still can’t get reliable TV reception, you can join the other 200,000 households across Australia and take advantage of the Viewer Access Satellite Television (VAST) service.</p>
+    <h2 id="what-s-been-the-problem">What’s been the problem?</h2>
+    <p>TV reception in the Hunter area has always been unusually challenging, with mother nature throwing in a few curve balls. The hilly countryside means that a large number of TV tower sites are needed to provide adequate television coverage, and the addition of a weather phenomenon called ‘seasonal ducting’ (see below) has also played a part.</p>
+    <p>Apart from these things we can’t control, poor antenna installation and cabling, wrongly located antennas, and incorrect receiver tuning are also to blame for reception difficulties.</p>
 
-      <p>Launched in 2010, VAST was established by the Australian Government to provide households without reliable terrestrial television reception with access to a range of standard and HD digital services. Channels on VAST include ABC 1 (NSW), ABC 2/ABC 4 Kids, ABC 3, ABC NEWS 24, SBS, SBS 2, SBS HD and NITV. Nine commercial digital channels are provided by Imparja Television and Southern Cross Austereo, drawing on programs from the Seven, Nine and Ten networks. <abbr>VAST</abbr> also provides dedicated news channels carrying bulletins from regional commercial television broadcasters, including bulletins from <abbr>NBN</abbr> Central Coast and <abbr>NBN</abbr> Newcastle. A range of <abbr>ABC</abbr> and <abbr>SBS</abbr> radio services is also available via <abbr>VAST</abbr>.</p>
+    <h3 id="seasonal-ducting-what-is-it">Seasonal ducting&mdash;what is it?</h3>
+    <p>Even with correct antenna installation, some viewers in the Hunter region may still have experienced poor TV reception because of the natural phenomenon known as atmospheric or signal ducting.</p>
+    <p>Atmospheric ducting of TV signals happens when distinctive weather conditions—especially high-pressure systems and still conditions—causes distant broadcast signals to travel further than planned. These unintended ‘rogue’ signals then interfere with local signals because antennas and receivers can’t differentiate between the local signals and those being ducted from distant TV towers. Ducting interference affects mainly households in the townships north of Newcastle that receive services from Mount Sugarloaf, as Mount Sugarloaf services operate on the same channels as the high power transmission site that serves the Illawarra area to the south of Sydney.</p>
+    <p>Summer is the most common time for ducting to occur, but it can happen at any time if conditions are right. You may be able to tell it’s ducting if your TV reception is affected in the late afternoon or early evening.</p>
 
-      <p>While there are no subscription costs, reception of the VAST service requires the installation of satellite reception equipment and a VAST set-top box.</p>
+    <h2 id="so-what-s-the-fix">So, what’s the fix?</h2>
+    <h3 id="new-infrastructure">New infrastructure</h3>
+    <p>The regional TV commercial broadcasters have put forward a plan that the Federal Government is supporting towards alleviating this ducting issue and improve coverage in some parts. They will do this by investing in new transmission infrastructure at three sites identified by the broadcasters:</p>
 
-      <h2>Related news</h2>
-      <ul class="list-horizontal">
-        <li>
-          <article>
-            <h3><a href="#content">Catalyst—Australian Arts and Culture Fund supports more than 70 innovative projects</a></h3>
-            <div class="meta"><time datetime="2016-05-02 00:00">Date published: 2 May 2016</time></div>
-            <p>$10 million for more than 70 projects through the Catalyst Australian Arts and Culture Fund.</p>
-          </article>
-        </li>
+    <ul>
+      <li>Port Stephens residents will have their existing TV tower upgraded to increase power and extend coverage</li>
+      <li>Bulahdelah residents will have a new TV tower established</li>
+      <li>Medowie, Salt Ash and the lower Tilligerry Peninsula residents will have a new TV tower established at Wallaroo.</li>
+    </ul>
 
-        <li>
-          <article>
-            <h3><a href="#content">New eSafety Women website launched</a></h3>
-            <div class="meta"><time datetime="2016-05-02 00:00">Date published: 2 May 2016</time></div>
-            <p>A new website which empowers women to take control online and protect themselves from technology-facilitated abuse</p>
-          </article>
-        </li>
-      </ul>
-      <p><a class="see-more" href="news-listing.html">See all Government news</a></p>
+    <p>By using different channels, these towers (as well as Anna Bay) will provide an alternative TV source that is reliable and not affected by the ducting.</p>
 
-    </article>
-    <!-- ========== end Content ========== -->
-  </main>
+    <p>The new and upgraded services are all expected to be in operation by early 2016.</p>
+
+    <h2 id="the-hills-are-alive-is-there-another-alternative">The hills are alive&mdash;is there another alternative?</h2>
+    <p>Those pesky trees&hellip; While the TV tower upgrades are expected to improve the TV reception, some households will still have trouble (even if they have proper antenna equipment and installation) because TV signals get obstructed by the hilly countryside, trees or buildings. If you still can’t get reliable TV reception, you can join the other 200,000 households across Australia and take advantage of the Viewer Access Satellite Television (VAST) service.</p>
+
+    <p>Launched in 2010, VAST was established by the Australian Government to provide households without reliable terrestrial television reception with access to a range of standard and HD digital services. Channels on VAST include ABC 1 (NSW), ABC 2/ABC 4 Kids, ABC 3, ABC NEWS 24, SBS, SBS 2, SBS HD and NITV. Nine commercial digital channels are provided by Imparja Television and Southern Cross Austereo, drawing on programs from the Seven, Nine and Ten networks. <abbr>VAST</abbr> also provides dedicated news channels carrying bulletins from regional commercial television broadcasters, including bulletins from <abbr>NBN</abbr> Central Coast and <abbr>NBN</abbr> Newcastle. A range of <abbr>ABC</abbr> and <abbr>SBS</abbr> radio services is also available via <abbr>VAST</abbr>.</p>
+
+    <p>While there are no subscription costs, reception of the VAST service requires the installation of satellite reception equipment and a VAST set-top box.</p>
+
+    <h2>Related news</h2>
+    <ul class="list-horizontal">
+      <li>
+        <article>
+          <h3><a href="#content">Catalyst—Australian Arts and Culture Fund supports more than 70 innovative projects</a></h3>
+          <div class="meta"><time datetime="2016-05-02 00:00">Date published: 2 May 2016</time></div>
+          <p>$10 million for more than 70 projects through the Catalyst Australian Arts and Culture Fund.</p>
+        </article>
+      </li>
+
+      <li>
+        <article>
+          <h3><a href="#content">New eSafety Women website launched</a></h3>
+          <div class="meta"><time datetime="2016-05-02 00:00">Date published: 2 May 2016</time></div>
+          <p>A new website which empowers women to take control online and protect themselves from technology-facilitated abuse</p>
+        </article>
+      </li>
+    </ul>
+    <p><a class="see-more" href="news-listing.html">See all Government news</a></p>
+
+  </article>
+  <!-- ========== end Content ========== -->
+</main>
 
 
-  <!-- ========== Page footer ========== -->
-  <footer role="contentinfo">
-    <div class="wrapper">
-      <section class="footer-top">
+<!-- ========== Page footer ========== -->
+<footer role="contentinfo">
+  <div class="wrapper">
+    <section class="footer-top">
+      <nav>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+      </nav>
+    </section>
+    <section>
+      <div class="footer-logo">
+        <img alt="Australian Government Coat of Arms" src="../latest/img/coat-of-arms.png">
+      </div>
+      <div class="footer-links">
         <nav>
           <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
           </ul>
         </nav>
-      </section>
-      <section>
-        <div class="footer-logo">
-          <img alt="Australian Government Coat of Arms" src="../latest/img/coat-of-arms.png">
-        </div>
-        <div class="footer-links">
-          <nav>
-            <ul>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-            </ul>
-          </nav>
-          <p>&copy; Commonwealth of Australia <br>
-          <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE.md" rel="license">Licensed under the MIT License.</a></p>
-        </div>
-      </section>
-    </div>
-  </footer>
-
-</body>
-</html>
+        <p>&copy; Commonwealth of Australia <br>
+        <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE.md" rel="license">Licensed under the MIT License.</a></p>
+      </div>
+    </section>
+  </div>
+</footer>

--- a/examples/news-listing.html
+++ b/examples/news-listing.html
@@ -1,451 +1,396 @@
-<!DOCTYPE html>
-<!--[if IE]><![endif]-->
-<!--[if lt IE 7 ]>
-<html lang="en" class="ie6 no-js">    <![endif]-->
-<!--[if IE 7 ]>
-<html lang="en" class="ie7 no-js">    <![endif]-->
-<!--[if IE 8 ]>
-<html lang="en" class="ie8 no-js">    <![endif]-->
-<!--[if IE 9 ]>
-<html lang="en" class="ie9 no-js">    <![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!-->
-<html lang="en" class="no-js"><!--<![endif]-->
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <!-- viewport declaration must be included in <head> for media queries to work correctly on real devices -->
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>News listing (global)</title>
+<!-- ========== Page header ========== -->
+<header role="banner">
 
-  <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.16/webfont.js"></script>
-  <script>
-    WebFont.load({
-      google: {
-        families: ['Open+Sans:400italic,700,400:latin,latin-ext']
-      }
-    });
-  </script>
-
-  <link rel="stylesheet" type="text/css" href="../latest/ui-kit.css"/>
-
-  <!--[if lt IE 9]>
-  <script src="//code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ="
-          crossorigin="anonymous"></script>
-  <script type="text/javascript"
-          src="//cdnjs.cloudflare.com/ajax/libs/corysimmons-selectivizr2/1.0.8/selectivizr2.min.js"></script>
-  <![endif]-->
-  <!--[if lte IE 9]>
-  <script type='text/javascript' src='//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js'></script>
-  <script type='text/javascript'
-          src='//cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.3/jquery.xdomainrequest.min.js'></script>
-  <![endif]-->
-
-  <script type="text/javascript" src="../latest/ui-kit.js"></script>
-
-</head>
-<body>
-
-  <nav class="skip-to">
-    <a href="#content">Skip to main content</a> <a href="#nav">Skip to section navigation</a>
-  </nav>
-
-
-  <!-- ========== Page header ========== -->
-  <header role="banner">
-
-    <section class="prerelease-govau--header">
-      <div class="wrapper">
-        <div class="govau--logo">
-          <img src="../latest/img/icons/logo-govau-full-2x.png" alt="gov.au crest logo" width="270"/>
-
-          <div id="test" class="brandbar default"><!--ID is temp for example-->
-            <div class="b1"></div>
-            <div class="b2"></div>
-          </div>
-        </div>
-
-        <div class="feedback" tabindex="1">
-          <a href="#content" class="button--feedback">Give feedback</a>
-        </div>
-
-      </div><!--wrapper-->
-
-      <nav class="breadcrumbs--inverted" aria-label="breadcrumb">
-        <div class="wrapper">
-          <ul>
-              <li><a href="#content">Home</a></li>
-              <li class="current">News</li>
-          </ul>
-        </div>
-      </nav>
-
-    </section>
-  </header>
-
-
-  <!-- ========== Hero ========== -->
-  <div class="hero-med">
+  <section class="prerelease-govau--header">
     <div class="wrapper">
-      <h1>News</h1>
-      <p>Announcements, media releases, interviews, speeches and more from the Australian Government.</p>
-    </div>
-  </div>
+      <div class="govau--logo">
+        <img src="../latest/img/icons/logo-govau-full-2x.png" alt="gov.au crest logo" width="270"/>
 
+        <div id="test" class="brandbar default"><!--ID is temp for example-->
+          <div class="b1"></div>
+          <div class="b2"></div>
+        </div>
+      </div>
 
-  <!-- ========== Main Page Row ========== -->
-  <main class="sidebar-has-controls">
+      <div class="feedback" tabindex="1">
+        <a href="#content" class="button--feedback">Give feedback</a>
+      </div>
 
-    <aside class="sidebar" id="nav">
-      <!-- ========== Nav ========== -->
-      <nav>
-        <h2>Refine by:</h2>
-        <p><a href="#content">{{Clear all}}</a></p>
-        <p><a href="#content">{{Collapse/expand all}}</a></p>
+    </div><!--wrapper-->
 
-        <form>
-          <details open data-label="accordion-topic-filter" aria-expanded="true">
-            <summary>Topic</summary>
-            <div class="accordion-panel">
-              <fieldset>
-
-                <legend class="is-visuallyhidden">Filter by Topic</legend>
-
-                <input id="aaa" name="reply" type="checkbox" value="AAA"/>
-                <label for="aaa">All</label>
-
-                <input id="bbb" name="reply" type="checkbox" value="BBB"/>
-                <label for="bbb">Adoption</label>
-
-                <input id="ccc" name="reply" type="checkbox" value="CCC"/>
-                <label for="ccc">Ageing and aged care</label>
-
-                <input id="ddd" name="reply" type="checkbox" value="DDD"/>
-                <label for="ddd">Bullying</label>
-
-                <input id="eee" name="reply" type="checkbox" value="EEE"/>
-                <label for="eee">Consumer protection</label>
-
-                <input id="fff" name="reply" type="checkbox" value="FFF"/>
-                <label for="fff">Cybersecurity</label>
-
-                <input id="ggg" name="reply" type="checkbox" value="GGG"/>
-                <label for="ggg">Food standards and safety</label>
-
-                <input id="hhh" name="reply" type="checkbox" value="HHH"/>
-                <label for="hhh">Visiting Australia</label>
-
-                <input id="iii" name="reply" type="checkbox" value="III"/>
-                <label for="iii">Working in Australia</label>
-
-              </fieldset>
-            </div>
-          </details>
-
-          <details open data-label="accordion-topic-filter-2" aria-expanded="true">
-            <summary>Department</summary>
-            <div class="accordion-panel">
-              <fieldset>
-                <legend class="is-visuallyhidden">Filter by Topic</legend>
-
-                <input id="aaa1" name="reply" type="checkbox" value="AAA1"/>
-                <label for="aaa1">All</label>
-
-                <input id="bbb1" name="reply" type="checkbox" value="BBB1"/>
-                <label for="bbb1">Aged Care</label>
-
-                <input id="ccc1" name="reply" type="checkbox" value="CCC1"/>
-                <label for="ccc1">The Arts</label>
-
-                <input id="ddd1" name="reply" type="checkbox" value="DDD1"/>
-                <label for="ddd1">Communications</label>
-
-                <input id="eee1" name="reply" type="checkbox" value="EEE1"/>
-                <label for="eee1">Finance</label>
-
-                <input id="fff1" name="reply" type="checkbox" value="FFF1"/>
-                <label for="fff1">Health</label>
-
-                <input id="ggg1" name="reply" type="checkbox" value="GGG1"/>
-                <label for="ggg1">Human Services</label>
-
-                <input id="hhh1" name="reply" type="checkbox" value="HHH1"/>
-                <label for="hhh1">Immigration and Border Protection</label>
-
-                <input id="iii1" name="reply" type="checkbox" value="III1"/>
-                <label for="iii1">Industry, Innovation and Science</label>
-
-                <input id="jjj1" name="reply" type="checkbox" value="JJJ1"/>
-                <label for="jjj1">Small Business</label>
-
-                <input id="kkk1" name="reply" type="checkbox" value="KKK1"/>
-                <label for="kkk1">Social Services</label>
-
-                <input id="lll1" name="reply" type="checkbox" value="LLL1"/>
-                <label for="lll1">Sport</label>
-
-              </fieldset>
-            </div>
-          </details>
-
-          <details open data-label="accordion-date-filter" aria-expanded="true">
-            <summary>Date</summary>
-            <div class="accordion-panel">
-              <fieldset>
-                <legend class="is-visuallyhidden">Filter by date</legend>
-
-                <input id="jjj" name="date" type="radio" value="JJJ"/>
-                <label for="jjj">Last week</label>
-
-                <input id="kkk" name="date" type="radio" value="KKK"/>
-                <label for="kkk">Last month</label>
-
-                <input id="lll" name="date" type="radio" value="LLL"/>
-                <label for="lll">Last 3 months</label>
-
-                <input id="mmm" name="date" type="radio" value="MMM"/>
-                <label for="mmm">Last year</label>
-
-              </fieldset>
-            </div>
-          </details>
-
-          <button role="button">Update news results</button>
-        </form>
-      </nav>
-      <!-- ========== end Nav ========== -->
-    </aside>
-
-    <!-- ========== Content ========== -->
-    <article id="content" class="content-main">
-
-      <nav class="inline-nav">
-        <h3>Sort by:</h3>
+    <nav class="breadcrumbs--inverted" aria-label="breadcrumb">
+      <div class="wrapper">
         <ul>
-          <li><a href="#content"><span class="is-visuallyhidden">Sort by </span>Most recent</a></li>
-          <li><a href="#content"><span class="is-visuallyhidden">Sort by </span>Oldest to newest</a></li>
-          <li><a href="#content"><span class="is-visuallyhidden">Sort by </span>A to Z</a></li>
+            <li><a href="#content">Home</a></li>
+            <li class="current">News</li>
+        </ul>
+      </div>
+    </nav>
+
+  </section>
+</header>
+
+
+<!-- ========== Hero ========== -->
+<div class="hero-med">
+  <div class="wrapper">
+    <h1>News</h1>
+    <p>Announcements, media releases, interviews, speeches and more from the Australian Government.</p>
+  </div>
+</div>
+
+
+<!-- ========== Main Page Row ========== -->
+<main class="sidebar-has-controls">
+
+  <aside class="sidebar" id="nav">
+    <!-- ========== Nav ========== -->
+    <nav>
+      <h2>Refine by:</h2>
+      <p><a href="#content">{{Clear all}}</a></p>
+      <p><a href="#content">{{Collapse/expand all}}</a></p>
+
+      <form>
+        <details open data-label="accordion-topic-filter" aria-expanded="true">
+          <summary>Topic</summary>
+          <div class="accordion-panel">
+            <fieldset>
+
+              <legend class="is-visuallyhidden">Filter by Topic</legend>
+
+              <input id="aaa" name="reply" type="checkbox" value="AAA"/>
+              <label for="aaa">All</label>
+
+              <input id="bbb" name="reply" type="checkbox" value="BBB"/>
+              <label for="bbb">Adoption</label>
+
+              <input id="ccc" name="reply" type="checkbox" value="CCC"/>
+              <label for="ccc">Ageing and aged care</label>
+
+              <input id="ddd" name="reply" type="checkbox" value="DDD"/>
+              <label for="ddd">Bullying</label>
+
+              <input id="eee" name="reply" type="checkbox" value="EEE"/>
+              <label for="eee">Consumer protection</label>
+
+              <input id="fff" name="reply" type="checkbox" value="FFF"/>
+              <label for="fff">Cybersecurity</label>
+
+              <input id="ggg" name="reply" type="checkbox" value="GGG"/>
+              <label for="ggg">Food standards and safety</label>
+
+              <input id="hhh" name="reply" type="checkbox" value="HHH"/>
+              <label for="hhh">Visiting Australia</label>
+
+              <input id="iii" name="reply" type="checkbox" value="III"/>
+              <label for="iii">Working in Australia</label>
+
+            </fieldset>
+          </div>
+        </details>
+
+        <details open data-label="accordion-topic-filter-2" aria-expanded="true">
+          <summary>Department</summary>
+          <div class="accordion-panel">
+            <fieldset>
+              <legend class="is-visuallyhidden">Filter by Topic</legend>
+
+              <input id="aaa1" name="reply" type="checkbox" value="AAA1"/>
+              <label for="aaa1">All</label>
+
+              <input id="bbb1" name="reply" type="checkbox" value="BBB1"/>
+              <label for="bbb1">Aged Care</label>
+
+              <input id="ccc1" name="reply" type="checkbox" value="CCC1"/>
+              <label for="ccc1">The Arts</label>
+
+              <input id="ddd1" name="reply" type="checkbox" value="DDD1"/>
+              <label for="ddd1">Communications</label>
+
+              <input id="eee1" name="reply" type="checkbox" value="EEE1"/>
+              <label for="eee1">Finance</label>
+
+              <input id="fff1" name="reply" type="checkbox" value="FFF1"/>
+              <label for="fff1">Health</label>
+
+              <input id="ggg1" name="reply" type="checkbox" value="GGG1"/>
+              <label for="ggg1">Human Services</label>
+
+              <input id="hhh1" name="reply" type="checkbox" value="HHH1"/>
+              <label for="hhh1">Immigration and Border Protection</label>
+
+              <input id="iii1" name="reply" type="checkbox" value="III1"/>
+              <label for="iii1">Industry, Innovation and Science</label>
+
+              <input id="jjj1" name="reply" type="checkbox" value="JJJ1"/>
+              <label for="jjj1">Small Business</label>
+
+              <input id="kkk1" name="reply" type="checkbox" value="KKK1"/>
+              <label for="kkk1">Social Services</label>
+
+              <input id="lll1" name="reply" type="checkbox" value="LLL1"/>
+              <label for="lll1">Sport</label>
+
+            </fieldset>
+          </div>
+        </details>
+
+        <details open data-label="accordion-date-filter" aria-expanded="true">
+          <summary>Date</summary>
+          <div class="accordion-panel">
+            <fieldset>
+              <legend class="is-visuallyhidden">Filter by date</legend>
+
+              <input id="jjj" name="date" type="radio" value="JJJ"/>
+              <label for="jjj">Last week</label>
+
+              <input id="kkk" name="date" type="radio" value="KKK"/>
+              <label for="kkk">Last month</label>
+
+              <input id="lll" name="date" type="radio" value="LLL"/>
+              <label for="lll">Last 3 months</label>
+
+              <input id="mmm" name="date" type="radio" value="MMM"/>
+              <label for="mmm">Last year</label>
+
+            </fieldset>
+          </div>
+        </details>
+
+        <button role="button">Update news results</button>
+      </form>
+    </nav>
+    <!-- ========== end Nav ========== -->
+  </aside>
+
+  <!-- ========== Content ========== -->
+  <article id="content" class="content-main">
+
+    <nav class="inline-nav">
+      <h3>Sort by:</h3>
+      <ul>
+        <li><a href="#content"><span class="is-visuallyhidden">Sort by </span>Most recent</a></li>
+        <li><a href="#content"><span class="is-visuallyhidden">Sort by </span>Oldest to newest</a></li>
+        <li><a href="#content"><span class="is-visuallyhidden">Sort by </span>A to Z</a></li>
+      </ul>
+    </nav>
+
+    <ul class="list-horizontal">
+      <li>
+        <article>
+          <h3><a href="#content">Sky News First Edition interview with Senator Mathias Cormann</a></h3>
+          <div class="meta">
+            <time datetime="2016-07-29">29 July 2016</time>
+            <a rel="author" href="#content">Minister for Finance</a> </div>
+          <p> A transcript of the interview by journalist Kieran Gilbert on topics including Kevin Rudd and the United Nations, immigration and the Royal Commission into Northern Territory Youth Detention.</p>
+          <footer class="tags">
+            <dl>
+              <dt>Topics:</dt>
+                <dd><a href="#content">Television (TV) reception</a></dd>
+                <dd><a href="#content">Tag Name</a></dd>
+            </dl>
+          </footer>
+        </article>
+      </li>
+
+      <li>
+        <article>
+          <h3><a href="#content">Minister for Health and Aged Care welcomes Whitecoat joint venture</a></h3>
+          <div class="meta">
+            <time datetime="2016-07-29">29 July 2016</time>
+            <a rel="author" href="#content">Minister for Health and Aged Care</a> </div>
+          <p> Minister Ley welcomes the announcement from some private health insurers that more information will be made available to Australians about their health services.</p>
+          <footer class="tags">
+            <dl>
+              <dt>Topics:</dt>
+                <dd><a href="#content">Television (TV) reception</a></dd>
+                <dd><a href="#content">Tag Name</a></dd>
+            </dl>
+          </footer>
+        </article>
+      </li>
+
+      <li>
+        <article>
+          <h3><a href="#content">Border clearance advice for religious pilgrims</a></h3>
+          <div class="meta">
+            <time datetime="2016-07-29">29 July 2016</time>
+            <a rel="author" href="#content">Department of Immigration and Border Protection</a>
+          </div>
+          <p> We recognise the importance of religious events such as the Hajj, Umrah and Arba’een and the right to travel for such events.</p>
+          <footer class="tags">
+            <dl>
+              <dt>Topics:</dt>
+                <dd><a href="#content">Television (TV) reception</a></dd>
+                <dd><a href="#content">Tag Name</a></dd>
+            </dl>
+          </footer>
+        </article>
+      </li>
+
+      <li>
+        <article>
+          <h3><a href="#content">Nola Marino re-appointed as Chief Government Whip</a></h3>
+          <div class="meta">
+            <time datetime="2016-07-29">29 July 2016</time>
+            <a rel="author" href="#content">Prime Minister</a> </div>
+          <p> I am pleased to announce the re-appointment of Ms Nola Marino as the Chief Government Whip.</p>
+          <footer class="tags">
+            <dl>
+              <dt>Topics:</dt>
+                <dd><a href="#content">Television (TV) reception</a></dd>
+                <dd><a href="#content">Tag Name</a></dd>
+            </dl>
+          </footer>
+        </article>
+      </li>
+
+      <li>
+        <article>
+          <h3><a href="#content">Thousands of Australians now free of Hepatitis C</a></h3>
+          <div class="meta">
+            <time datetime="2016-07-28">28 July 2016</time>
+            <a rel="author" href="#content">Minister for Health and Aged Care</a> </div>
+          <p> The Australian Government’s commitment to put an end to the Hep C virus is paying off.</p>
+          <footer class="tags">
+            <dl>
+              <dt>Topics:</dt>
+                <dd><a href="#content">Television (TV) reception</a></dd>
+                <dd><a href="#content">Tag Name</a></dd>
+            </dl>
+          </footer>
+        </article>
+      </li>
+
+      <li>
+        <article>
+          <h3><a href="#content">Immigration and customs functions in Norfolk Island</a></h3>
+          <div class="meta">
+            <time datetime="2016-07-11">11 July 2016</time>
+            <a rel="author" href="#content">Department of Immigration and Border Protection</a> </div>
+          <p> The Department of Immigration and Border Protection is delivering immigration and customs functions on Norfolk Island.</p>
+          <footer class="tags">
+            <dl>
+              <dt>Topics:</dt>
+                <dd><a href="#content">Television (TV) reception</a></dd>
+                <dd><a href="#content">Tag Name</a></dd>
+            </dl>
+          </footer>
+        </article>
+      </li>
+
+      <li>
+        <article>
+          <h3><a href="#content">Whole of Australian Government (WoAG) Accommodation Arrangement</a></h3>
+          <div class="meta">
+            <time datetime="2016-05-10">10 May 2016</time>
+            <a rel="author" href="#content">Department of Finance</a> </div>
+          <p> The Department of Finance is seeking comments on a discussion paper that may shape a future accommodation program for the Australian Government.</p>
+          <footer class="tags">
+            <dl>
+              <dt>Topics:</dt>
+                <dd><a href="#content">Television (TV) reception</a></dd>
+                <dd><a href="#content">Tag Name</a></dd>
+            </dl>
+          </footer>
+        </article>
+      </li>
+
+      <li>
+        <article>
+          <h3><a href="#content">Aged under 15: what does it mean for classifications?</a></h3>
+          <div class="meta">
+            <time datetime="2016-05-06">06 May 2016</time>
+            <a rel="author" href="agency-landing.html">Department of Communications and the Arts</a> </div>
+          <p> Classifications help you to make informed decisions about what you and your children see and play.</p>
+          <footer class="tags">
+            <dl>
+              <dt>Topics:</dt>
+                <dd><a href="#content">Television (TV) reception</a></dd>
+                <dd><a href="#content">Tag Name</a></dd>
+            </dl>
+          </footer>
+        </article>
+      </li>
+
+      <li>
+        <article>
+          <h3><a href="#content">Sydney – final countdown to digital-only TV has begun</a></h3>
+          <div class="meta">
+            <time datetime="2013-11-13">13 November 2013</time>
+            <a rel="author" href="ministers-landing.html">Minister for Communications</a> </div>
+          <p> Sydney and surrounding areas will switch to digital-only TV at 9am on 3 December 2013.</p>
+          <footer class="tags">
+            <dl>
+              <dt>Topics:</dt>
+                <dd><a href="#content">Television (TV) reception</a></dd>
+                <dd><a href="#content">Tag Name</a></dd>
+            </dl>
+          </footer>
+        </article>
+      </li>
+
+    </ul>
+
+    <h1>{{Pagination}}</h1>
+
+  </article>
+  <!-- ========== end Content ========== -->
+</main>
+
+
+<!-- ========== Page footer ========== -->
+<footer role="contentinfo">
+  <div class="wrapper">
+    <section class="footer-top">
+      <nav>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
         </ul>
       </nav>
-
-      <ul class="list-horizontal">
-        <li>
-          <article>
-            <h3><a href="#content">Sky News First Edition interview with Senator Mathias Cormann</a></h3>
-            <div class="meta">
-              <time datetime="2016-07-29">29 July 2016</time>
-              <a rel="author" href="#content">Minister for Finance</a> </div>
-            <p> A transcript of the interview by journalist Kieran Gilbert on topics including Kevin Rudd and the United Nations, immigration and the Royal Commission into Northern Territory Youth Detention.</p>
-            <footer class="tags">
-              <dl>
-                <dt>Topics:</dt>
-                  <dd><a href="#content">Television (TV) reception</a></dd>
-                  <dd><a href="#content">Tag Name</a></dd>
-              </dl>
-            </footer>
-          </article>
-        </li>
-
-        <li>
-          <article>
-            <h3><a href="#content">Minister for Health and Aged Care welcomes Whitecoat joint venture</a></h3>
-            <div class="meta">
-              <time datetime="2016-07-29">29 July 2016</time>
-              <a rel="author" href="#content">Minister for Health and Aged Care</a> </div>
-            <p> Minister Ley welcomes the announcement from some private health insurers that more information will be made available to Australians about their health services.</p>
-            <footer class="tags">
-              <dl>
-                <dt>Topics:</dt>
-                  <dd><a href="#content">Television (TV) reception</a></dd>
-                  <dd><a href="#content">Tag Name</a></dd>
-              </dl>
-            </footer>
-          </article>
-        </li>
-
-        <li>
-          <article>
-            <h3><a href="#content">Border clearance advice for religious pilgrims</a></h3>
-            <div class="meta">
-              <time datetime="2016-07-29">29 July 2016</time>
-              <a rel="author" href="#content">Department of Immigration and Border Protection</a>
-            </div>
-            <p> We recognise the importance of religious events such as the Hajj, Umrah and Arba’een and the right to travel for such events.</p>
-            <footer class="tags">
-              <dl>
-                <dt>Topics:</dt>
-                  <dd><a href="#content">Television (TV) reception</a></dd>
-                  <dd><a href="#content">Tag Name</a></dd>
-              </dl>
-            </footer>
-          </article>
-        </li>
-
-        <li>
-          <article>
-            <h3><a href="#content">Nola Marino re-appointed as Chief Government Whip</a></h3>
-            <div class="meta">
-              <time datetime="2016-07-29">29 July 2016</time>
-              <a rel="author" href="#content">Prime Minister</a> </div>
-            <p> I am pleased to announce the re-appointment of Ms Nola Marino as the Chief Government Whip.</p>
-            <footer class="tags">
-              <dl>
-                <dt>Topics:</dt>
-                  <dd><a href="#content">Television (TV) reception</a></dd>
-                  <dd><a href="#content">Tag Name</a></dd>
-              </dl>
-            </footer>
-          </article>
-        </li>
-
-        <li>
-          <article>
-            <h3><a href="#content">Thousands of Australians now free of Hepatitis C</a></h3>
-            <div class="meta">
-              <time datetime="2016-07-28">28 July 2016</time>
-              <a rel="author" href="#content">Minister for Health and Aged Care</a> </div>
-            <p> The Australian Government’s commitment to put an end to the Hep C virus is paying off.</p>
-            <footer class="tags">
-              <dl>
-                <dt>Topics:</dt>
-                  <dd><a href="#content">Television (TV) reception</a></dd>
-                  <dd><a href="#content">Tag Name</a></dd>
-              </dl>
-            </footer>
-          </article>
-        </li>
-
-        <li>
-          <article>
-            <h3><a href="#content">Immigration and customs functions in Norfolk Island</a></h3>
-            <div class="meta">
-              <time datetime="2016-07-11">11 July 2016</time>
-              <a rel="author" href="#content">Department of Immigration and Border Protection</a> </div>
-            <p> The Department of Immigration and Border Protection is delivering immigration and customs functions on Norfolk Island.</p>
-            <footer class="tags">
-              <dl>
-                <dt>Topics:</dt>
-                  <dd><a href="#content">Television (TV) reception</a></dd>
-                  <dd><a href="#content">Tag Name</a></dd>
-              </dl>
-            </footer>
-          </article>
-        </li>
-
-        <li>
-          <article>
-            <h3><a href="#content">Whole of Australian Government (WoAG) Accommodation Arrangement</a></h3>
-            <div class="meta">
-              <time datetime="2016-05-10">10 May 2016</time>
-              <a rel="author" href="#content">Department of Finance</a> </div>
-            <p> The Department of Finance is seeking comments on a discussion paper that may shape a future accommodation program for the Australian Government.</p>
-            <footer class="tags">
-              <dl>
-                <dt>Topics:</dt>
-                  <dd><a href="#content">Television (TV) reception</a></dd>
-                  <dd><a href="#content">Tag Name</a></dd>
-              </dl>
-            </footer>
-          </article>
-        </li>
-
-        <li>
-          <article>
-            <h3><a href="#content">Aged under 15: what does it mean for classifications?</a></h3>
-            <div class="meta">
-              <time datetime="2016-05-06">06 May 2016</time>
-              <a rel="author" href="agency-landing.html">Department of Communications and the Arts</a> </div>
-            <p> Classifications help you to make informed decisions about what you and your children see and play.</p>
-            <footer class="tags">
-              <dl>
-                <dt>Topics:</dt>
-                  <dd><a href="#content">Television (TV) reception</a></dd>
-                  <dd><a href="#content">Tag Name</a></dd>
-              </dl>
-            </footer>
-          </article>
-        </li>
-
-        <li>
-          <article>
-            <h3><a href="#content">Sydney – final countdown to digital-only TV has begun</a></h3>
-            <div class="meta">
-              <time datetime="2013-11-13">13 November 2013</time>
-              <a rel="author" href="ministers-landing.html">Minister for Communications</a> </div>
-            <p> Sydney and surrounding areas will switch to digital-only TV at 9am on 3 December 2013.</p>
-            <footer class="tags">
-              <dl>
-                <dt>Topics:</dt>
-                  <dd><a href="#content">Television (TV) reception</a></dd>
-                  <dd><a href="#content">Tag Name</a></dd>
-              </dl>
-            </footer>
-          </article>
-        </li>
-
-      </ul>
-
-      <h1>{{Pagination}}</h1>
-
-    </article>
-    <!-- ========== end Content ========== -->
-  </main>
-
-
-  <!-- ========== Page footer ========== -->
-  <footer role="contentinfo">
-    <div class="wrapper">
-      <section class="footer-top">
+    </section>
+    <section>
+      <div class="footer-logo">
+        <img alt="Australian Government Coat of Arms" src="../latest/img/coat-of-arms.png">
+      </div>
+      <div class="footer-links">
         <nav>
           <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
           </ul>
         </nav>
-      </section>
-      <section>
-        <div class="footer-logo">
-          <img alt="Australian Government Coat of Arms" src="../latest/img/coat-of-arms.png">
-        </div>
-        <div class="footer-links">
-          <nav>
-            <ul>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-            </ul>
-          </nav>
-          <p>&copy; Commonwealth of Australia <br>
-          <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE.md">Licensed under the MIT License.</a></p>
-        </div>
-      </section>
-    </div>
-  </footer>
-
-</body>
-</html>
+        <p>&copy; Commonwealth of Australia <br>
+        <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE.md">Licensed under the MIT License.</a></p>
+      </div>
+    </section>
+  </div>
+</footer>

--- a/examples/news-section-listing.html
+++ b/examples/news-section-listing.html
@@ -1,241 +1,186 @@
-<!DOCTYPE html>
-<!--[if IE]><![endif]-->
-<!--[if lt IE 7 ]>
-<html lang="en" class="ie6 no-js">    <![endif]-->
-<!--[if IE 7 ]>
-<html lang="en" class="ie7 no-js">    <![endif]-->
-<!--[if IE 8 ]>
-<html lang="en" class="ie8 no-js">    <![endif]-->
-<!--[if IE 9 ]>
-<html lang="en" class="ie9 no-js">    <![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!-->
-<html lang="en" class="no-js"><!--<![endif]-->
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <!-- viewport declaration must be included in <head> for media queries to work correctly on real devices -->
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>News listing section</title>
+<!-- ========== Page header ========== -->
+<header role="banner">
 
-  <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.16/webfont.js"></script>
-  <script>
-    WebFont.load({
-      google: {
-        families: ['Open+Sans:400italic,700,400:latin,latin-ext']
-      }
-    });
-  </script>
-
-  <link rel="stylesheet" type="text/css" href="../latest/ui-kit.css"/>
-
-  <!--[if lt IE 9]>
-  <script src="//code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ="
-          crossorigin="anonymous"></script>
-  <script type="text/javascript"
-          src="//cdnjs.cloudflare.com/ajax/libs/corysimmons-selectivizr2/1.0.8/selectivizr2.min.js"></script>
-  <![endif]-->
-  <!--[if lte IE 9]>
-  <script type='text/javascript' src='//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js'></script>
-  <script type='text/javascript'
-          src='//cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.3/jquery.xdomainrequest.min.js'></script>
-  <![endif]-->
-
-  <script type="text/javascript" src="../latest/ui-kit.js"></script>
-
-</head>
-<body>
-
-  <nav class="skip-to">
-    <a href="#content">Skip to main content</a> <a href="#nav">Skip to section navigation</a>
-  </nav>
-
-
-  <!-- ========== Page header ========== -->
-  <header role="banner">
-
-    <section class="prerelease-govau--header">
-      <div class="wrapper">
-        <div class="govau--logo">
-          <img src="../latest/img/icons/logo-govau-full-2x.png" alt="gov.au crest logo" width="270"/>
-
-          <div id="test" class="brandbar default"><!--ID is temp for example-->
-            <div class="b1"></div>
-            <div class="b2"></div>
-          </div>
-        </div>
-
-        <div class="feedback" tabindex="1">
-          <a href="#content" class="button--feedback">Give feedback</a>
-        </div>
-
-      </div><!--wrapper-->
-
-      <nav class="breadcrumbs--inverted" aria-label="breadcrumb">
-        <div class="wrapper">
-          <ul>
-            <li><a href="#content">Home</a></li>
-            <li><a href="ministers-landing.html">Minister for Communications</a></li>
-            <li class="current">News</li>
-          </ul>
-        </div>
-      </nav>
-
-    </section>
-  </header>
-
-
-  <!-- ========== Hero ========== -->
-  <div class="hero-sml corporate">
+  <section class="prerelease-govau--header">
     <div class="wrapper">
-      <p>Minister for Communications</p>
-    </div>
-  </div>
+      <div class="govau--logo">
+        <img src="../latest/img/icons/logo-govau-full-2x.png" alt="gov.au crest logo" width="270"/>
 
+        <div id="test" class="brandbar default"><!--ID is temp for example-->
+          <div class="b1"></div>
+          <div class="b2"></div>
+        </div>
+      </div>
 
-  <!-- ========== Main page row ========== -->
-  <main role="main">
-    <aside class="sidebar" id="nav">
+      <div class="feedback" tabindex="1">
+        <a href="#content" class="button--feedback">Give feedback</a>
+      </div>
 
-      <!-- ========== Nav ========== -->
-      <nav class="local-nav" aria-label="main navigation">
-        <h1 class="is-visuallyhidden">Menu</h1>
+    </div><!--wrapper-->
+
+    <nav class="breadcrumbs--inverted" aria-label="breadcrumb">
+      <div class="wrapper">
         <ul>
-          <li><a class="is-active" href="ministers-landing.html">Minister for Communications</a>
-            <ul>
-              <li><a href="ministers-content.html">Responsibilities</a></li>
-              <li><a href="#content">About the minister</a></li>
-              <li><a href="#content" class="is-active is-current">News</a></li>
-              <li><a href="#content">Contact</a></li>
-            </ul>
-          </li>
+          <li><a href="#content">Home</a></li>
+          <li><a href="ministers-landing.html">Minister for Communications</a></li>
+          <li class="current">News</li>
         </ul>
-      </nav>
+      </div>
+    </nav>
 
-    </aside>
+  </section>
+</header>
 
 
-    <!-- ========== Content ========== -->
-    <article id="content" class="content-main">
-      <header>
-        <h1>News</h1>
-      </header>
+<!-- ========== Hero ========== -->
+<div class="hero-sml corporate">
+  <div class="wrapper">
+    <p>Minister for Communications</p>
+  </div>
+</div>
 
-      <ul class="list-horizontal">
-        <li>
-          <article>
-            <h3><a href="#content">Australian Government support for Confluence: Festival of India 2016</a></h3>
-            <div class="meta">
-              <time datetime="2016-07-26">26 July 2016</time>
-              <a rel="author" href="#content">Minister for Communications</a>
-            </div>
-            <p> The government has announced $250,000 to support the most significant showcase of India’s arts and culture to be staged in Australia.</p>
-            <footer class="tags">
-              <dl>
-                <dt>Topics:</dt>
-                  <dd><a href="#content">Television (TV) reception</a></dd>
-                  <dd><a href="#content">Tag Name</a></dd>
-              </dl>
-            </footer>
-          </article>
-        </li>
 
-        <li>
-          <article>
-            <h3><a href="#content">Year of achievement for Children’s eSafety Commissioner</a></h3>
-            <div class="meta">
-              <time datetime="2016-07-26">26 July 2016</time>
-              <a rel="author" href="#content">Minister for Communications</a>
-            </div>
-            <p> A first-year report card by the Office of the Children's eSafety Commissioner.</p>
-            <footer class="tags">
-              <dl>
-                <dt>Topics:</dt>
-                  <dd><a href="#content">Television (TV) reception</a></dd>
-                  <dd><a href="#content">Tag Name</a></dd>
-              </dl>
-            </footer>
-          </article>
-        </li>
+<!-- ========== Main page row ========== -->
+<main role="main">
+  <aside class="sidebar" id="nav">
 
-        <li>
-          <article>
-            <h3><a href="#content">Sydney – final countdown to digital-only TV has begun</a></h3>
-            <div class="meta">
-              <time datetime="2013-11-13">13 November 2013</time>
-              <a rel="author" href="#content">Minister for Communications</a>
-            </div>
-            <p>Sydney and surrounding areas will switch to digital-only TV at 9am on 3 December 2013.</p>
-            <footer class="tags">
-              <dl>
-                <dt>Topics:</dt>
-                  <dd><a href="#content">Television (TV) reception</a></dd>
-                  <dd><a href="#content">Tag Name</a></dd>
-              </dl>
-            </footer>
-          </article>
+    <!-- ========== Nav ========== -->
+    <nav class="local-nav" aria-label="main navigation">
+      <h1 class="is-visuallyhidden">Menu</h1>
+      <ul>
+        <li><a class="is-active" href="ministers-landing.html">Minister for Communications</a>
+          <ul>
+            <li><a href="ministers-content.html">Responsibilities</a></li>
+            <li><a href="#content">About the minister</a></li>
+            <li><a href="#content" class="is-active is-current">News</a></li>
+            <li><a href="#content">Contact</a></li>
+          </ul>
         </li>
       </ul>
+    </nav>
 
-    </article>
-    <!-- ========== End Content ========== -->
-  </main>
+  </aside>
 
 
-  <!-- ========== footer ========== -->
-  <footer role="contentinfo">
-    <div class="wrapper">
-      <section class="footer-top">
+  <!-- ========== Content ========== -->
+  <article id="content" class="content-main">
+    <header>
+      <h1>News</h1>
+    </header>
+
+    <ul class="list-horizontal">
+      <li>
+        <article>
+          <h3><a href="#content">Australian Government support for Confluence: Festival of India 2016</a></h3>
+          <div class="meta">
+            <time datetime="2016-07-26">26 July 2016</time>
+            <a rel="author" href="#content">Minister for Communications</a>
+          </div>
+          <p> The government has announced $250,000 to support the most significant showcase of India’s arts and culture to be staged in Australia.</p>
+          <footer class="tags">
+            <dl>
+              <dt>Topics:</dt>
+                <dd><a href="#content">Television (TV) reception</a></dd>
+                <dd><a href="#content">Tag Name</a></dd>
+            </dl>
+          </footer>
+        </article>
+      </li>
+
+      <li>
+        <article>
+          <h3><a href="#content">Year of achievement for Children’s eSafety Commissioner</a></h3>
+          <div class="meta">
+            <time datetime="2016-07-26">26 July 2016</time>
+            <a rel="author" href="#content">Minister for Communications</a>
+          </div>
+          <p> A first-year report card by the Office of the Children's eSafety Commissioner.</p>
+          <footer class="tags">
+            <dl>
+              <dt>Topics:</dt>
+                <dd><a href="#content">Television (TV) reception</a></dd>
+                <dd><a href="#content">Tag Name</a></dd>
+            </dl>
+          </footer>
+        </article>
+      </li>
+
+      <li>
+        <article>
+          <h3><a href="#content">Sydney – final countdown to digital-only TV has begun</a></h3>
+          <div class="meta">
+            <time datetime="2013-11-13">13 November 2013</time>
+            <a rel="author" href="#content">Minister for Communications</a>
+          </div>
+          <p>Sydney and surrounding areas will switch to digital-only TV at 9am on 3 December 2013.</p>
+          <footer class="tags">
+            <dl>
+              <dt>Topics:</dt>
+                <dd><a href="#content">Television (TV) reception</a></dd>
+                <dd><a href="#content">Tag Name</a></dd>
+            </dl>
+          </footer>
+        </article>
+      </li>
+    </ul>
+
+  </article>
+  <!-- ========== End Content ========== -->
+</main>
+
+
+<!-- ========== footer ========== -->
+<footer role="contentinfo">
+  <div class="wrapper">
+    <section class="footer-top">
+      <nav>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+      </nav>
+    </section>
+    <section>
+      <div class="footer-logo">
+        <img alt="Australian Government Coat of Arms" src="../latest/img/coat-of-arms.png">
+      </div>
+      <div class="footer-links">
         <nav>
           <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
           </ul>
         </nav>
-      </section>
-      <section>
-        <div class="footer-logo">
-          <img alt="Australian Government Coat of Arms" src="../latest/img/coat-of-arms.png">
-        </div>
-        <div class="footer-links">
-          <nav>
-            <ul>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-            </ul>
-          </nav>
-          <p>&copy; Commonwealth of Australia <br>
-          <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE.md" rel="license">Licensed under the MIT License.</a></p>
-        </div>
-      </section>
-    </div>
-  </footer>
-
-</body>
-</html>
+        <p>&copy; Commonwealth of Australia <br>
+        <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE.md" rel="license">Licensed under the MIT License.</a></p>
+      </div>
+    </section>
+  </div>
+</footer>

--- a/examples/profile.html
+++ b/examples/profile.html
@@ -1,214 +1,159 @@
-<!DOCTYPE html>
-<!--[if IE]><![endif]-->
-<!--[if lt IE 7 ]>
-<html lang="en" class="ie6 no-js">    <![endif]-->
-<!--[if IE 7 ]>
-<html lang="en" class="ie7 no-js">    <![endif]-->
-<!--[if IE 8 ]>
-<html lang="en" class="ie8 no-js">    <![endif]-->
-<!--[if IE 9 ]>
-<html lang="en" class="ie9 no-js">    <![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!-->
-<html lang="en" class="no-js"><!--<![endif]-->
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <!-- viewport declaration must be included in <head> for media queries to work correctly on real devices -->
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Profile</title>
+<!-- ========== Page header ========== -->
+<header role="banner">
 
-  <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.16/webfont.js"></script>
-  <script>
-    WebFont.load({
-      google: {
-        families: ['Open+Sans:400italic,700,400:latin,latin-ext']
-      }
-    });
-  </script>
-
-  <link rel="stylesheet" type="text/css" href="../latest/ui-kit.css"/>
-
-  <!--[if lt IE 9]>
-  <script src="//code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ="
-          crossorigin="anonymous"></script>
-  <script type="text/javascript"
-          src="//cdnjs.cloudflare.com/ajax/libs/corysimmons-selectivizr2/1.0.8/selectivizr2.min.js"></script>
-  <![endif]-->
-  <!--[if lte IE 9]>
-  <script type='text/javascript' src='//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js'></script>
-  <script type='text/javascript'
-          src='//cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.3/jquery.xdomainrequest.min.js'></script>
-  <![endif]-->
-
-  <script type="text/javascript" src="../latest/ui-kit.js"></script>
-
-</head>
-<body>
-
-  <nav class="skip-to">
-    <a href="#content">Skip to main content</a> <a href="#nav">Skip to section navigation</a>
-  </nav>
-
-
-  <!-- ========== Page header ========== -->
-  <header role="banner">
-
-    <section class="prerelease-govau--header">
-      <div class="wrapper">
-        <div class="govau--logo">
-          <img src="../latest/img/icons/logo-govau-full-2x.png" alt="gov.au crest logo" width="270"/>
-
-          <div id="test" class="brandbar default"><!--ID is temp for example-->
-            <div class="b1"></div>
-            <div class="b2"></div>
-          </div>
-        </div>
-
-        <div class="feedback" tabindex="1">
-          <a href="#content" class="button--feedback">Give feedback</a>
-        </div>
-
-      </div><!--wrapper-->
-
-      <nav class="breadcrumbs--inverted" aria-label="breadcrumb">
-        <div class="wrapper">
-          <ul>
-            <li><a href="#content">Home</a></li>
-            <li><a href="ministers-landing.html">Minister for Communications</a></li>
-            <li class="current">About the minister</li>
-          </ul>
-        </div>
-      </nav>
-
-    </section>
-  </header>
-
-
-  <!-- ========== Hero ========== -->
-  <div class="hero-sml corporate">
+  <section class="prerelease-govau--header">
     <div class="wrapper">
-      <p>Minister for Communications</p>
-    </div>
-  </div>
+      <div class="govau--logo">
+        <img src="../latest/img/icons/logo-govau-full-2x.png" alt="gov.au crest logo" width="270"/>
 
+        <div id="test" class="brandbar default"><!--ID is temp for example-->
+          <div class="b1"></div>
+          <div class="b2"></div>
+        </div>
+      </div>
 
-  <!-- ========== Main Page Row ========== -->
-  <main role="main">
-    <aside class="sidebar" id="nav">
+      <div class="feedback" tabindex="1">
+        <a href="#content" class="button--feedback">Give feedback</a>
+      </div>
 
-      <!-- ========== Nav ========== -->
-      <nav class="local-nav" aria-label="main navigation">
-        <h1 class="is-visuallyhidden">Menu</h1>
+    </div><!--wrapper-->
+
+    <nav class="breadcrumbs--inverted" aria-label="breadcrumb">
+      <div class="wrapper">
         <ul>
-          <li><a class="is-active" href="ministers-landing.html">Minister for Communications</a>
-            <ul>
-              <li><a href="ministers-content.html">Responsibilities</a></li>
-              <li><a href="#content" class="is-active is-current">About the minister</a></li>
-              <li><a href="news-section-listing.html">News</a></li>
-              <li><a href="#content">Contact</a></li>
-            </ul>
-          </li>
+          <li><a href="#content">Home</a></li>
+          <li><a href="ministers-landing.html">Minister for Communications</a></li>
+          <li class="current">About the minister</li>
+        </ul>
+      </div>
+    </nav>
+
+  </section>
+</header>
+
+
+<!-- ========== Hero ========== -->
+<div class="hero-sml corporate">
+  <div class="wrapper">
+    <p>Minister for Communications</p>
+  </div>
+</div>
+
+
+<!-- ========== Main Page Row ========== -->
+<main role="main">
+  <aside class="sidebar" id="nav">
+
+    <!-- ========== Nav ========== -->
+    <nav class="local-nav" aria-label="main navigation">
+      <h1 class="is-visuallyhidden">Menu</h1>
+      <ul>
+        <li><a class="is-active" href="ministers-landing.html">Minister for Communications</a>
+          <ul>
+            <li><a href="ministers-content.html">Responsibilities</a></li>
+            <li><a href="#content" class="is-active is-current">About the minister</a></li>
+            <li><a href="news-section-listing.html">News</a></li>
+            <li><a href="#content">Contact</a></li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+
+  </aside>
+
+
+  <!-- ========== Content ========== -->
+  <article id="content" class="content-main">
+    <header>
+      <h1>About the minister</h1>
+      <div class="abstract">
+        <p>The current Minister for Communications is the Hon Mitch Fifield, Senator for Victoria.</p>
+        <p><img src="https://placehold.it/800x450" alt="Placeholder image of 800 by 450 px"></p>
+      </div>
+    </header>
+
+    <h2 id="senator-the-hon-mitch-fifield">Senator the Hon Mitch Fifield</h2>
+    <p>Liberal Party of Australia</p>
+
+    <h3 id="political-career">Political career</h3>
+    <p>Senator Fifield was appointed as the <a href="#content">Minister for Communications</a>, <a href="#content">Minister for the Arts</a> and Minister Assisting the Prime Minister for Digital Government on 21 September 2015.</p>
+
+    <p>He also serves as a member of the Prime Minister's leadership group and the Senate leadership team, as Manager of Government Business in the Senate.</p>
+
+    <p>Senator Fifield was previously the Assistant Minister for Social Services, with responsibility for disabilities and ageing.</p>
+
+    <p>He was sworn in as Senator for Victoria in the Australian Parliament on 1 April 2004 and re-elected at the 2007 and 2013 elections.</p>
+
+    <p>Before entering parliament, Senator Fifield worked as a senior political adviser to the former Treasurer, Peter Costello, and held senior advisory positions in the Victorian Kennett and New South Wales Greiner governments.</p>
+
+    <p><a href="http://www.mitchfifield.com/" rel="external">Read more on his personal website</a></p>
+
+    <h3 id="life-and-career-outside-politics">Life and career outside politics</h3>
+    <p>Senator Fifield has served as a reservist in the Australian Army Psychology Corps and studied politics at Sydney University.</p>
+
+    <p>He was an ambassador for the not-for-profit school music organisation The Song Room and was an advisory board member for the Yachad Accelerated Learning Project for Aboriginal and Torres Strait Islander students. Senator Fifield was also a founding director and is the current chair of the Sir Paul Hasluck Foundation.</p>
+
+    <footer>
+      <p>Information sources: <cite>Department of Communications website</cite> and <cite>Senator Fifiel’s personal website</cite>.</p>
+    </footer>
+
+  </article>
+  <!-- ========== end Content ========== -->
+</main>
+
+
+<!-- ========== Page footer ========== -->
+<footer role="contentinfo">
+  <div class="wrapper">
+    <section class="footer-top">
+      <nav>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
         </ul>
       </nav>
-
-    </aside>
-
-
-    <!-- ========== Content ========== -->
-    <article id="content" class="content-main">
-      <header>
-        <h1>About the minister</h1>
-        <div class="abstract">
-          <p>The current Minister for Communications is the Hon Mitch Fifield, Senator for Victoria.</p>
-          <p><img src="https://placehold.it/800x450" alt="Placeholder image of 800 by 450 px"></p>
-        </div>
-      </header>
-
-      <h2 id="senator-the-hon-mitch-fifield">Senator the Hon Mitch Fifield</h2>
-      <p>Liberal Party of Australia</p>
-
-      <h3 id="political-career">Political career</h3>
-      <p>Senator Fifield was appointed as the <a href="#content">Minister for Communications</a>, <a href="#content">Minister for the Arts</a> and Minister Assisting the Prime Minister for Digital Government on 21 September 2015.</p>
-
-      <p>He also serves as a member of the Prime Minister's leadership group and the Senate leadership team, as Manager of Government Business in the Senate.</p>
-
-      <p>Senator Fifield was previously the Assistant Minister for Social Services, with responsibility for disabilities and ageing.</p>
-
-      <p>He was sworn in as Senator for Victoria in the Australian Parliament on 1 April 2004 and re-elected at the 2007 and 2013 elections.</p>
-
-      <p>Before entering parliament, Senator Fifield worked as a senior political adviser to the former Treasurer, Peter Costello, and held senior advisory positions in the Victorian Kennett and New South Wales Greiner governments.</p>
-
-      <p><a href="http://www.mitchfifield.com/" rel="external">Read more on his personal website</a></p>
-
-      <h3 id="life-and-career-outside-politics">Life and career outside politics</h3>
-      <p>Senator Fifield has served as a reservist in the Australian Army Psychology Corps and studied politics at Sydney University.</p>
-
-      <p>He was an ambassador for the not-for-profit school music organisation The Song Room and was an advisory board member for the Yachad Accelerated Learning Project for Aboriginal and Torres Strait Islander students. Senator Fifield was also a founding director and is the current chair of the Sir Paul Hasluck Foundation.</p>
-
-      <footer>
-        <p>Information sources: <cite>Department of Communications website</cite> and <cite>Senator Fifiel’s personal website</cite>.</p>
-      </footer>
-
-    </article>
-    <!-- ========== end Content ========== -->
-  </main>
-
-
-  <!-- ========== Page footer ========== -->
-  <footer role="contentinfo">
-    <div class="wrapper">
-      <section class="footer-top">
+    </section>
+    <section>
+      <div class="footer-logo">
+        <img alt="Australian Government Coat of Arms" src="../latest/img/coat-of-arms.png">
+      </div>
+      <div class="footer-links">
         <nav>
           <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
           </ul>
         </nav>
-      </section>
-      <section>
-        <div class="footer-logo">
-          <img alt="Australian Government Coat of Arms" src="../latest/img/coat-of-arms.png">
-        </div>
-        <div class="footer-links">
-          <nav>
-            <ul>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-            </ul>
-          </nav>
-          <p>&copy; Commonwealth of Australia <br>
-          <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE.md">Licensed under the MIT License.</a></p>
-        </div>
-      </section>
-    </div>
-  </footer>
-
-</body>
-</html>
+        <p>&copy; Commonwealth of Australia <br>
+        <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE.md">Licensed under the MIT License.</a></p>
+      </div>
+    </section>
+  </div>
+</footer>

--- a/examples/topic-category.html
+++ b/examples/topic-category.html
@@ -1,228 +1,173 @@
-<!DOCTYPE html>
-<!--[if IE]><![endif]-->
-<!--[if lt IE 7 ]>
-<html lang="en" class="ie6 no-js">    <![endif]-->
-<!--[if IE 7 ]>
-<html lang="en" class="ie7 no-js">    <![endif]-->
-<!--[if IE 8 ]>
-<html lang="en" class="ie8 no-js">    <![endif]-->
-<!--[if IE 9 ]>
-<html lang="en" class="ie9 no-js">    <![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!-->
-<html lang="en" class="no-js"><!--<![endif]-->
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <!-- viewport declaration must be included in <head> for media queries to work correctly on real devices -->
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Category page</title>
+<!-- ========== Page header ========== -->
+<header role="banner">
 
-  <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.16/webfont.js"></script>
-  <script>
-    WebFont.load({
-      google: {
-        families: ['Open+Sans:400italic,700,400:latin,latin-ext']
-      }
-    });
-  </script>
+  <section class="prerelease-govau--header">
+    <div class="wrapper">
+      <div class="govau--logo">
+        <img src="../latest/img/icons/logo-govau-full-2x.png" alt="gov.au crest logo" width="270"/>
 
-  <link rel="stylesheet" type="text/css" href="../latest/ui-kit.css"/>
+        <div id="test" class="brandbar default"><!--ID is temp for example-->
+          <div class="b1"></div>
+          <div class="b2"></div>
+        </div>
+      </div>
 
-  <!--[if lt IE 9]>
-  <script src="//code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ="
-          crossorigin="anonymous"></script>
-  <script type="text/javascript"
-          src="//cdnjs.cloudflare.com/ajax/libs/corysimmons-selectivizr2/1.0.8/selectivizr2.min.js"></script>
-  <![endif]-->
-  <!--[if lte IE 9]>
-  <script type='text/javascript' src='//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js'></script>
-  <script type='text/javascript'
-          src='//cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.3/jquery.xdomainrequest.min.js'></script>
-  <![endif]-->
+      <div class="feedback" tabindex="1">
+        <a href="#content" class="button--feedback">Give feedback</a>
+      </div>
 
-  <script type="text/javascript" src="../latest/ui-kit.js"></script>
+    </div><!--wrapper-->
 
-</head>
-<body>
-
-  <nav class="skip-to">
-    <a href="#content">Skip to main content</a> <a href="#nav">Skip to section navigation</a>
-  </nav>
-
-
-  <!-- ========== Page header ========== -->
-  <header role="banner">
-
-    <section class="prerelease-govau--header">
+    <nav class="breadcrumbs--inverted" aria-label="breadcrumb">
       <div class="wrapper">
-        <div class="govau--logo">
-          <img src="../latest/img/icons/logo-govau-full-2x.png" alt="gov.au crest logo" width="270"/>
+        <ul>
+          <li><a href="#content">Home</a></li>
+          <li class="current">Infrastructure and telecommunications</li>
+        </ul>
+      </div>
+    </nav>
 
-          <div id="test" class="brandbar default"><!--ID is temp for example-->
-            <div class="b1"></div>
-            <div class="b2"></div>
-          </div>
-        </div>
-
-        <div class="feedback" tabindex="1">
-          <a href="#content" class="button--feedback">Give feedback</a>
-        </div>
-
-      </div><!--wrapper-->
-
-      <nav class="breadcrumbs--inverted" aria-label="breadcrumb">
-        <div class="wrapper">
-          <ul>
-            <li><a href="#content">Home</a></li>
-            <li class="current">Infrastructure and telecommunications</li>
-          </ul>
-        </div>
-      </nav>
-
-    </section>
-  </header>
+  </section>
+</header>
 
 
-  <!-- ========== Hero ========== -->
-  <div class="hero-med">
-    <div class="wrapper">
-      <h1>Infrastructure and telecommunications</h1>
-      <p>Australian Government information and services related to infrastructure and telecommunications.</p>
-    </div>
+<!-- ========== Hero ========== -->
+<div class="hero-med">
+  <div class="wrapper">
+    <h1>Infrastructure and telecommunications</h1>
+    <p>Australian Government information and services related to infrastructure and telecommunications.</p>
   </div>
+</div>
 
 
-  <!-- ========== Main page row ========== -->
-  <main role="main">
+<!-- ========== Main page row ========== -->
+<main role="main">
 
-    <!-- ========== Content ========== -->
-    <article id="content" class="content-main">
-      <header>
-        <h2>Infrastructure</h2>
-      </header>
+  <!-- ========== Content ========== -->
+  <article id="content" class="content-main">
+    <header>
+      <h2>Infrastructure</h2>
+    </header>
 
-      <h4>Regional development</h4>
-      <ul>
-        <li><a href="#content">Work as a doctor</a></li>
-        <li><a href="#content">Urban &amp; regional development</a></li>
-        <li><a href="#content">National capital</a></li>
-      </ul>
+    <h4>Regional development</h4>
+    <ul>
+      <li><a href="#content">Work as a doctor</a></li>
+      <li><a href="#content">Urban &amp; regional development</a></li>
+      <li><a href="#content">National capital</a></li>
+    </ul>
 
-      <h4>Aviation</h4>
-      <ul>
-        <li><a href="#content">Aviation safety &amp; security</a></li>
-        <li><a href="#content">Aviation performance and statistics</a></li>
-        <li><a href="#content">Airport planning &amp; regulation</a></li>
-      </ul>
+    <h4>Aviation</h4>
+    <ul>
+      <li><a href="#content">Aviation safety &amp; security</a></li>
+      <li><a href="#content">Aviation performance and statistics</a></li>
+      <li><a href="#content">Airport planning &amp; regulation</a></li>
+    </ul>
 
-      <h4>Road</h4>
-      <ul>
-        <li><a href="#content">Road transport programs</a></li>
-        <li><a href="#content">Road transport industry</a></li>
-        <li><a href="#content">Road safety</a></li>
-        <li><a href="#content">Vehicles</a></li>
-        <li><a href="#content">Trucks</a></li>
-        <li><a href="#content">Freight and logistics</a></li>
-      </ul>
+    <h4>Road</h4>
+    <ul>
+      <li><a href="#content">Road transport programs</a></li>
+      <li><a href="#content">Road transport industry</a></li>
+      <li><a href="#content">Road safety</a></li>
+      <li><a href="#content">Vehicles</a></li>
+      <li><a href="#content">Trucks</a></li>
+      <li><a href="#content">Freight and logistics</a></li>
+    </ul>
 
-      <h4>Rail</h4>
-      <ul>
-        <li><a href="#content">Rail transport programs</a></li>
-      </ul>
+    <h4>Rail</h4>
+    <ul>
+      <li><a href="#content">Rail transport programs</a></li>
+    </ul>
 
-      <h4>Maritime</h4>
-      <ul>
-        <li><a href="#content">Maritime safety</a></li>
-        <li><a href="#content">Transport security</a></li>
-      </ul>
+    <h4>Maritime</h4>
+    <ul>
+      <li><a href="#content">Maritime safety</a></li>
+      <li><a href="#content">Transport security</a></li>
+    </ul>
 
-      <h4>Transport safety</h4>
-      <ul>
-        <li><a href="#content">Transport safety</a></li>
-      </ul>
+    <h4>Transport safety</h4>
+    <ul>
+      <li><a href="#content">Transport safety</a></li>
+    </ul>
 
-      <h2>Telecommunications</h2>
-      <h4>Television and radio</h4>
-      <ul>
-        <li><a href="topic-landing.html">Television reception</a></li>
-        <li><a href="#content">Digital television</a></li>
-        <li><a href="#content">Digital radio</a></li>
-        <li><a href="#content">Television content rules</a></li>
-      </ul>
+    <h2>Telecommunications</h2>
+    <h4>Television and radio</h4>
+    <ul>
+      <li><a href="topic-landing.html">Television reception</a></li>
+      <li><a href="#content">Digital television</a></li>
+      <li><a href="#content">Digital radio</a></li>
+      <li><a href="#content">Television content rules</a></li>
+    </ul>
 
-      <h4>Internet</h4>
-      <ul>
-        <li><a href="#content">Internet speeds</a></li>
-        <li><a href="#content">Internet safety</a></li>
-        <li><a href="#content">National broadband network</a></li>
-      </ul>
+    <h4>Internet</h4>
+    <ul>
+      <li><a href="#content">Internet speeds</a></li>
+      <li><a href="#content">Internet safety</a></li>
+      <li><a href="#content">National broadband network</a></li>
+    </ul>
 
-      <h4>Phone</h4>
-      <ul>
-        <li><a href="#content">Mobile phone black spots</a></li>
-        <li><a href="#content">Accessible phone services</a></li>
-      </ul>
+    <h4>Phone</h4>
+    <ul>
+      <li><a href="#content">Mobile phone black spots</a></li>
+      <li><a href="#content">Accessible phone services</a></li>
+    </ul>
 
-    </article>
-    <!-- ========== end Content ========== -->
-  </main>
+  </article>
+  <!-- ========== end Content ========== -->
+</main>
 
 
-  <!-- ========== Page footer ========== -->
-  <footer role="contentinfo">
-    <div class="wrapper">
-      <section class="footer-top">
+<!-- ========== Page footer ========== -->
+<footer role="contentinfo">
+  <div class="wrapper">
+    <section class="footer-top">
+      <nav>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+      </nav>
+    </section>
+    <section>
+      <div class="footer-logo">
+        <img alt="Australian Government Coat of Arms" src="../latest/img/coat-of-arms.png">
+      </div>
+      <div class="footer-links">
         <nav>
           <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
           </ul>
         </nav>
-      </section>
-      <section>
-        <div class="footer-logo">
-          <img alt="Australian Government Coat of Arms" src="../latest/img/coat-of-arms.png">
-        </div>
-        <div class="footer-links">
-          <nav>
-            <ul>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-            </ul>
-          </nav>
-          <p>&copy; Commonwealth of Australia <br>
-          <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE.md">Licensed under the MIT License.</a></p>
-        </div>
-      </section>
-    </div>
-  </footer>
-
-</body>
-</html>
+        <p>&copy; Commonwealth of Australia <br>
+        <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE.md">Licensed under the MIT License.</a></p>
+      </div>
+    </section>
+  </div>
+</footer>

--- a/examples/topic-content.html
+++ b/examples/topic-content.html
@@ -1,297 +1,243 @@
-<!DOCTYPE html>
-<!--[if IE]><![endif]-->
-<!--[if lt IE 7 ]>
-<html lang="en" class="ie6 no-js">    <![endif]-->
-<!--[if IE 7 ]>
-<html lang="en" class="ie7 no-js">    <![endif]-->
-<!--[if IE 8 ]>
-<html lang="en" class="ie8 no-js">    <![endif]-->
-<!--[if IE 9 ]>
-<html lang="en" class="ie9 no-js">    <![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!-->
-<html lang="en" class="no-js"><!--<![endif]-->
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <!-- viewport declaration must be included in <head> for media queries to work correctly on real devices -->
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Topic content</title>
+<!-- ========== Page header ========== -->
+<header role="banner">
 
-  <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.16/webfont.js"></script>
-  <script>
-    WebFont.load({
-      google: {
-        families: ['Open+Sans:400italic,700,400:latin,latin-ext']
-      }
-    });
-  </script>
-
-  <link rel="stylesheet" type="text/css" href="../latest/ui-kit.css"/>
-
-  <!--[if lt IE 9]>
-  <script src="//code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ="
-          crossorigin="anonymous"></script>
-  <script type="text/javascript"
-          src="//cdnjs.cloudflare.com/ajax/libs/corysimmons-selectivizr2/1.0.8/selectivizr2.min.js"></script>
-  <![endif]-->
-  <!--[if lte IE 9]>
-  <script type='text/javascript' src='//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js'></script>
-  <script type='text/javascript'
-          src='//cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.3/jquery.xdomainrequest.min.js'></script>
-  <![endif]-->
-
-  <script type="text/javascript" src="../latest/ui-kit.js"></script>
-
-</head>
-<body>
-
-  <nav class="skip-to">
-    <a href="#content">Skip to main content</a><a href="#nav">Skip to section navigation</a>
-  </nav>
-
-  <!-- ========== Page header ========== -->
-  <header role="banner">
-
-    <section class="prerelease-govau--header">
-      <div class="wrapper">
-        <div class="govau--logo">
-          <img src="../latest/img/icons/logo-govau-full-2x.png" alt="gov.au crest logo" width="270"/>
-
-          <div id="test" class="brandbar default"><!--ID is temp for example-->
-            <div class="b1"></div>
-            <div class="b2"></div>
-          </div>
-        </div>
-
-        <div class="feedback" tabindex="1">
-          <a href="#content" class="button--feedback">Give feedback</a>
-        </div>
-
-      </div><!--wrapper-->
-
-      <nav class="breadcrumbs--inverted" aria-label="breadcrumb">
-        <div class="wrapper">
-          <ul>
-            <li><a href="#content">Home</a></li>
-            <li><a href="topic-landing.html">Television (TV) reception</a></li>
-            <li class="current">Setting up digital TV</li>
-          </ul>
-        </div>
-      </nav>
-
-    </section>
-  </header>
-
-
-  <!-- ========== Hero ========== -->
-  <div class="hero-sml">
+  <section class="prerelease-govau--header">
     <div class="wrapper">
-      <p>Television (TV) reception</p>
-    </div>
-  </div>
+      <div class="govau--logo">
+        <img src="../latest/img/icons/logo-govau-full-2x.png" alt="gov.au crest logo" width="270"/>
 
+        <div id="test" class="brandbar default"><!--ID is temp for example-->
+          <div class="b1"></div>
+          <div class="b2"></div>
+        </div>
+      </div>
 
-  <!-- ========== Main page row ========== -->
-  <main role="main">
-    <aside class="sidebar" id="nav">
+      <div class="feedback" tabindex="1">
+        <a href="#content" class="button--feedback">Give feedback</a>
+      </div>
 
-      <!-- ========== Nav ========== -->
-      <nav class="local-nav" aria-label="main navigation">
-        <h1 class="is-visuallyhidden">Menu</h1>
+    </div><!--wrapper-->
+
+    <nav class="breadcrumbs--inverted" aria-label="breadcrumb">
+      <div class="wrapper">
         <ul>
-          <li><a class="is-active" href="topic-landing.html">Television (TV) reception</a>
-            <ul>
-              <li><a class="is-active is-current" href="#content">Setting up digital TV</a></li>
-              <li><a href="#content">Troubleshooting TV reception</a></li>
-              <li><a href="#content">Areas with temporary reception issues</a></li>
-              <li><a href="#content">Retransmitting TV channels</a></li>
-              <li><a href="#content">News</a></li>
-            </ul>
-          </li>
+          <li><a href="#content">Home</a></li>
+          <li><a href="topic-landing.html">Television (TV) reception</a></li>
+          <li class="current">Setting up digital TV</li>
+        </ul>
+      </div>
+    </nav>
+
+  </section>
+</header>
+
+
+<!-- ========== Hero ========== -->
+<div class="hero-sml">
+  <div class="wrapper">
+    <p>Television (TV) reception</p>
+  </div>
+</div>
+
+
+<!-- ========== Main page row ========== -->
+<main role="main">
+  <aside class="sidebar" id="nav">
+
+    <!-- ========== Nav ========== -->
+    <nav class="local-nav" aria-label="main navigation">
+      <h1 class="is-visuallyhidden">Menu</h1>
+      <ul>
+        <li><a class="is-active" href="topic-landing.html">Television (TV) reception</a>
+          <ul>
+            <li><a class="is-active is-current" href="#content">Setting up digital TV</a></li>
+            <li><a href="#content">Troubleshooting TV reception</a></li>
+            <li><a href="#content">Areas with temporary reception issues</a></li>
+            <li><a href="#content">Retransmitting TV channels</a></li>
+            <li><a href="#content">News</a></li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+
+  </aside>
+
+
+  <!-- ========== Content ========== -->
+  <article id="content" class="content-main">
+    <header>
+      <h1> Setting up digital TV </h1>
+      <div class="abstract">
+        <p> You can watch free-to-air digital TV channels with an antenna or a satellite dish.</p>
+      </div>
+
+      <nav class="index-links">
+        <h2>On this page</h2>
+        <ul>
+          <li><a href="#overview">Overview</a></li>
+          <li><a href="#digital-tv-with-an-antenna">Digital TV with an antenna</a></li>
+          <li><a href="#digital-tv-with-a-satellite-dish">Digital TV with a satellite dish</a></li>
         </ul>
       </nav>
+    </header>
 
-    </aside>
+    <h2 id="overview">Overview</h2>
+    <p>Australian broadcasters transmit more than 20 free-to-air digital TV channels, with support from the Australian Government. All TV channels in Australia are now digital.</p>
 
+    <p>There are 2 ways to get digital TV:</p>
 
-    <!-- ========== Content ========== -->
-    <article id="content" class="content-main">
-      <header>
-        <h1> Setting up digital TV </h1>
-        <div class="abstract">
-          <p> You can watch free-to-air digital TV channels with an antenna or a satellite dish.</p>
-        </div>
+    <ul>
+      <li><a href="#digital-tv-with-an-antenna">with an antenna</a></li>
+      <li><a href="#digital-tv-with-a-satellite-dish">with a satellite dish</a>.</li>
+    </ul>
 
-        <nav class="index-links">
-          <h2>On this page</h2>
-          <ul>
-            <li><a href="#overview">Overview</a></li>
-            <li><a href="#digital-tv-with-an-antenna">Digital TV with an antenna</a></li>
-            <li><a href="#digital-tv-with-a-satellite-dish">Digital TV with a satellite dish</a></li>
-          </ul>
-        </nav>
-      </header>
+    <h2 id="digital-tv-with-an-antenna">Digital TV with an antenna</h2>
+    <p>In most areas, you will need to connect your TV to a suitable antenna to watch free-to-air channels. You can use a VHF antenna or a UHF antenna.</p>
 
-      <h2 id="overview">Overview</h2>
-      <p>Australian broadcasters transmit more than 20 free-to-air digital TV channels, with support from the Australian Government. All TV channels in Australia are now digital.</p>
+    <p>If your TV is not digital, you will need to connect it to either a digital set-top box or personal video recorder (PVR).</p>
 
-      <p>There are 2 ways to get digital TV:</p>
+    <h2 id="digital-tv-with-a-satellite-dish">Digital TV with a satellite dish</h2>
+    <p>Satellite TV is an option if you have variable or no coverage from the nearest TV transmitter tower.</p>
 
-      <ul>
-        <li><a href="#digital-tv-with-an-antenna">with an antenna</a></li>
-        <li><a href="#digital-tv-with-a-satellite-dish">with a satellite dish</a>.</li>
-      </ul>
+    <p>The Australian Government funds a free-to-air satellite service called Viewer Access Satellite Television (VAST). It provides channels from national broadcasters (ABC and SBS) and commercial broadcasters (Seven, Nine, Ten and others).</p>
 
-      <h2 id="digital-tv-with-an-antenna">Digital TV with an antenna</h2>
-      <p>In most areas, you will need to connect your TV to a suitable antenna to watch free-to-air channels. You can use a VHF antenna or a UHF antenna.</p>
+    <p>Accessing channels is free but you will need to buy your own satellite dish and other equipment.</p>
 
-      <p>If your TV is not digital, you will need to connect it to either a digital set-top box or personal video recorder (PVR).</p>
+    <p>You may be eligible for VAST if:</p>
 
-      <h2 id="digital-tv-with-a-satellite-dish">Digital TV with a satellite dish</h2>
-      <p>Satellite TV is an option if you have variable or no coverage from the nearest TV transmitter tower.</p>
+    <ul>
+      <li>you live in a remote area with variable or no coverage</li>
+      <li>a hill, large tree or other structure blocks your TV signal</li>
+      <li>local interference causes problems with your TV signal</li>
+      <li>you are travelling in a mobile home or caravan and need temporary access to satellite TV.</li>
+    </ul>
 
-      <p>The Australian Government funds a free-to-air satellite service called Viewer Access Satellite Television (VAST). It provides channels from national broadcasters (ABC and SBS) and commercial broadcasters (Seven, Nine, Ten and others).</p>
+    <h3 id="how-to-get-satellite-tv-using-the-vast-service">How to get satellite TV using the VAST service</h3>
+    <p>Go to the <a href="/myswitch.digitalready.gov.au" rel="external">MySwitch tool</a> and enter your address. This will tell you how far you are from the nearest TV transmitter and whether you are eligible to apply for VAST. It will also guide you through the application process.</p>
 
-      <p>Accessing channels is free but you will need to buy your own satellite dish and other equipment.</p>
+    <p>If you need help with your application, contact the VAST administrator (RBA Holdings Pty Ltd):</p>
 
-      <p>You may be eligible for VAST if:</p>
+    <dl>
+      <dt>Email</dt>
+      <dd><a href="mailto:vast.administration@mysattv.com.au">vast.administration@mysattv.com.au</a></dd>
 
-      <ul>
-        <li>you live in a remote area with variable or no coverage</li>
-        <li>a hill, large tree or other structure blocks your TV signal</li>
-        <li>local interference causes problems with your TV signal</li>
-        <li>you are travelling in a mobile home or caravan and need temporary access to satellite TV.</li>
-      </ul>
+      <dt>Phone</dt>
+      <dd><a href="tel:1300993376">1300 993 376</a></dd>
+    </dl>
 
-      <h3 id="how-to-get-satellite-tv-using-the-vast-service">How to get satellite TV using the VAST service</h3>
-      <p>Go to the <a href="/myswitch.digitalready.gov.au" rel="external">MySwitch tool</a> and enter your address. This will tell you how far you are from the nearest TV transmitter and whether you are eligible to apply for VAST. It will also guide you through the application process.</p>
+    <h3 id="problems-with-vast-reception">Problems with VAST reception</h3>
+    <p>If you experience problems with VAST reception, go to the <a href="https://www.mysattv.com.au/Troubleshooting.aspx" rel="external">VAST website</a> for troubleshooting tips.</p>
 
-      <p>If you need help with your application, contact the VAST administrator (RBA Holdings Pty Ltd):</p>
+    <p>You can also request help using the VAST <a href="http://www.mysattv.com.au/Enquiry.aspx" rel="external">online enquiry form</a>.</p>
 
-      <dl>
-        <dt>Email</dt>
-        <dd><a href="mailto:vast.administration@mysattv.com.au">vast.administration@mysattv.com.au</a></dd>
+    <h3 id="complaints-about-vast-applications">Complaints about VAST applications</h3>
+    <p>You can lodge a complaint with the Australian Communications and Media Authority (ACMA) if the VAST administrator: </p>
 
-        <dt>Phone</dt>
-        <dd><a href="tel:1300993376">1300 993 376</a></dd>
-      </dl>
+    <ul>
+      <li>rejected your application for VAST</li>
+      <li>approved your access to VAST but later rejected it</li>
+      <li>has not processed your application within 15 business days.</li>
+    </ul>
 
-      <h3 id="problems-with-vast-reception">Problems with VAST reception</h3>
-      <p>If you experience problems with VAST reception, go to the <a href="https://www.mysattv.com.au/Troubleshooting.aspx" rel="external">VAST website</a> for troubleshooting tips.</p>
+    <p>If you decide to complain, include this information: </p>
 
-      <p>You can also request help using the VAST <a href="http://www.mysattv.com.au/Enquiry.aspx" rel="external">online enquiry form</a>.</p>
+    <ul>
+      <li>your name</li>
+      <li>your contact information (email, telephone and postal address)</li>
+      <li>the address you requested VAST services for</li>
+      <li>the date you applied for VAST</li>
+      <li>a copy of your application if available</li>
+      <li>the reception equipment you own</li>
+      <li>the issue</li>
+      <li>any correspondence between you and the VAST administrator.</li>
+    </ul>
 
-      <h3 id="complaints-about-vast-applications">Complaints about VAST applications</h3>
-      <p>You can lodge a complaint with the Australian Communications and Media Authority (ACMA) if the VAST administrator: </p>
+    <p>You can make your complaint by email, post or fax:</p>
 
-      <ul>
-        <li>rejected your application for VAST</li>
-        <li>approved your access to VAST but later rejected it</li>
-        <li>has not processed your application within 15 business days.</li>
-      </ul>
+    <dl>
+      <dt>Email</dt>
+      <dd><a href="mailto:info@acma.gov.au?subject=Satellite%20TV%20Complaint">info@acma.gov.au</a></dd>
 
-      <p>If you decide to complain, include this information: </p>
-
-      <ul>
-        <li>your name</li>
-        <li>your contact information (email, telephone and postal address)</li>
-        <li>the address you requested VAST services for</li>
-        <li>the date you applied for VAST</li>
-        <li>a copy of your application if available</li>
-        <li>the reception equipment you own</li>
-        <li>the issue</li>
-        <li>any correspondence between you and the VAST administrator.</li>
-      </ul>
-
-      <p>You can make your complaint by email, post or fax:</p>
-
-      <dl>
-        <dt>Email</dt>
-        <dd><a href="mailto:info@acma.gov.au?subject=Satellite%20TV%20Complaint">info@acma.gov.au</a></dd>
-
-        <dt>Post</dt>
-        <dd>
-          <div id="office-postal-address" class="vcard">
-            <div class="subject">Satellite TV Complaint</div>
-            <div class="org">Australian Communications and Media Authority</div>
-            <div class="adr">
-              <div class="street-address">PO Box 78</div>
-                <span class="locality">Belconnen</span>,
-                <span class="region">ACT</span>,
-                <span class="postal-code">2616</span>
-            </div>
-            <div class="fax">Fax: 02 6219 5347</div>
+      <dt>Post</dt>
+      <dd>
+        <div id="office-postal-address" class="vcard">
+          <div class="subject">Satellite TV Complaint</div>
+          <div class="org">Australian Communications and Media Authority</div>
+          <div class="adr">
+            <div class="street-address">PO Box 78</div>
+              <span class="locality">Belconnen</span>,
+              <span class="region">ACT</span>,
+              <span class="postal-code">2616</span>
           </div>
-        </dd>
-      </dl>
+          <div class="fax">Fax: 02 6219 5347</div>
+        </div>
+      </dd>
+    </dl>
 
-      <h3 id="government-subsidies">Government subsidies</h3>
-      <p>The Australian Government funds the VAST service.</p>
+    <h3 id="government-subsidies">Government subsidies</h3>
+    <p>The Australian Government funds the VAST service.</p>
 
-      <p>The Satellite Subsidy Scheme (SSS) and the Household Assistance Scheme (HAS) have now finished.</p>
+    <p>The Satellite Subsidy Scheme (SSS) and the Household Assistance Scheme (HAS) have now finished.</p>
 
-      <p>If you have questions about an installation under the SSS or the HAS, contact the service provider who did the installation. The phone number should be on the sticker attached to the set-top box or information card you were given at the time of installation.</p>
+    <p>If you have questions about an installation under the SSS or the HAS, contact the service provider who did the installation. The phone number should be on the sticker attached to the set-top box or information card you were given at the time of installation.</p>
 
-    </article>
-    <!-- ========== end Content ========== -->
-  </main>
+  </article>
+  <!-- ========== end Content ========== -->
+</main>
 
 
-  <!-- ========== Page footer ========== -->
-  <footer role="contentinfo">
-    <div class="wrapper">
-      <section class="footer-top">
+<!-- ========== Page footer ========== -->
+<footer role="contentinfo">
+  <div class="wrapper">
+    <section class="footer-top">
+      <nav>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+      </nav>
+    </section>
+    <section>
+      <div class="footer-logo">
+        <img alt="Australian Government Coat of Arms" src="../latest/img/coat-of-arms.png">
+      </div>
+      <div class="footer-links">
         <nav>
           <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
           </ul>
         </nav>
-      </section>
-      <section>
-        <div class="footer-logo">
-          <img alt="Australian Government Coat of Arms" src="../latest/img/coat-of-arms.png">
-        </div>
-        <div class="footer-links">
-          <nav>
-            <ul>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-            </ul>
-          </nav>
-          <p>&copy; Commonwealth of Australia <br>
-          <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE.md">Licensed under the MIT License.</a></p>
-        </div>
-      </section>
-    </div>
-  </footer>
-
-</body>
-</html>
+        <p>&copy; Commonwealth of Australia <br>
+        <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE.md">Licensed under the MIT License.</a></p>
+      </div>
+    </section>
+  </div>
+</footer>

--- a/examples/topic-landing.html
+++ b/examples/topic-landing.html
@@ -1,219 +1,164 @@
-<!DOCTYPE html>
-<!--[if IE]><![endif]-->
-<!--[if lt IE 7 ]>
-<html lang="en" class="ie6 no-js">    <![endif]-->
-<!--[if IE 7 ]>
-<html lang="en" class="ie7 no-js">    <![endif]-->
-<!--[if IE 8 ]>
-<html lang="en" class="ie8 no-js">    <![endif]-->
-<!--[if IE 9 ]>
-<html lang="en" class="ie9 no-js">    <![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!-->
-<html lang="en" class="no-js"><!--<![endif]-->
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <!-- viewport declaration must be included in <head> for media queries to work correctly on real devices -->
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Topic landing page</title>
+<!-- ========== Page header ========== -->
+<header role="banner">
 
-  <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.16/webfont.js"></script>
-  <script>
-    WebFont.load({
-      google: {
-        families: ['Open+Sans:400italic,700,400:latin,latin-ext']
-      }
-    });
-  </script>
-
-  <link rel="stylesheet" type="text/css" href="../latest/ui-kit.css"/>
-
-  <!--[if lt IE 9]>
-  <script src="//code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ="
-          crossorigin="anonymous"></script>
-  <script type="text/javascript"
-          src="//cdnjs.cloudflare.com/ajax/libs/corysimmons-selectivizr2/1.0.8/selectivizr2.min.js"></script>
-  <![endif]-->
-  <!--[if lte IE 9]>
-  <script type='text/javascript' src='//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js'></script>
-  <script type='text/javascript'
-          src='//cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.3/jquery.xdomainrequest.min.js'></script>
-  <![endif]-->
-
-  <script type="text/javascript" src="../latest/ui-kit.js"></script>
-
-</head>
-<body>
-
-  <nav class="skip-to">
-    <a href="#content">Skip to main content</a> <a href="#nav">Skip to section navigation</a>
-  </nav>
-
-
-  <!-- ========== Page header ========== -->
-  <header role="banner">
-
-    <section class="prerelease-govau--header">
-      <div class="wrapper">
-        <div class="govau--logo">
-          <img src="../latest/img/icons/logo-govau-full-2x.png" alt="gov.au crest logo" width="270"/>
-
-          <div id="test" class="brandbar default"><!--ID is temp for example-->
-            <div class="b1"></div>
-            <div class="b2"></div>
-          </div>
-        </div>
-
-        <div class="feedback" tabindex="1">
-          <a href="#content" class="button--feedback">Give feedback</a>
-        </div>
-
-      </div><!--wrapper-->
-
-      <nav class="breadcrumbs--inverted" aria-label="breadcrumb">
-        <div class="wrapper">
-          <ul>
-            <li><a href="#content">Home</a></li>
-            <li class="current">Television (TV) reception</li>
-          </ul>
-        </div>
-      </nav>
-
-    </section>
-  </header>
-
-
-  <!-- ========== Hero ========== -->
-  <div class="hero-med">
+  <section class="prerelease-govau--header">
     <div class="wrapper">
-      <h1>Television (TV) reception</h1>
-      <p>Everyone in Australia should see a clear picture and hear good sound quality with free-to-air digital television (TV).</p>
-    </div>
-  </div>
+      <div class="govau--logo">
+        <img src="../latest/img/icons/logo-govau-full-2x.png" alt="gov.au crest logo" width="270"/>
 
+        <div id="test" class="brandbar default"><!--ID is temp for example-->
+          <div class="b1"></div>
+          <div class="b2"></div>
+        </div>
+      </div>
 
-  <!-- ========== Main Page Row ========== -->
-  <main role="main">
-    <aside class="sidebar" id="nav">
+      <div class="feedback" tabindex="1">
+        <a href="#content" class="button--feedback">Give feedback</a>
+      </div>
 
-      <!-- ========== Nav ========== -->
-      <nav class="local-nav" aria-label="main navigation">
-        <h1 class="is-visuallyhidden">Menu</h1>
+    </div><!--wrapper-->
+
+    <nav class="breadcrumbs--inverted" aria-label="breadcrumb">
+      <div class="wrapper">
         <ul>
-          <li><a class="is-active is-current" href="#content">Television (TV) reception</a>
-            <ul>
-              <li><a href="topic-content.html">Setting up digital TV</a></li>
-              <li><a href="#content">Troubleshooting TV reception</a></li>
-              <li><a href="#content">Areas with temporary reception issues</a></li>
-              <li><a href="#content">Retransmitting TV channels</a></li>
-              <li><a href="#content">News</a></li>
-            </ul>
-          </li>
+          <li><a href="#content">Home</a></li>
+          <li class="current">Television (TV) reception</li>
         </ul>
-      </nav>
+      </div>
+    </nav>
 
-    </aside>
+  </section>
+</header>
 
-    <!-- ========== Content ========== -->
-    <article id="content" class="content-main">
-      <header>
-        <h2>{{Title TBC}}</h2>
-      </header>
 
-      <dl>
-        <dt><a href="#content">Setting up digital TV</a></dt>
-        <dd>Find out how to get free-to-air TV using an antenna or a satellite dish.</dd>
+<!-- ========== Hero ========== -->
+<div class="hero-med">
+  <div class="wrapper">
+    <h1>Television (TV) reception</h1>
+    <p>Everyone in Australia should see a clear picture and hear good sound quality with free-to-air digital television (TV).</p>
+  </div>
+</div>
 
-        <dt><a href="#content">Troubleshooting TV reception</a></dt>
-        <dd>Follow these steps to fix TV reception and signal issues.</dd>
 
-        <dt><a href="#content">Areas with temporary reception issues</a></dt>
-        <dd>Check to see if your area has poor TV reception because of temporary issues such as planned maintenance or storm damage.</dd>
+<!-- ========== Main Page Row ========== -->
+<main role="main">
+  <aside class="sidebar" id="nav">
 
-        <dt><a href="#content">Retransmitting TV channels</a></dt>
-        <dd>In remote areas with poor TV reception, local organisations can apply to retransmit channels.</dd>
-      </dl>
-
-      <h2>News</h2>
-      <p>Announcements, media releases, interviews, speeches and more.</p>
-
-      <ul class='list-vertical--thirds'>
-        <li>
-          <article>
-            <h3><a href="#content">A warm reception for viewers in the Hunter</a></h3>
-            <div class="meta">22 July 2016</div>
-          </article>
-        </li>
-        <li>
-          <article>
-            <h3><a href="#content">Sydney – final countdown to digital-only TV has begun</a></h3>
-            <div class="meta">13 November 2013</div>
-          </article>
+    <!-- ========== Nav ========== -->
+    <nav class="local-nav" aria-label="main navigation">
+      <h1 class="is-visuallyhidden">Menu</h1>
+      <ul>
+        <li><a class="is-active is-current" href="#content">Television (TV) reception</a>
+          <ul>
+            <li><a href="topic-content.html">Setting up digital TV</a></li>
+            <li><a href="#content">Troubleshooting TV reception</a></li>
+            <li><a href="#content">Areas with temporary reception issues</a></li>
+            <li><a href="#content">Retransmitting TV channels</a></li>
+            <li><a href="#content">News</a></li>
+          </ul>
         </li>
       </ul>
+    </nav>
 
-      <p><a class="see-more" href="news-section-listing.html">More news</a></p>
+  </aside>
 
-    </article>
-    <!-- ========== end Content ========== -->
-  </main>
+  <!-- ========== Content ========== -->
+  <article id="content" class="content-main">
+    <header>
+      <h2>{{Title TBC}}</h2>
+    </header>
+
+    <dl>
+      <dt><a href="#content">Setting up digital TV</a></dt>
+      <dd>Find out how to get free-to-air TV using an antenna or a satellite dish.</dd>
+
+      <dt><a href="#content">Troubleshooting TV reception</a></dt>
+      <dd>Follow these steps to fix TV reception and signal issues.</dd>
+
+      <dt><a href="#content">Areas with temporary reception issues</a></dt>
+      <dd>Check to see if your area has poor TV reception because of temporary issues such as planned maintenance or storm damage.</dd>
+
+      <dt><a href="#content">Retransmitting TV channels</a></dt>
+      <dd>In remote areas with poor TV reception, local organisations can apply to retransmit channels.</dd>
+    </dl>
+
+    <h2>News</h2>
+    <p>Announcements, media releases, interviews, speeches and more.</p>
+
+    <ul class='list-vertical--thirds'>
+      <li>
+        <article>
+          <h3><a href="#content">A warm reception for viewers in the Hunter</a></h3>
+          <div class="meta">22 July 2016</div>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h3><a href="#content">Sydney – final countdown to digital-only TV has begun</a></h3>
+          <div class="meta">13 November 2013</div>
+        </article>
+      </li>
+    </ul>
+
+    <p><a class="see-more" href="news-section-listing.html">More news</a></p>
+
+  </article>
+  <!-- ========== end Content ========== -->
+</main>
 
 
-  <!-- ========== Page footer ========== -->
-  <footer role="contentinfo">
-    <div class="wrapper">
-      <section class="footer-top">
+<!-- ========== Page footer ========== -->
+<footer role="contentinfo">
+  <div class="wrapper">
+    <section class="footer-top">
+      <nav>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+        <ul>
+          <li><h2>Title header</h2></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+          <li><a href="#content">This is a footer link</a></li>
+        </ul>
+      </nav>
+    </section>
+    <section>
+      <div class="footer-logo">
+        <img alt="Australian Government Coat of Arms" src="../latest/img/coat-of-arms.png">
+      </div>
+      <div class="footer-links">
         <nav>
           <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-          </ul>
-          <ul>
-            <li><h2>Title header</h2></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
-            <li><a href="#content">This is a footer link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
+            <li><a href="#content">Example global link</a></li>
           </ul>
         </nav>
-      </section>
-      <section>
-        <div class="footer-logo">
-          <img alt="Australian Government Coat of Arms" src="../latest/img/coat-of-arms.png">
-        </div>
-        <div class="footer-links">
-          <nav>
-            <ul>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-              <li><a href="#content">Example global link</a></li>
-            </ul>
-          </nav>
-          <p>&copy; Commonwealth of Australia <br>
-          <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE.md" rel="license">Licensed under the MIT License.</a></p>
-        </div>
-      </section>
-    </div>
-  </footer>
-
-</body>
-</html>
+        <p>&copy; Commonwealth of Australia <br>
+        <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE.md" rel="license">Licensed under the MIT License.</a></p>
+      </div>
+    </section>
+  </div>
+</footer>

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "gulp-svg2png": "^1.0.2",
     "gulp-uglify": "^1.5.3",
     "gulp-util": "^3.0.7",
+    "gulp-wrap": "^0.13.0",
     "gulp-zip": "^3.2.0",
     "handlebars.moment": "^1.0.4",
     "htmlparser2": "^3.9.1",


### PR DESCRIPTION
## Description

This PR updates the Examples task in our Gulp build so that all examples are now wrapped in a common layout. 

This is not a template (i.e. we can't include partials) but it might save us a bit of time updating the example templates. Changes to the global `<head>` will now only have to be made in two places:
- Default example layout at `examples/layouts/default.html`
- Guide template landing page at `kss-builder/index.hbs`
## Definition of Done
- [x] Code reviewed by one of the core developers
- [x] Acceptance Testing
  - [x] HTML5 validation (CircleCI)
  - [x] Accessibility testing & WCAG2 compliance (`node test/pa11y.js`)
- [x] Stakeholder/PO review
- [x] CHANGELOG updated
