### PR TITLE
Fix HTML validation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Desktop: Content area is now 12 columns wide to accommodate larger block elements. In response basic text elements `h1-h6, p, li, dl` now have a max-width for readability. See `_grid-layout.scss`
 - Desktop: Added `.content-full-width` as a method of making basic text elements fill to 12 columns if required (see above).
 
+#### Bugfixes
+
+- Fixed HTML validation errors [PR 311](https://github.com/AusDTO/gov-au-ui-kit/pull/311)
+
 ### 1.7.5 - 2016-08-25
 
 #### UI-Kit changes

--- a/assets/sass/_forms.scss
+++ b/assets/sass/_forms.scss
@@ -17,7 +17,7 @@ Text input
 
 Single line text inputs.
 
-They can be limited to number input only by setting the `type` attribute to `number`. For telephone numbers set the `type` attribute to `tel`. To trigger the num-pad on iPhones, add a pattern attribute to the input element: `pattern="[0-9]*"`.
+They can be limited to number input only by setting the `type` attribute to `number`. For telephone numbers set the `type` attribute to `tel`. To explicityly trigger the num-pad on iPhones, omit the `type` attribute and add a pattern attribute to the input element: `pattern="[0-9]*"`.
 
 Markup: templates/text-input-single-line.hbs
 

--- a/assets/sass/templates/groups-links.hbs
+++ b/assets/sass/templates/groups-links.hbs
@@ -17,7 +17,7 @@
 </div>
 
 <div class="links-group">
-  <h3>Related topics</h2>
+  <h3>Related topics</h3>
   <ul class="popular-now">
     <li><a href="#">Dates and times</a></li>
     <li><a href="#">Tax returns</a></li>

--- a/assets/sass/templates/text-input-single-line.hbs
+++ b/assets/sass/templates/text-input-single-line.hbs
@@ -5,7 +5,7 @@
   </p>
   <p>
     <label for="numberin">A <code>number</code> input field</label>
-    <input name="numberin" id="numberin" type="number" pattern="[0-9]*" />
+    <input name="numberin" id="numberin" type="number" />
   </p>
   <p>
     <label for="phonein">A phone number (<code>tel</code>) input field:</label>

--- a/kss-builder/index.hbs
+++ b/kss-builder/index.hbs
@@ -196,7 +196,7 @@
 
           {{#if sourceFile.name}}
             <div class="kss-source">
-              Source on GitHub: <a href="https://github.com/AusDTO/gov-au-ui-kit/tree/master/assets/sass/{{sourceFile.name}}#L{{sourceFile.line}}" rel="external gh-source-ref"><code>{{sourceFile.name}}</code></a>, line {{sourceFile.line}}
+              Source on GitHub: <a href="https://github.com/AusDTO/gov-au-ui-kit/tree/master/assets/sass/{{sourceFile.name}}#L{{sourceFile.line}}" rel="external"><code>{{sourceFile.name}}</code></a>, line {{sourceFile.line}}
             </div>
           {{/if}}
 


### PR DESCRIPTION
## Description

There were 3 errors arising in the `htmlvalidate` task which are now fixed:
- `<input type="number">` can't have a `pattern` attribute. When I took a look at [the spec](https://www.w3.org/TR/2011/WD-html5-20110525/common-input-element-attributes.html#attr-input-pattern) it seems that `pattern` can be used instead of `type`, so this might be an alternate approach.
- `gh-source-ref` is not an [allowed token](https://www.w3.org/TR/html5/links.html#linkTypes) for the `rel` attribute
- Group Links example had a mis-matched `<h3>` tag
## Definition of Done
- [x] Content/documentation reviewed by Julian or someone in the Content Team
- [x] Code reviewed by one of the core developers
- [x] Acceptance Testing
  - [x] HTML5 validation (CircleCI)
  - [x] Accessibility testing & WCAG2 compliance (`npm test`)
- [x] Stakeholder/PO review
- [x] CHANGELOG updated
