### PR TITLE
Fix for line-length and full width (12col) elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## UI Kit "Kraken"
 
+### `develop` (unreleased)
+
+#### UI-Kit changes
+
+- Desktop: Content area is now 12 columns wide to accommodate larger block elements. In response basic text elements `h1-h6, p, li, dl` now have a max-width for readability. See `_grid-layout.scss`
+- Desktop: Added `.content-full-width` as a method of making basic text elements fill to 12 columns if required (see above).
+
 ### 1.7.5 - 2016-08-25
 
 #### UI-Kit changes

--- a/assets/sass/_grid-layout.scss
+++ b/assets/sass/_grid-layout.scss
@@ -149,8 +149,7 @@ main {
         p,
         ul,
         ol,
-        dl,
-        pre {
+        dl {
           max-width: 38rem;
         }
 

--- a/assets/sass/_grid-layout.scss
+++ b/assets/sass/_grid-layout.scss
@@ -139,22 +139,6 @@ main {
 
       @include media($desktop) {
         @include span-columns(12 of 16);
-
-        h1,
-        h2,
-        h3,
-        h4,
-        h5,
-        p,
-        li,
-        dl {
-          max-width: 38rem;
-        }
-
-        .content-full-width {
-          max-width: none;
-          width: 100%;
-        }
       }
 
       // Know what this is for?

--- a/assets/sass/_grid-layout.scss
+++ b/assets/sass/_grid-layout.scss
@@ -146,6 +146,7 @@ main {
         h4,
         h5,
         p,
+        li,
         dl {
           max-width: 38rem;
         }

--- a/assets/sass/_grid-layout.scss
+++ b/assets/sass/_grid-layout.scss
@@ -149,7 +149,8 @@ main {
         p,
         ul,
         ol,
-        dl {
+        dl,
+        pre {
           max-width: 38rem;
         }
 

--- a/assets/sass/_grid-layout.scss
+++ b/assets/sass/_grid-layout.scss
@@ -140,28 +140,17 @@ main {
       @include media($desktop) {
         @include span-columns(12 of 16);
 
-        //Elements which should have shorter line-length for readability.
         h1,
         h2,
         h3,
         h4,
         h5,
         p,
-        ul,
-        ol,
         dl {
           max-width: 38rem;
         }
 
-        //Elements which are one of the above but should be full width.
-        .content-full-width,
-        .list-horizontal,
-        .list-vertical,
-        .list-vertical--thirds,
-        .list-vertical--forths,
-        .inline-tab-nav ul,
-        .inline-links,
-        .inline-links--inverted {
+        .content-full-width {
           max-width: none;
           width: 100%;
         }

--- a/assets/sass/_grid-layout.scss
+++ b/assets/sass/_grid-layout.scss
@@ -138,10 +138,36 @@ main {
       }
 
       @include media($desktop) {
-        @include span-columns(10 of 16);
-        @include shift(2);
+        @include span-columns(12 of 16);
+
+        //Elements which should have shorter line-length for readability.
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        p,
+        ul,
+        ol,
+        dl {
+          max-width: 38rem;
+        }
+
+        //Elements which are one of the above but should be full width.
+        .content-full-width,
+        .list-horizontal,
+        .list-vertical,
+        .list-vertical--thirds,
+        .list-vertical--forths,
+        .inline-tab-nav ul,
+        .inline-links,
+        .inline-links--inverted {
+          max-width: none;
+          width: 100%;
+        }
       }
 
+      // Know what this is for?
       &:first-child {
 
         @include reset-layout-direction;

--- a/assets/sass/_lists.scss
+++ b/assets/sass/_lists.scss
@@ -162,7 +162,7 @@ Style guide: List styles.4 Highlighted word style
   }
 
   > li {
-    padding: $base-spacing 0;
+    padding: 4% 0; //Was `padding: $base-spacing 0;` changed to match gutter
     border-bottom: solid 1px $border-colour;
     margin-bottom: 0;
   }

--- a/assets/sass/_lists.scss
+++ b/assets/sass/_lists.scss
@@ -190,6 +190,9 @@ Style guide: List styles.4 Highlighted word style
 
   > li {
 
+    width: 100%;
+    max-width: none;
+
     @include media($tablet) {
       display: flex;
     }

--- a/assets/sass/_typography.scss
+++ b/assets/sass/_typography.scss
@@ -246,7 +246,7 @@ We are currently testing all styles for legibility and readability.
 
 Markup: templates/heading-body-styles.hbs
 
-Style guide: Typography.2 Headings & body copy
+Style guide: Typography.4 Headings & body copy
 */
 
 // Styling for headings
@@ -379,6 +379,32 @@ h6 {
   }
 }
 
+/*
+Line length
+
+UI Kit applies a maximum width to typographic elements that appear within the main content container. This maintains a readable line length.
+
+A max-width of 38rem (about 70 characters) is applied to these elements:
+- h1 - h5
+- p
+- li
+- dl
+
+<div class="callout">
+
+If you'd like to include an element that spans across the maximum available space, apply the class `.content-full-width`.
+
+</div>
+
+### Resources
+- [Typography -  Accessibility](/section-typography.html#guide-typography-1-typeface-2-accessibility)
+- <a href="https://www.smashingmagazine.com/2014/09/balancing-line-length-font-size-responsive-web-design/#line-length-measure-and-reading" rel="external">Size Matters, Smashing Magazine</a>
+
+Markup: templates/content-full-width.hbs
+
+Style guide: Typography.4 Line length
+*/
+
 .content-main {
   @include media($desktop) {
     h1,
@@ -430,7 +456,7 @@ Markup: Copy text to clipboard using <kbd>Ctrl</kbd> + <kbd>C</kbd>.
   </div>
 </details>
 
-Style guide: Typography.8 Keyboard input
+Style guide: Typography.5 Keyboard input
 */
 
 kbd {
@@ -520,7 +546,7 @@ More [complex list styles](section-list-styles.html) are available.
 
 Markup: templates/list-examples.hbs
 
-Style guide: Typography.4 Lists
+Style guide: Typography.6 Lists
 */
 
 ul,
@@ -597,7 +623,7 @@ Markup: templates/callouts-examples.hbs
   </div>
 </details>
 
-Style guide: Typography.5 Callouts & warnings
+Style guide: Typography.7 Callouts & warnings
 */
 
 %base-callout {
@@ -672,7 +698,7 @@ Markup: templates/badges.hbs
   </div>
 </details>
 
-Style guide: Typography.6 Badges
+Style guide: Typography.8 Badges
 */
 
 $badges: (
@@ -730,7 +756,7 @@ Markup: templates/quotation-examples.hbs
   </div>
 </details>
 
-Style guide: Typography.7 Quotations
+Style guide: Typography.9 Quotations
 */
 
 blockquote {

--- a/assets/sass/_typography.scss
+++ b/assets/sass/_typography.scss
@@ -379,6 +379,26 @@ h6 {
   }
 }
 
+.content-main {
+  @include media($desktop) {
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    p,
+    li,
+    dl {
+      max-width: 38rem;
+    }
+
+    .content-full-width {
+      max-width: none;
+      width: 100%;
+    }
+  }
+}
+
 // a {
 //   color: $link-colour;
 //   text-decoration: none;

--- a/assets/sass/_typography.scss
+++ b/assets/sass/_typography.scss
@@ -399,22 +399,6 @@ h6 {
   }
 }
 
-// a {
-//   color: $link-colour;
-//   text-decoration: none;
-//   border-bottom: 1px solid;
-//
-//   &:visited {
-//     color: $link-colour;
-//   }
-//
-//   &:hover,
-//   &:active {
-//     color: $link-hover-colour;
-//   }
-//
-// }
-
 code,
 pre,
 samp,

--- a/assets/sass/templates/content-full-width.hbs
+++ b/assets/sass/templates/content-full-width.hbs
@@ -1,0 +1,9 @@
+<p>
+  This paragraph will automatically wrap to a readable line length, which is usually estimated to be 65 characters (2.5 times the Roman alphabet). This can vary based on other factors, such as type face and size.
+</p>
+<p class="content-full-width">
+  This paragraph will span the full width of the main content area, which represents 12 of 16 total columns, about 900px at the maximum layout size. This can be useful when including an inline image which you'd like to appear at full-width.
+</p>
+<p class="content-full-width">
+  <img src="http://placehold.it/900x150" alt="Demonstration image" />
+</p>


### PR DESCRIPTION
- `.content-main` Change to 12 col.
- body copy elements set to max-rem width
- resets for above added
- new class `.content-full-width` added
## Definition of Done
- [x] Content/documentation reviewed by Julian or someone in the Content Team
- [x] UX reviewed by Gary or someone the Design team
- [x] Code reviewed by one of the core developers
- [x] Acceptance Testing
  - [x] Cross-browser tested
  - [x] Tested on multiple devices
  - [x] HTML5 validation (CircleCI)
  - [x] Accessibility testing & WCAG2 compliance (`node test/pa11y.js`)
- [x] Stakeholder/PO review
- [x] CHANGELOG updated
