### PR TITLE
Edits to make default link style apply to all content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 #### UI-Kit changes
 
 - Added `.ua-notification` class for issuing top-of-page User Agent (browser) notifications (eg for browsers we have difficulty supporting) in the `_accessibility.scss` partial.
+- Link styles are now applied to any `article` that is a direct child of the page's `main` element
 
 ### 1.7.4 - 2016-08-17
 

--- a/assets/sass/_accordions.scss
+++ b/assets/sass/_accordions.scss
@@ -3,7 +3,7 @@ Accordions
 
 Accordions help users find only the content they need.
 
-The **expand/collapse all** feature will be provided soon&mdash;this will be mandatory if using a series of accordion elements.
+The **expand/collapse all** feature will be provided soon &mdash; this will be mandatory if using a series of accordion elements.
 
 ***
 

--- a/assets/sass/_buttons.scss
+++ b/assets/sass/_buttons.scss
@@ -1,11 +1,11 @@
 /*
 Buttons
 
-Buttons signal action&mdash;use them to move the user through a transaction.
+Buttons signal action &mdash; use them to move the user through a transaction.
 
 Use 1 button per page to build a strong call to action. Adding a second or third button forces users to make a choice. If choice is required use another kind of element eg radio button.
 
-Use button text to describe what the button does&mdash;keep it short.
+Use button text to describe what the button does &mdash; keep it short.
 
 The button alignment in [forms](section-forms.html) should put the primary action button at the left edge, in the user's line of sight.
 

--- a/assets/sass/_colours.scss
+++ b/assets/sass/_colours.scss
@@ -3,7 +3,7 @@ Colours
 
 A basic palette of colours that are clear and accessible.
 
-We are finalising the colours&mdash;for help <a href="https://github.com/AusDTO/gov-au-ui-kit/issues" rel="external">log a GitHub issue</a>.
+We are finalising the colours &mdash; for help <a href="https://github.com/AusDTO/gov-au-ui-kit/issues" rel="external">log a GitHub issue</a>.
 
 Style guide: Colours
 */
@@ -16,73 +16,73 @@ Lighter and darker versions are percentage variations of the original colours (S
 <div class="guide-colour-examples">
   <div class="guide-colour">
     <div class="swatch bg-non-black"></div>
-    <p class="text"> <strong>Non-black</strong><br/>
+    <p class="text"><strong>Non-black</strong><br/>
       <small>$non-black<br/>#313131</small></p>
   </div>
 
   <div class="guide-colour">
     <div class="swatch bg-grey"></div>
-    <p class="text"> <strong>Grey</strong><br/>
+    <p class="text"><strong>Grey</strong><br/>
       <small>$grey<br/> #717171</small></p>
   </div>
 
   <div class="guide-colour">
     <div class="swatch bg-light-grey"></div>
-    <p class="text"> <strong>Light-grey</strong><br/>
+    <p class="text"><strong>Light-grey</strong><br/>
       <small>$light-grey<br/> #BEBEBE</small></p>
   </div>
 
   <div class="guide-colour">
     <div class="swatch bg-non-white"></div>
-    <p class="text"> <strong>Non-white</strong><br/>
+    <p class="text"><strong>Non-white</strong><br/>
       <small>$non-white<br/> #F0F3F5</small></p>
   </div>
 
   <div class="guide-colour">
     <div class="swatch bg-darker-aqua"></div>
-    <p class="text"> <strong>Darker-aqua</strong><br/>
+    <p class="text"><strong>Darker-aqua</strong><br/>
       <small>$darker-aqua<br/> #115361</small></p>
   </div>
 
   <div class="guide-colour">
     <div class="swatch bg-dark-aqua"></div>
-    <p class="text"> <strong>Dark-aqua</strong><br/>
+    <p class="text"><strong>Dark-aqua</strong><br/>
       <small>$dark-aqua<br/> #146577</small></p>
   </div>
 
   <div class="guide-colour">
     <div class="swatch bg-aqua"></div>
-    <p class="text"> <strong>Aqua</strong><br/>
+    <p class="text"><strong>Aqua</strong><br/>
       <small>$aqua<br/> #18788D</small></p>
   </div>
 
   <div class="guide-colour">
     <div class="swatch bg-light-aqua"></div>
-    <p class="text"> <strong>Light-aqua</strong><br/>
+    <p class="text"><strong>Light-aqua</strong><br/>
       <small>$light-aqua<br/> #5BCBE3</small></p>
   </div>
 
   <div class="guide-colour">
     <div class="swatch bg-lighter-aqua"></div>
-    <p class="text"> <strong>Lighter-aqua</strong><br/>
+    <p class="text"><strong>Lighter-aqua</strong><br/>
       <small>$lighter-aqua<br/> #5BCBE3</small></p>
   </div>
 
   <div class="guide-colour">
     <div class="swatch bg-dark-navy"></div>
-    <p class="text"> <strong>Dark-navy</strong><br/>
+    <p class="text"><strong>Dark-navy</strong><br/>
       <small>$dark-navy<br/> #152D3B</small></p>
   </div>
 
   <div class="guide-colour">
     <div class="swatch bg-navy"></div>
-    <p class="text"> <strong>Navy</strong><br/>
+    <p class="text"><strong>Navy</strong><br/>
       <small>$navy<br/> #224A61</small></p>
   </div>
 
   <div class="guide-colour">
     <div class="swatch bg-maroon"></div>
-    <p class="text"> <strong>Maroon</strong><br/>
+    <p class="text"><strong>Maroon</strong><br/>
       <small>$maroon<br/> #880E48</small></p>
   </div>
 </div>
@@ -119,49 +119,49 @@ These colours are reserved to help show specific changes in status.
 <div class="guide-colour-examples">
   <div class="guide-colour">
     <div class="swatch bg-success-green"></div>
-    <p class="text"> <strong>Success-green</strong><br/>
+    <p class="text"><strong>Success-green</strong><br/>
       <small>$success-colour<br/> #007554</small></p>
   </div>
 
   <div class="guide-colour">
     <div class="swatch bg-light-green"></div>
-    <p class="text"> <strong>Light-green</strong><br/>
+    <p class="text"><strong>Light-green</strong><br/>
       <small>$light-green<br/> #e6efc2</small></p>
   </div>
 
   <div class="guide-colour">
     <div class="swatch bg-error-red"></div>
-    <p class="text"> <strong>Error-red</strong><br/>
+    <p class="text"><strong>Error-red</strong><br/>
       <small>$error-colour<br/> #cc0000</small></p>
   </div>
 
   <div class="guide-colour">
     <div class="swatch bg-light-red"></div>
-    <p class="text"> <strong>Light-red</strong><br/>
+    <p class="text"><strong>Light-red</strong><br/>
       <small>$light-red<br/> #f9dede</small></p>
   </div>
 
   <div class="guide-colour">
     <div class="swatch bg-warning-yellow"></div>
-    <p class="text"> <strong>Warning-yellow</strong><br/>
+    <p class="text"><strong>Warning-yellow</strong><br/>
       <small>$warning-colour<br/> #f9c642</small></p>
   </div>
 
   <div class="guide-colour">
     <div class="swatch bg-light-yellow"></div>
-    <p class="text"> <strong>Light-yellow</strong><br/>
+    <p class="text"><strong>Light-yellow</strong><br/>
       <small>$light-yellow<br/> #fdf7dc</small></p>
   </div>
 
   <div class="guide-colour">
     <div class="swatch bg-info-blue"></div>
-    <p class="text"> <strong>Info-blue</strong><br/>
+    <p class="text"><strong>Info-blue</strong><br/>
       <small>$info-colour<br/> #00Bfe9</small></p>
   </div>
 
   <div class="guide-colour">
     <div class="swatch bg-light-blue"></div>
-    <p class="text"> <strong>Light-blue</strong><br/>
+    <p class="text"><strong>Light-blue</strong><br/>
       <small>$light-blue<br/> #e8f5fa</small></p>
   </div>
 </div>

--- a/assets/sass/_forms.scss
+++ b/assets/sass/_forms.scss
@@ -1,7 +1,7 @@
 /*
 Forms
 
-Keep forms as simple as possible&mdash;only ask what is needed for the transaction.
+Keep forms as simple as possible &mdash; only ask what is needed for the transaction.
 
 Ask only 1 question per page.
 

--- a/assets/sass/_grid-settings.scss
+++ b/assets/sass/_grid-settings.scss
@@ -13,7 +13,7 @@ Primary content is always contained in 12 columns. This allows for seamless intr
 
 The grid unit proportions, gutters and spacing are defined in `_grid-settings.scss`.
 
-If you need an element not defined here you are probably not the only one&mdash;please <a href="https://github.com/AusDTO/gov-au-ui-kit/issues" rel="external">log a GitHub issue</a> so we can provide it for everyone.
+If you need an element not defined here you are probably not the only one &mdash; please <a href="https://github.com/AusDTO/gov-au-ui-kit/issues" rel="external">log a GitHub issue</a> so we can provide it for everyone.
 
 ***
 

--- a/assets/sass/_links.scss
+++ b/assets/sass/_links.scss
@@ -53,7 +53,7 @@ Style guide: Link styles.1 Hover links
 }
 
 @mixin link-colours($text-colour, $hover-bg-colour, $hover-text-colour: $text-colour) {
-  $link-disabled-colour: transparentize($text-colour, 0.4);
+  $link-disabled-colour: transparentize($text-colour, 0.3);
   color: $text-colour;
 
   a {

--- a/assets/sass/_links.scss
+++ b/assets/sass/_links.scss
@@ -189,7 +189,7 @@ Style guide: Link styles.1 Hover links
 
 // move these bad boys to their right contextual places
 
-.content-main,
+main > article,
 footer[role='contentinfo'] {
   @include link-colours($non-black, $light-aqua, $non-black);
   @include button-colours($button-bg-colour, $button-bg-colour--hover, $button-bg-colour--active, $button-text-colour);

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -105,7 +105,7 @@ Contents links
 
 Contents links (index links) help users understand the page structure.
 
-A heading is optional&mdash;use the correct header level for the page structure.
+A heading is optional &mdash; use the correct header level for the page structure.
 
 Users with modern browsers will see a smooth scroll down the page.
 

--- a/assets/sass/_typography.scss
+++ b/assets/sass/_typography.scss
@@ -225,7 +225,7 @@ We are currently testing all styles for legibility and readability.
   </tr>
 </table>
 
-### Base size examples&mdash;global styles
+### Base size examples &mdash; global styles
 
 Markup: templates/heading-body-styles.hbs
 

--- a/assets/sass/templates/calendar-callout-example.hbs
+++ b/assets/sass/templates/calendar-callout-example.hbs
@@ -1,4 +1,4 @@
 <section class="callout--calendar-event">
   <h3 class="next-event">The next public holiday is:</h3>
-  <p><time datetime="2016-12-25T02:30:00+00:00">Sunday 25 December </time><span class="event-name">Christmas day</span></p>
+  <p><time datetime="2016-12-25T02:30:00+00:00">Sunday 25 December</time> <span class="event-name">Christmas day</span></p>
 </section>

--- a/assets/sass/templates/callouts-examples.hbs
+++ b/assets/sass/templates/callouts-examples.hbs
@@ -4,5 +4,5 @@
 
 <div class="callout--calendar-event">
   <span class="next-event">The next public holiday is:</span>
-  <p><time datetime="2017-01-01T00:00:00+00:00">Sunday 1 January </time><span class="event-name">New Year's Day</span></p>
+  <p><time datetime="2017-01-01T00:00:00+00:00">Sunday 1 January</time> <span class="event-name">New Year's Day</span></p>
 </div>

--- a/assets/sass/templates/global-navigation.hbs
+++ b/assets/sass/templates/global-navigation.hbs
@@ -3,7 +3,7 @@
     <div class="govau--logo">
       <a href="/" class="logo">gov.au</a> <span class="badge--default">draft</span>
     </div>
-    <nav class="global-nav" aria-label="global navigation" tabindex="2">
+    <nav class="global-nav" aria-label="global navigation">
       <ul>
         <li><a href="#">About us</a></li>
         <li><a href="#">Information and services</a></li>

--- a/assets/sass/templates/global-navigation.hbs
+++ b/assets/sass/templates/global-navigation.hbs
@@ -9,7 +9,7 @@
         <li><a href="#">Information and services</a></li>
         <li><a href="#">Ministers</a></li>
         <li><a href="#">News</a></li>
-        <li><a href="#">Departments & Agencies</a></li>
+        <li><a href="#">Departments &amp; Agencies</a></li>
         <li><a href="#">Contact us</a></li>
       </ul>
     </nav>

--- a/assets/sass/templates/lists-horizontal.hbs
+++ b/assets/sass/templates/lists-horizontal.hbs
@@ -16,7 +16,7 @@
     <li>
       <article>
         <h3>
-          <a href="#">List item&mdash;with metadata</a>
+          <a href="#">List item &mdash; with metadata</a>
         </h3>
 
         <div class="meta">
@@ -43,7 +43,7 @@
     </figure>
     <article>
       <h3>
-        <a href="#">List item&mdash;with hero image</a>
+        <a href="#">List item &mdash; with hero image</a>
       </h3>
       <p>The Digital Transformation Office (DTO) was established as an executive agency in July 2015. Its mission is to lead the [&hellip;]</p>
     </article>
@@ -56,7 +56,7 @@
     </figure>
     <article>
       <h3>
-        <a href="#">List item&mdash;with regular image</a>
+        <a href="#">List item &mdash; with regular image</a>
       </h3>
       <div class="meta">
         <time datetime="2016-05-08 00:00">08 May 2016</time>
@@ -81,7 +81,7 @@
     </figure>
     <article>
       <h3>
-        <a href="#">List item&mdash;with left padding</a>
+        <a href="#">List item &mdash; with left padding</a>
       </h3>
 
       <div class="meta">

--- a/assets/sass/templates/lists-small.hbs
+++ b/assets/sass/templates/lists-small.hbs
@@ -5,7 +5,7 @@
       <div class="meta">
         <time datetime="2016-05-08 00:00">08 May 2016</time>
       </div>
-      <span>Small list item&mdash;with metadata</span>
+      <span>Small list item &mdash; with metadata</span>
     </a>
   </li>
 

--- a/assets/sass/templates/lists-vertical.hbs
+++ b/assets/sass/templates/lists-vertical.hbs
@@ -1,10 +1,10 @@
-<h3>Vertical style&mdash;default</h3>
+<h3>Vertical style &mdash; default</h3>
 
 <ul class="list-vertical">
   <li>
     <article>
       <h3>
-        <a href="#">List item&mdash;with metadata</a>
+        <a href="#">List item &mdash; with metadata</a>
       </h3>
 
       <div class="meta">
@@ -18,7 +18,7 @@
   <li>
     <article>
       <h3>
-        <a href="#">List item&mdash;with image</a>
+        <a href="#">List item &mdash; with image</a>
       </h3>
 
       <div class="meta">

--- a/examples/agency-contact.html
+++ b/examples/agency-contact.html
@@ -11,7 +11,7 @@
         </div>
       </div>
 
-      <div class="feedback" tabindex="1">
+      <div class="feedback">
         <a href="#content" class="button--feedback">Give feedback</a>
       </div>
 

--- a/examples/agency-content.html
+++ b/examples/agency-content.html
@@ -169,8 +169,8 @@
     <p>We offer services to support carers including:</p>
 
     <ul>
-      <li>The Vacation Childcare Subsidisation Program&mdash;for children aged between five and 12 years. To qualify, children must attend a registered child care service during the school holidays.</li>
-      <li>Carers’ room&mdash;available for staff who need to take care of immediate family members in an emergency. It gives people an alternative to using leave. Conditions of use apply.</li>
+      <li>The Vacation Childcare Subsidisation Program &mdash; for children aged between five and 12 years. To qualify, children must attend a registered child care service during the school holidays.</li>
+      <li>Carers’ room &mdash; available for staff who need to take care of immediate family members in an emergency. It gives people an alternative to using leave. Conditions of use apply.</li>
     </ul>
 
     <h3 id="eldercare">Eldercare</h3>

--- a/examples/agency-content.html
+++ b/examples/agency-content.html
@@ -11,7 +11,7 @@
         </div>
       </div>
 
-      <div class="feedback" tabindex="1">
+      <div class="feedback">
         <a href="#content" class="button--feedback">Give feedback</a>
       </div>
 

--- a/examples/agency-landing.html
+++ b/examples/agency-landing.html
@@ -11,7 +11,7 @@
         </div>
       </div>
 
-      <div class="feedback" tabindex="1">
+      <div class="feedback">
         <a href="#content" class="button--feedback">Give feedback</a>
       </div>
 

--- a/examples/agency-listing.html
+++ b/examples/agency-listing.html
@@ -11,7 +11,7 @@
         </div>
       </div>
 
-      <div class="feedback" tabindex="1">
+      <div class="feedback">
         <a href="#content" class="button--feedback">Give feedback</a>
       </div>
 

--- a/examples/govau-home.html
+++ b/examples/govau-home.html
@@ -14,12 +14,12 @@
         <h2>Popular links</h2>
         <ul>
           <li><a href="#content">Dates and times</a></li>
-          <li><a href="#content">Tax returns</a></li>
-          <li><a href="#content">Broadband</a></li>
-          <li><a href="#content">Elections</a></li>
+          <li><span class="placeholder-link">Tax returns</span></li>
+          <li><span class="placeholder-link">Broadband</span></li>
+          <li><span class="placeholder-link">Elections</span></li>
           <li><a href="#content">Television reception</a></li>
-          <li><a href="#content">School holiday dates</a></li>
-          <li><a href="#content">Government jobs</a></li>
+          <li><span class="placeholder-link">School holiday dates</span></li>
+          <li><span class="placeholder-link">Government jobs</span></li>
         </ul>
       </div>
 
@@ -45,37 +45,37 @@
     <ul class="list-vertical--thirds">
       <li>
         <article>
-          <h3><a href="javascript:void(0)">Business and industry</a></h3>
+          <h3><span class="placeholder-link">Business and industry</span></h3>
           <p> ABNs, grants, non-profits, small business, import, export.</p>
         </article>
       </li>
       <li>
         <article>
-          <h3><a href="javascript:void(0)">Crime, justice and the law</a></h3>
+          <h3><span class="placeholder-link">Crime, justice and the law</span></h3>
           <p> Consumer protection, fraud, emergency services, police, rights.</p>
         </article>
       </li>
       <li>
         <article>
-          <h3><a href="javascript:void(0)">Culture, sport and the arts</a></h3>
+          <h3><span class="placeholder-link">Culture, sport and the arts</span></h3>
           <p> Indigenous heritage, arts grants, cultural institutions, awards.</p>
         </article>
       </li>
       <li>
         <article>
-          <h3><a href="javascript:void(0)">Education</a></h3>
+          <h3><span class="placeholder-link">Education</span></h3>
           <p> Early childhood, school, higher education, skills recognition, VET.</p>
         </article>
       </li>
       <li>
         <article>
-          <h3><a href="javascript:void(0)">Emergencies and disasters</a></h3>
+          <h3><span class="placeholder-link">Emergencies and disasters</span></h3>
           <p> Triple Zero (000), natural disasters, health emergencies.</p>
         </article>
       </li>
       <li>
         <article>
-          <h3><a href="javascript:void(0)">Environment and agriculture</a></h3>
+          <h3><span class="placeholder-link">Environment and agriculture</span></h3>
           <p> Energy efficiency, environmental management, biodiversity, grants.</p>
         </article>
       </li>
@@ -87,7 +87,7 @@
       </li>
       <li>
         <article>
-          <h3><a href="javascript:void(0)">Immigration, visas and citizenship</a></h3>
+          <h3><span class="placeholder-link">Immigration, visas and citizenship</span></h3>
           <p> Australian citizenship, customs, visas, migration and tourism.</p>
         </article>
       </li>
@@ -99,37 +99,37 @@
       </li>
       <li>
         <article>
-          <h3><a href="javascript:void(0)">Jobs and work</a></h3>
+          <h3><span class="placeholder-link">Jobs and work</span></h3>
           <p> Government jobs, employment services, working conditions.</p>
         </article>
       </li>
       <li>
         <article>
-          <h3><a href="javascript:void(0)">Money, tax and super</a></h3>
+          <h3><span class="placeholder-link">Money, tax and super</span></h3>
           <p> Tax returns, ABNs, superannuation, personal finance, financial regulation.</p>
         </article>
       </li>
       <li>
         <article>
-          <h3><a href="javascript:void(0)">Science</a></h3>
+          <h3><span class="placeholder-link">Science</span></h3>
           <p> Science grants and awards, National Measurement Institute.</p>
         </article>
       </li>
       <li>
         <article>
-          <h3><a href="javascript:void(0)">Security and defence</a></h3>
+          <h3><span class="placeholder-link">Security and defence</span></h3>
           <p> National security, cyber security, ADF, military history, commemoration.</p>
         </article>
       </li>
       <li>
         <article>
-          <h3><a href="javascript:void(0)">Trade and international</a></h3>
+          <h3><span class="placeholder-link">Trade and international</span></h3>
           <p> Importing, exporting, free trade, foreign investment, foreign aid.</p>
         </article>
       </li>
       <li>
         <article>
-          <h3><a href="javascript:void(0)">Travelling overseas</a></h3>
+          <h3><span class="placeholder-link">Travelling overseas</span></h3>
           <p> Customs and quarantine, embassies and consulates, travelling overseas.</p>
         </article>
       </li>
@@ -141,7 +141,7 @@
       </li>
       <li>
         <article>
-          <h3><a href="javascript:void(0)">About Government</a></h3>
+          <h3><span class="placeholder-link">About Government</span></h3>
           <p>Government structure, elections, Budget, Australian Public Service.</p>
         </article>
       </li>
@@ -315,9 +315,9 @@
         <ul>
           <li><h2>Title header</h2></li>
           <li><a href="#content">This is a footer link</a></li>
-          <li><a href="#content">This is a footer link</a></li>
-          <li><a href="#content">This is a footer link</a></li>
-          <li><a href="#content">This is a footer link</a></li>
+          <li><span class="placeholder-link">This is a footer link</span></li>
+          <li><span class="placeholder-link">This is a footer link</span></li>
+          <li><span class="placeholder-link">This is a footer link</span></li>
         </ul>
       </nav>
     </section>
@@ -332,7 +332,7 @@
             <li><a href="#content">Example global link</a></li>
             <li><a href="#content">Example global link</a></li>
             <li><a href="#content">Example global link</a></li>
-            <li><a href="#content">Example global link</a></li>
+            <li><span class="placeholder-link">Example global link</span></li>
           </ul>
         </nav>
         <p>&copy; Commonwealth of Australia <br>

--- a/examples/govau-home.html
+++ b/examples/govau-home.html
@@ -35,10 +35,10 @@
 
 
 <!-- ========== Main page row ========== -->
-<main id="content">
+<main>
 
 
-  <!--<article id="content" class="content-main">-->
+  <article id="content">
   <!-- ========== Content ========== -->
 
     <h2>Information and services</h2>
@@ -282,7 +282,7 @@
 
 
   <!-- ========== end Content ========== -->
-  <!--</article>-->
+  </article>
 </main>
 
 

--- a/examples/ministers-content.html
+++ b/examples/ministers-content.html
@@ -11,7 +11,7 @@
         </div>
       </div>
 
-      <div class="feedback" tabindex="1">
+      <div class="feedback">
         <a href="#content" class="button--feedback">Give feedback</a>
       </div>
 

--- a/examples/ministers-content.html
+++ b/examples/ministers-content.html
@@ -47,12 +47,12 @@
     <nav class="local-nav" aria-label="main navigation">
       <h1 class="is-visuallyhidden">Menu</h1>
       <ul>
-        <li> <a class="is-active" href="ministers-landing.html">Minister for Communications</a>
+        <li><a class="is-active" href="ministers-landing.html">Minister for Communications</a>
           <ul>
-            <li> <a href="#content" class="is-active is-current"> Responsibilities </a> </li>
-            <li> <a href="profile.html"> About the minister </a> </li>
-            <li> <a href="news-section-listing.html"> News </a> </li>
-            <li> <a href="#content"> Contact </a> </li>
+            <li><a href="#content" class="is-active is-current">Responsibilities</a></li>
+            <li><a href="profile.html">About the minister</a></li>
+            <li><a href="news-section-listing.html">News</a></li>
+            <li><a href="#content">Contact</a></li>
           </ul>
         </li>
       </ul>
@@ -71,7 +71,7 @@
 
     <p>The minister leads the <a href="agency-landing.html">Department of Communications and the Arts</a> and other government agencies within the Communications portfolio.</p>
     <p>Ministers are members of the Australian Government who have been allocated an area of responsibility for how Australia is run. This area of responsibility is known as a portfolio.</p>
-    <p>The department and agencies provide information and deliver services related to various portfolio responsibilities such as <a href="#content">television, radio, internet, phones and more.</a> </p>
+    <p>The department and agencies provide information and deliver services related to various portfolio responsibilities such as <a href="#content">television, radio, internet, phones and more.</a></p>
     <p>The minister works with their department, agencies, community organisations and professional associations to:</p>
 
     <ul>

--- a/examples/ministers-landing.html
+++ b/examples/ministers-landing.html
@@ -110,7 +110,7 @@
       </li>
       <li>
         <article>
-          <h3><a href="#content">Sydney&mdash;final countdown to digital-only TV has begun</a></h3>
+          <h3><a href="#content">Sydney &mdash; final countdown to digital-only TV has begun</a></h3>
           <div class="meta">13 November 2013</div>
         </article>
       </li>

--- a/examples/ministers-landing.html
+++ b/examples/ministers-landing.html
@@ -11,7 +11,7 @@
         </div>
       </div>
 
-      <div class="feedback" tabindex="1">
+      <div class="feedback">
         <a href="#content" class="button--feedback">Give feedback</a>
       </div>
 

--- a/examples/ministers-listing.html
+++ b/examples/ministers-listing.html
@@ -11,7 +11,7 @@
         </div>
       </div>
 
-      <div class="feedback" tabindex="1">
+      <div class="feedback">
         <a href="#content" class="button--feedback">Give feedback</a>
       </div>
 

--- a/examples/ministers-listing.html
+++ b/examples/ministers-listing.html
@@ -50,7 +50,7 @@
       <li><a href="#content"><span> Minister for the</span> Arts</a></li>
       <li><a href="#content">Attorney-General</a></li>
       <li><a href="#content">Cabinet Secretary</a></li>
-      <li><a href="ministers-landing.html"> <span> Minister for</span> Communications</a></li>
+      <li><a href="ministers-landing.html"><span> Minister for</span> Communications</a></li>
       <li><a href="#content"><span> Minister for</span> Defence</a></li>
       <li><a href="#content"><span> Minister for</span> Defence Industry</a></li>
       <li><a href="#content">Deputy Prime Minister</a></li>

--- a/examples/news-article.html
+++ b/examples/news-article.html
@@ -79,7 +79,7 @@
     <p>TV reception in the Hunter area has always been unusually challenging, with mother nature throwing in a few curve balls. The hilly countryside means that a large number of TV tower sites are needed to provide adequate television coverage, and the addition of a weather phenomenon called ‘seasonal ducting’ (see below) has also played a part.</p>
     <p>Apart from these things we can’t control, poor antenna installation and cabling, wrongly located antennas, and incorrect receiver tuning are also to blame for reception difficulties.</p>
 
-    <h3 id="seasonal-ducting-what-is-it">Seasonal ducting&mdash;what is it?</h3>
+    <h3 id="seasonal-ducting-what-is-it">Seasonal ducting &mdash; what is it?</h3>
     <p>Even with correct antenna installation, some viewers in the Hunter region may still have experienced poor TV reception because of the natural phenomenon known as atmospheric or signal ducting.</p>
     <p>Atmospheric ducting of TV signals happens when distinctive weather conditions—especially high-pressure systems and still conditions—causes distant broadcast signals to travel further than planned. These unintended ‘rogue’ signals then interfere with local signals because antennas and receivers can’t differentiate between the local signals and those being ducted from distant TV towers. Ducting interference affects mainly households in the townships north of Newcastle that receive services from Mount Sugarloaf, as Mount Sugarloaf services operate on the same channels as the high power transmission site that serves the Illawarra area to the south of Sydney.</p>
     <p>Summer is the most common time for ducting to occur, but it can happen at any time if conditions are right. You may be able to tell it’s ducting if your TV reception is affected in the late afternoon or early evening.</p>
@@ -98,7 +98,7 @@
 
     <p>The new and upgraded services are all expected to be in operation by early 2016.</p>
 
-    <h2 id="the-hills-are-alive-is-there-another-alternative">The hills are alive&mdash;is there another alternative?</h2>
+    <h2 id="the-hills-are-alive-is-there-another-alternative">The hills are alive &mdash; is there another alternative?</h2>
     <p>Those pesky trees&hellip; While the TV tower upgrades are expected to improve the TV reception, some households will still have trouble (even if they have proper antenna equipment and installation) because TV signals get obstructed by the hilly countryside, trees or buildings. If you still can’t get reliable TV reception, you can join the other 200,000 households across Australia and take advantage of the Viewer Access Satellite Television (VAST) service.</p>
 
     <p>Launched in 2010, VAST was established by the Australian Government to provide households without reliable terrestrial television reception with access to a range of standard and HD digital services. Channels on VAST include ABC 1 (NSW), ABC 2/ABC 4 Kids, ABC 3, ABC NEWS 24, SBS, SBS 2, SBS HD and NITV. Nine commercial digital channels are provided by Imparja Television and Southern Cross Austereo, drawing on programs from the Seven, Nine and Ten networks. <abbr>VAST</abbr> also provides dedicated news channels carrying bulletins from regional commercial television broadcasters, including bulletins from <abbr>NBN</abbr> Central Coast and <abbr>NBN</abbr> Newcastle. A range of <abbr>ABC</abbr> and <abbr>SBS</abbr> radio services is also available via <abbr>VAST</abbr>.</p>

--- a/examples/news-article.html
+++ b/examples/news-article.html
@@ -12,7 +12,7 @@
         </div>
       </div>
 
-      <div class="feedback" tabindex="1">
+      <div class="feedback">
         <a href="#" class="button--feedback">Give feedback</a>
       </div>
 

--- a/examples/news-listing.html
+++ b/examples/news-listing.html
@@ -12,7 +12,7 @@
         </div>
       </div>
 
-      <div class="feedback" tabindex="1">
+      <div class="feedback">
         <a href="#content" class="button--feedback">Give feedback</a>
       </div>
 

--- a/examples/news-listing.html
+++ b/examples/news-listing.html
@@ -181,7 +181,8 @@
           <h3><a href="#content">Sky News First Edition interview with Senator Mathias Cormann</a></h3>
           <div class="meta">
             <time datetime="2016-07-29">29 July 2016</time>
-            <a rel="author" href="#content">Minister for Finance</a> </div>
+            <a rel="author" href="#content">Minister for Finance</a>
+          </div>
           <p> A transcript of the interview by journalist Kieran Gilbert on topics including Kevin Rudd and the United Nations, immigration and the Royal Commission into Northern Territory Youth Detention.</p>
           <footer class="tags">
             <dl>
@@ -198,7 +199,8 @@
           <h3><a href="#content">Minister for Health and Aged Care welcomes Whitecoat joint venture</a></h3>
           <div class="meta">
             <time datetime="2016-07-29">29 July 2016</time>
-            <a rel="author" href="#content">Minister for Health and Aged Care</a> </div>
+            <a rel="author" href="#content">Minister for Health and Aged Care</a>
+          </div>
           <p> Minister Ley welcomes the announcement from some private health insurers that more information will be made available to Australians about their health services.</p>
           <footer class="tags">
             <dl>
@@ -233,7 +235,8 @@
           <h3><a href="#content">Nola Marino re-appointed as Chief Government Whip</a></h3>
           <div class="meta">
             <time datetime="2016-07-29">29 July 2016</time>
-            <a rel="author" href="#content">Prime Minister</a> </div>
+            <a rel="author" href="#content">Prime Minister</a>
+          </div>
           <p> I am pleased to announce the re-appointment of Ms Nola Marino as the Chief Government Whip.</p>
           <footer class="tags">
             <dl>
@@ -250,7 +253,8 @@
           <h3><a href="#content">Thousands of Australians now free of Hepatitis C</a></h3>
           <div class="meta">
             <time datetime="2016-07-28">28 July 2016</time>
-            <a rel="author" href="#content">Minister for Health and Aged Care</a> </div>
+            <a rel="author" href="#content">Minister for Health and Aged Care</a>
+          </div>
           <p> The Australian Government’s commitment to put an end to the Hep C virus is paying off.</p>
           <footer class="tags">
             <dl>
@@ -267,7 +271,8 @@
           <h3><a href="#content">Immigration and customs functions in Norfolk Island</a></h3>
           <div class="meta">
             <time datetime="2016-07-11">11 July 2016</time>
-            <a rel="author" href="#content">Department of Immigration and Border Protection</a> </div>
+            <a rel="author" href="#content">Department of Immigration and Border Protection</a>
+          </div>
           <p> The Department of Immigration and Border Protection is delivering immigration and customs functions on Norfolk Island.</p>
           <footer class="tags">
             <dl>
@@ -284,7 +289,8 @@
           <h3><a href="#content">Whole of Australian Government (WoAG) Accommodation Arrangement</a></h3>
           <div class="meta">
             <time datetime="2016-05-10">10 May 2016</time>
-            <a rel="author" href="#content">Department of Finance</a> </div>
+            <a rel="author" href="#content">Department of Finance</a>
+          </div>
           <p> The Department of Finance is seeking comments on a discussion paper that may shape a future accommodation program for the Australian Government.</p>
           <footer class="tags">
             <dl>
@@ -301,7 +307,8 @@
           <h3><a href="#content">Aged under 15: what does it mean for classifications?</a></h3>
           <div class="meta">
             <time datetime="2016-05-06">06 May 2016</time>
-            <a rel="author" href="agency-landing.html">Department of Communications and the Arts</a> </div>
+            <a rel="author" href="agency-landing.html">Department of Communications and the Arts</a>
+          </div>
           <p> Classifications help you to make informed decisions about what you and your children see and play.</p>
           <footer class="tags">
             <dl>
@@ -318,7 +325,8 @@
           <h3><a href="#content">Sydney – final countdown to digital-only TV has begun</a></h3>
           <div class="meta">
             <time datetime="2013-11-13">13 November 2013</time>
-            <a rel="author" href="ministers-landing.html">Minister for Communications</a> </div>
+            <a rel="author" href="ministers-landing.html">Minister for Communications</a>
+          </div>
           <p> Sydney and surrounding areas will switch to digital-only TV at 9am on 3 December 2013.</p>
           <footer class="tags">
             <dl>

--- a/examples/news-section-listing.html
+++ b/examples/news-section-listing.html
@@ -12,7 +12,7 @@
         </div>
       </div>
 
-      <div class="feedback" tabindex="1">
+      <div class="feedback">
         <a href="#content" class="button--feedback">Give feedback</a>
       </div>
 

--- a/examples/profile.html
+++ b/examples/profile.html
@@ -12,7 +12,7 @@
         </div>
       </div>
 
-      <div class="feedback" tabindex="1">
+      <div class="feedback">
         <a href="#content" class="button--feedback">Give feedback</a>
       </div>
 

--- a/examples/topic-category.html
+++ b/examples/topic-category.html
@@ -12,7 +12,7 @@
         </div>
       </div>
 
-      <div class="feedback" tabindex="1">
+      <div class="feedback">
         <a href="#content" class="button--feedback">Give feedback</a>
       </div>
 

--- a/examples/topic-content.html
+++ b/examples/topic-content.html
@@ -12,7 +12,7 @@
         </div>
       </div>
 
-      <div class="feedback" tabindex="1">
+      <div class="feedback">
         <a href="#content" class="button--feedback">Give feedback</a>
       </div>
 

--- a/examples/topic-landing.html
+++ b/examples/topic-landing.html
@@ -12,7 +12,7 @@
         </div>
       </div>
 
-      <div class="feedback" tabindex="1">
+      <div class="feedback">
         <a href="#content" class="button--feedback">Give feedback</a>
       </div>
 


### PR DESCRIPTION
## Description

Specific link styles to `.content-main` have been replaced so that
those link styles are applied to any `article` within `main`. Keeping
it more high level.

The `content-main` class, which the link style was originally applied
to, was specifically a content area for layouts with a sidebar…
## Additional information

That said…
NOTE: Should revisit the naming structure for `content-main`, and
clarify full-width layouts, layouts with sidebars, layouts that have
multiple columns within the `content-main` etc….

Previously looked like this:

![image](https://cloud.githubusercontent.com/assets/19661064/17798865/d894e8fc-6618-11e6-8b7d-1110a5b5da8b.png)

Now looks like this:
![image](https://cloud.githubusercontent.com/assets/19661064/17798881/f8344734-6618-11e6-80a5-b10aff719a7c.png)
## Definition of Done
- [x] Code reviewed by one of the core developers
- [x] Acceptance Testing
  - [x] HTML5 validation (CircleCI)
  - [x] Accessibility testing & WCAG2 compliance (`node test/pa11y.js`)
- [x] Stakeholder/PO review
- [x] CHANGELOG updated
