### PR TITLE
Make Header title image fluid on small screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
 
 - Added guidance for font usage and accessibility (documented under *§ Typography - Typeface*).
 
+#### Bugfixes
+
+- Fixed Header title image not fluid-width on small screens
+
 ### 1.7.4 - 2016-08-17
 
 #### Accessibility testing

--- a/assets/sass/_page-header.scss
+++ b/assets/sass/_page-header.scss
@@ -159,7 +159,8 @@
     background-position: center center;
     background-repeat: no-repeat;
     background-size: 100% auto;
-    width: 337px;
+    width: 100%;
+    max-width: 337px;
     height: 51px;
 
     &.dusk {


### PR DESCRIPTION
## Description

The `.govau--text` image didn't have a fluid width, so I gave it one and added a `max-width`
## Before

![image](https://cloud.githubusercontent.com/assets/5482613/17919168/b39aed5e-6a0e-11e6-96d9-bb7c06041ce9.png)
## After

![image](https://cloud.githubusercontent.com/assets/5482613/17919156/9b083cec-6a0e-11e6-8c37-89305df1eca8.png)
## Definition of Done
- [x] UX reviewed by Gary or someone the Design team
- [x] Code reviewed by one of the core developers
- [ ] Acceptance Testing
  - [x] Cross-browser tested
  - [x] Tested on multiple devices
  - [x] HTML5 validation (CircleCI)
  - [x] Accessibility testing & WCAG2 compliance (`npm test`)
- [x] Stakeholder/PO review
- [x] CHANGELOG updated
