### PR TITLE
Grid helpers: Omega reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Added a 'Zoo' example page (`/examples/zoo.html`) that demonstrates every element in the UI Kit
 - Section index links now only show Section headings and not Sub-sections
+- Omega reset mixin added to Grid settings (documented under *§ Grid - Helpers*).
 
 #### Bugfixes
 

--- a/assets/sass/_grid-layout.scss
+++ b/assets/sass/_grid-layout.scss
@@ -1,5 +1,5 @@
 @mixin wrapper-padding {
-  @include pad(0 $base-spacing);
+  @include pad(0 $gutter);
   width: 100%;
   box-sizing: border-box;
 

--- a/assets/sass/_grid-settings.scss
+++ b/assets/sass/_grid-settings.scss
@@ -26,7 +26,6 @@ $grid-columns: 4 !global;
 $max-width: em(1200) !global;
 $gutter: em(32);
 
-
 /*
 Responsive breakpoints
 
@@ -56,11 +55,55 @@ $mobile-minwidth: 420px;
 $tablet-minwidth: 768px;
 $desktop-minwidth: 1200px;
 
-$mobile: new-breakpoint(min-width $mobile-minwidth, 8);
-$mobile-only: new-breakpoint(min-width $mobile-minwidth max-width $tablet-minwidth - 1, 8);
-$tablet: new-breakpoint(min-width $tablet-minwidth, 12);
-$tablet-only: new-breakpoint(min-width $tablet-minwidth max-width $desktop-minwidth - 1, 12);
-$desktop: new-breakpoint(min-width $max-width, 16);
+$mobile-grid-columns: 8;
+$tablet-grid-columns: 12;
+$content-grid-columns: $tablet-grid-columns;
+$desktop-grid-columns: 16;
+
+$mobile: new-breakpoint(min-width $mobile-minwidth, $mobile-grid-columns);
+$mobile-only: new-breakpoint(min-width $mobile-minwidth max-width $tablet-minwidth - 1, $mobile-grid-columns);
+$tablet: new-breakpoint(min-width $tablet-minwidth, $tablet-grid-columns);
+$tablet-only: new-breakpoint(min-width $tablet-minwidth max-width $desktop-minwidth - 1, $tablet-grid-columns);
+$desktop: new-breakpoint(min-width $max-width, $desktop-grid-columns);
+
+/*
+Helpers
+
+Style guide: Grid.4 Helpers
+*/
+
+/*
+Omega Reset
+
+When applying grid-columns to responsive layouts you may find yourself needing to reset the [omega properties applied by Neat](http://thoughtbot.github.io/neat-docs/latest/#omega):
+
+```
+.grid-item {
+  @include span-columns(2 of 4);
+  @include omega(2n);
+
+  @include media($desktop) {
+    @include omega-reset(2n);
+    @include span-columns(4 of 12);
+    @include omega(3n);
+  }
+}
+```
+
+Style guide: Grid.4 Helpers.1 Font stacks
+*/
+
+@mixin omega-reset($nth) {
+  $nth-plus-one: '#{$nth}+1';
+
+  &:nth-child(#{$nth}) {
+    margin-right: flex-gutter($content-grid-columns);
+  }
+
+  &:nth-child(#{$nth-plus-one}) {
+    clear: none;
+  }
+}
 
 /*
 Debugging
@@ -73,7 +116,7 @@ $visual-grid: true;
 
 See the example <a href="http://neat.bourbon.io/examples/" rel="external">Bourbon Neat working grid layout</a>.
 
-Style guide: Grid.4 Debugging
+Style guide: Grid.4 Helpers.2 Debugging
 */
 
 // Toggle visibility of your grid columns for development/debugging.

--- a/assets/sass/_lists.scss
+++ b/assets/sass/_lists.scss
@@ -277,17 +277,6 @@ Style guide: List styles.4 Highlighted word style
   }
 }
 
-@mixin reset-omega2 {
-  &:nth-child(2n) {
-    margin-right: 2.74614%; //can this be pulled as a var from somewhere?
-  }
-
-  &:nth-child(2n+1) {
-    clear: none;
-  }
-}
-
-
 .list-vertical {
   @extend %base-vertical-list;
 
@@ -323,13 +312,12 @@ Style guide: List styles.4 Highlighted word style
       @include omega(2n);
     }
     @include media($desktop) {
-      @include reset-omega2;
+      @include omega-reset(2n);
       @include span-columns(4 of 12);
       @include omega(3n);
     }
   }
 }
-
 
 
 .list-vertical--fourths {
@@ -348,7 +336,7 @@ Style guide: List styles.4 Highlighted word style
       @include omega(2n);
     }
     @include media($desktop) {
-      @include reset-omega2;
+      @include omega-reset(2n);
       @include span-columns(3 of 12);
       @include omega(4n);
     }

--- a/assets/sass/_page-footer.scss
+++ b/assets/sass/_page-footer.scss
@@ -63,7 +63,7 @@ footer[role='contentinfo'] {
         }
 
         @include media($desktop) {
-          @include reset-omega2;
+          @include omega-reset(2n);
           @include span-columns(3 of 12);
           @include omega(5n);
         }


### PR DESCRIPTION
## Description
- Refactors `omega-reset` mixin to accept an nth value
- Moves the `omega-reset` function to `_grid-settings.scss`
- Documents the `omega-reset` under Grid: Helpers

![image](https://cloud.githubusercontent.com/assets/5482613/18071268/cfbd9954-6e97-11e6-8037-0fbd9e47edff.png)
## Definition of Done
- [x] Code reviewed by one of the core developers
- [x] Acceptance Testing
  - [x] HTML5 validation (CircleCI)
  - [x] Accessibility testing & WCAG2 compliance (`npm test`)
- [x] CHANGELOG updated
