### PR TITLE
Update Guide section index links to only list sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 #### Styleguide
 
 - Added a 'Zoo' example page (`/examples/zoo.html`) that demonstrates every element in the UI Kit
+- Section index links now only show Section headings and not Sub-sections
 
 #### Bugfixes
 

--- a/kss-builder/helpers/isEqual.js
+++ b/kss-builder/helpers/isEqual.js
@@ -1,0 +1,13 @@
+/**
+ * Registers the "Package Settings" Handlebars helper.
+ *
+ * @param {object} handlebars The global Handlebars object used by kss-node's kssHandlebarsGenerator.
+ */
+module.exports.register = function(handlebars) {
+  handlebars.registerHelper('if_equal', function(a, b, opts) {
+    if(a == b)
+      return opts.fn(this);
+    else
+      return opts.inverse(this);
+  });
+};

--- a/kss-builder/index.hbs
+++ b/kss-builder/index.hbs
@@ -118,9 +118,9 @@
         <h2>In this section</h2>
         <ul>
           {{#each sections}}
-            {{#unless @first}}
+            {{#if_equal depth 2}}
             <li><a href="#guide-{{referenceURI}}">{{header}}</a></li>
-            {{/unless}}
+            {{/if_equal}}
           {{/each}}
         </ul>
       </nav>


### PR DESCRIPTION
## Description
- Added a helper `is_equal` to use in the guide template
- Checked `depth` of sections before listing them in index links
## Definition of Done
- [x] Code reviewed by one of the core developers
- [x] Acceptance Testing
  - [x] HTML5 validation (CircleCI)
  - [x] Accessibility testing & WCAG2 compliance (`npm test`)
- [x] CHANGELOG updated
