### PR TITLE
Fix for line-length and full width (12col) elements

### DIFF
--- a/assets/sass/_grid-layout.scss
+++ b/assets/sass/_grid-layout.scss
@@ -138,10 +138,36 @@ main {
       }
 
       @include media($desktop) {
-        @include span-columns(10 of 16);
-        @include shift(2);
+        @include span-columns(12 of 16);
+
+        //Elements which should have shorter line-length for readability.
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        p,
+        ul,
+        ol,
+        dl {
+          max-width: 38rem;
+        }
+
+        //Elements which are one of the above but should be full width.
+        .content-full-width,
+        .list-horizontal,
+        .list-vertical,
+        .list-vertical--thirds,
+        .list-vertical--forths,
+        .inline-tab-nav ul,
+        .inline-links,
+        .inline-links--inverted {
+          max-width: none;
+          width: 100%;
+        }
       }
 
+      // Know what this is for?
       &:first-child {
 
         @include reset-layout-direction;


### PR DESCRIPTION
- `.content-main` Change to 12 col.
- body copy elements set to max-rem width
- resets for above added
- new class `.content-full-width` added (if useful?)
## Definition of Done
- [ ] Content/documentation reviewed by Julian or someone in the Content Team
- [x] UX reviewed by Gary or someone the Design team
- [ ] Code reviewed by one of the core developers
- [ ] Acceptance Testing
  - [ ] Cross-browser tested against standard browser matrix (TBD)
  - [ ] Tested on multiple devices (TBD)
  - [ ] HTML5 validation (CircleCI)
  - [ ] Accessibility testing & WCAG2 compliance (`node test/pa11y.js`)
- [ ] Stakeholder/PO review
- [ ] CHANGELOG updated
