### PR TITLE
Remove `strong` from a11y accordion

### DIFF
--- a/assets/sass/_accordions.scss
+++ b/assets/sass/_accordions.scss
@@ -33,12 +33,12 @@ When implementing accordions:
 <details data-label="accordions-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
-  Passed:
+    <p>Passed:</p>
     <ul>
-      <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
-      <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
+      <li>HTML5 validation (automated)</li>
+      <li>WCAG:AA compliant (automated)</li>
     </ul>
-  Untested:
+    <p>Untested:</p>
     <ul>
       <li>WCAG:AA manual</li>
       <li>Browser support &mdash; automated and manual</li>

--- a/assets/sass/_accordions.scss
+++ b/assets/sass/_accordions.scss
@@ -33,12 +33,12 @@ When implementing accordions:
 <details data-label="accordions-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
-  <strong>Passed</strong>:
+  Passed:
     <ul>
       <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
       <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
     </ul>
-  <strong>Untested</strong>:
+  Untested:
     <ul>
       <li>WCAG:AA manual</li>
       <li>Browser support &mdash; automated and manual</li>

--- a/assets/sass/_buttons.scss
+++ b/assets/sass/_buttons.scss
@@ -31,12 +31,12 @@ Markup: templates/buttons-examples.hbs
 <details data-label="buttons-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
-  <strong>Passed</strong>:
+  Passed:
     <ul>
       <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
       <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
     </ul>
-  <strong>Untested</strong>:
+  Untested:
     <ul>
       <li>WCAG:AA manual</li>
       <li>Browser support &mdash; automated and manual</li>

--- a/assets/sass/_colours.scss
+++ b/assets/sass/_colours.scss
@@ -209,12 +209,12 @@ The <a href="http://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-con
 <details data-label="colour-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
-  <strong>Passed</strong>:
+  Passed:
     <ul>
       <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
       <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
     </ul>
-  <strong>Untested</strong>:
+  Untested:
     <ul>
       <li>WCAG:AA manual</li>
       <li>Browser support &mdash; automated and manual</li>

--- a/assets/sass/_forms.scss
+++ b/assets/sass/_forms.scss
@@ -24,12 +24,12 @@ Markup: templates/text-input-single-line.hbs
 <details data-label="text-input-single-line-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
-  <strong>Passed</strong>:
+  Passed:
     <ul>
       <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
       <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
     </ul>
-  <strong>Untested</strong>:
+  Untested:
     <ul>
       <li>WCAG:AA manual</li>
       <li>Browser support &mdash; automated and manual</li>
@@ -114,12 +114,12 @@ form {
   <details data-label="text-area-input-accessibility" aria-expanded="false">
     <summary>Accessibility &amp; browser testing</summary>
     <div class="accordion-panel">
-    <strong>Passed</strong>:
+    Passed:
       <ul>
         <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
         <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
       </ul>
-    <strong>Untested</strong>:
+    Untested:
       <ul>
         <li>WCAG:AA manual</li>
         <li>Browser support &mdash; automated and manual</li>
@@ -206,12 +206,12 @@ form {
   <details data-label="radio-button-accessibility" aria-expanded="false">
     <summary>Accessibility &amp; browser testing</summary>
     <div class="accordion-panel">
-    <strong>Passed</strong>:
+    Passed:
       <ul>
         <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
         <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
       </ul>
-    <strong>Untested</strong>:
+    Untested:
       <ul>
         <li>WCAG:AA manual</li>
         <li>Browser support &mdash; automated and manual</li>
@@ -279,12 +279,12 @@ Markup:
 <details data-label="checkbox-input-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
-  <strong>Passed</strong>:
+  Passed:
     <ul>
       <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
       <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
     </ul>
-  <strong>Untested</strong>:
+  Untested:
     <ul>
       <li>WCAG:AA manual</li>
       <li>Browser support &mdash; automated and manual</li>

--- a/assets/sass/_grid-layout.scss
+++ b/assets/sass/_grid-layout.scss
@@ -227,12 +227,12 @@ Low-vision users should be able to increase the size of the text by up to 200 pe
 <details data-label="grid-text-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
-  <strong>Passed</strong>:
+  Passed:
     <ul>
       <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
       <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
     </ul>
-  <strong>Untested</strong>:
+  Untested:
     <ul>
       <li>WCAG:AA manual</li>
       <li>Browser support &mdash; automated and manual</li>

--- a/assets/sass/_links.scss
+++ b/assets/sass/_links.scss
@@ -22,12 +22,12 @@ Markup: templates/basic-links.hbs
 <details data-label="basic-links-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
-  <strong>Passed</strong>:
+  Passed:
     <ul>
       <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
       <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
     </ul>
-  <strong>Untested</strong>:
+  Untested:
     <ul>
       <li>WCAG:AA manual</li>
       <li>Browser support &mdash; automated and manual</li>
@@ -100,12 +100,12 @@ Style guide: Link styles.1 Hover links
   <details data-label="placeholder-link-accessibility" aria-expanded="false">
     <summary>Accessibility &amp; browser testing</summary>
     <div class="accordion-panel">
-    <strong>Passed</strong>:
+    Passed:
       <ul>
         <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
         <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
       </ul>
-    <strong>Untested</strong>:
+    Untested:
       <ul>
         <li>WCAG:AA manual</li>
         <li>Browser support &mdash; automated and manual</li>
@@ -159,12 +159,12 @@ Style guide: Link styles.1 Hover links
   <details data-label="placeholder-links-accessibility" aria-expanded="false">
     <summary>Accessibility &amp; browser testing</summary>
     <div class="accordion-panel">
-    <strong>Passed</strong>:
+    Passed:
       <ul>
         <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
         <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
       </ul>
-    <strong>Untested</strong>:
+    Untested:
       <ul>
         <li>WCAG:AA manual</li>
         <li>Browser support &mdash; automated and manual</li>

--- a/assets/sass/_lists.scss
+++ b/assets/sass/_lists.scss
@@ -20,12 +20,12 @@ Markup: templates/lists-horizontal.hbs
 <details data-label="horizontal-list-styles-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
-  <strong>Passed</strong>:
+  Passed:
     <ul>
       <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
       <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
     </ul>
-  <strong>Untested</strong>:
+  Untested:
     <ul>
       <li>WCAG:AA manual</li>
       <li>Browser support &mdash; automated and manual</li>
@@ -53,12 +53,12 @@ Markup: templates/lists-vertical.hbs
 <details data-label="vertical-list-styles-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
-  <strong>Passed</strong>:
+  Passed:
     <ul>
       <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
       <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
     </ul>
-  <strong>Untested</strong>:
+  Untested:
     <ul>
       <li>WCAG:AA manual</li>
       <li>Browser support &mdash; automated and manual</li>
@@ -79,12 +79,12 @@ Markup: templates/lists-small.hbs
 <details data-label="small-list-styles-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
-  <strong>Passed</strong>:
+  Passed:
     <ul>
       <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
       <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
     </ul>
-  <strong>Untested</strong>:
+  Untested:
     <ul>
       <li>WCAG:AA manual</li>
       <li>Browser support &mdash; automated and manual</li>
@@ -102,14 +102,19 @@ Use highlighted words style for a list with repeating phrases.
 
 Markup: templates/lists-highlighted.hbs
 
-<details data-label="highlighted-list-styles-accessibility" aria-expanded="false">
-  <summary>Accessibility notes</summary>
+<details data-label="small-list-styles-accessibility" aria-expanded="false">
+  <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
-
-    <p>**Passed** HTML5 validation by <a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a><br/>
-    **Passed** WCAG:AA automated by <a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a><br/>
-    **Untested** WCAG:AA manual compliance<br/>
-    **Untested** Supported browsers tested</p>
+  Passed:
+    <ul>
+      <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
+      <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
+    </ul>
+  Untested:
+    <ul>
+      <li>WCAG:AA manual</li>
+      <li>Browser support &mdash; automated and manual</li>
+    </ul>
   </div>
 </details>
 

--- a/assets/sass/_navigation.scss
+++ b/assets/sass/_navigation.scss
@@ -22,12 +22,12 @@ Markup: templates/global-navigation.hbs
 <details data-label="global-nav-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
-  <strong>Passed</strong>:
+  Passed:
     <ul>
       <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
       <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
     </ul>
-  <strong>Untested</strong>:
+  Untested:
     <ul>
       <li>WCAG:AA manual</li>
       <li>Browser support &mdash; automated and manual</li>
@@ -56,12 +56,12 @@ Markup: templates/local-navigation.hbs
 <details data-label="local-nav-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
-  <strong>Passed</strong>:
+  Passed:
     <ul>
       <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
       <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
     </ul>
-  <strong>Untested</strong>:
+  Untested:
     <ul>
       <li>WCAG:AA manual</li>
       <li>Browser support &mdash; automated and manual</li>
@@ -84,12 +84,12 @@ Markup: templates/breadcrumbs.hbs
 <details data-label="breadcrumb-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
-  <strong>Passed</strong>:
+  Passed:
     <ul>
       <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
       <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
     </ul>
-  <strong>Untested</strong>:
+  Untested:
     <ul>
       <li>WCAG:AA manual</li>
       <li>Browser support &mdash; automated and manual</li>
@@ -114,12 +114,12 @@ Markup: templates/index-links.hbs
 <details data-label="index-links-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
-  <strong>Passed</strong>:
+  Passed:
     <ul>
       <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
       <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
     </ul>
-  <strong>Untested</strong>:
+  Untested:
     <ul>
       <li>WCAG:AA manual</li>
       <li>Browser support &mdash; automated and manual</li>
@@ -140,12 +140,12 @@ Markup: templates/inline-links.hbs
 <details data-label="inline-links-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
-  <strong>Passed</strong>:
+  Passed:
     <ul>
       <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
       <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
     </ul>
-  <strong>Untested</strong>:
+  Untested:
     <ul>
       <li>WCAG:AA manual</li>
       <li>Browser support &mdash; automated and manual</li>
@@ -172,12 +172,12 @@ Markup: templates/footer-navigation.hbs
 <details data-label="footer-nav-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
-  <strong>Passed</strong>:
+  Passed:
     <ul>
       <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
       <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
     </ul>
-  <strong>Untested</strong>:
+  Untested:
     <ul>
       <li>WCAG:AA manual</li>
       <li>Browser support &mdash; automated and manual</li>
@@ -555,12 +555,12 @@ Markup: templates/skip-link.hbs
 <details data-label="skip-links-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
-  <strong>Passed</strong>:
+  Passed:
     <ul>
       <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
       <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
     </ul>
-  <strong>Untested</strong>:
+  Untested:
     <ul>
       <li>WCAG:AA manual</li>
       <li>Browser support &mdash; automated and manual</li>
@@ -670,12 +670,12 @@ Markup: templates/groups-links.hbs
 <details data-label="group-links-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
-  <strong>Passed</strong>:
+  Passed:
     <ul>
       <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
       <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
     </ul>
-  <strong>Untested</strong>:
+  Untested:
     <ul>
       <li>WCAG:AA manual</li>
       <li>Browser support &mdash; automated and manual</li>

--- a/assets/sass/_tables.scss
+++ b/assets/sass/_tables.scss
@@ -25,12 +25,12 @@ Markup: templates/table-examples.hbs
 <details data-label="table-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
-  <strong>Passed</strong>:
+  Passed:
     <ul>
       <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
       <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
     </ul>
-  <strong>Untested</strong>:
+  Untested:
     <ul>
       <li>WCAG:AA manual</li>
       <li>Browser support &mdash; automated and manual</li>
@@ -79,12 +79,12 @@ Markup: templates/table-calendar.hbs
 <details data-label="table-calendar-style-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
-  <strong>Passed</strong>:
+  Passed:
     <ul>
       <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
       <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
     </ul>
-  <strong>Untested</strong>:
+  Untested:
     <ul>
       <li>WCAG:AA manual</li>
       <li>Browser support &mdash; automated and manual</li>

--- a/assets/sass/_typography.scss
+++ b/assets/sass/_typography.scss
@@ -443,12 +443,12 @@ Markup: Copy text to clipboard using <kbd>Ctrl</kbd> + <kbd>C</kbd>.
 <details data-label="kbd-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
-  <strong>Passed</strong>:
+  Passed:
     <ul>
       <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
       <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
     </ul>
-  <strong>Untested</strong>:
+  Untested:
     <ul>
       <li>WCAG:AA manual</li>
       <li>Browser support &mdash; automated and manual</li>
@@ -610,12 +610,12 @@ Markup: templates/callouts-examples.hbs
 <details data-label="callouts-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
-  <strong>Passed</strong>:
+  Passed:
     <ul>
       <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
       <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
     </ul>
-  <strong>Untested</strong>:
+  Untested:
     <ul>
       <li>WCAG:AA manual</li>
       <li>Browser support &mdash; automated and manual</li>
@@ -685,12 +685,12 @@ Markup: templates/badges.hbs
 <details data-label="badges-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
-  <strong>Passed</strong>:
+  Passed:
     <ul>
       <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
       <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
     </ul>
-  <strong>Untested</strong>:
+  Untested:
     <ul>
       <li>WCAG:AA manual</li>
       <li>Browser support &mdash; automated and manual</li>
@@ -743,12 +743,12 @@ Markup: templates/quotation-examples.hbs
 <details data-label="blockquote-accessibility" aria-expanded="false">
   <summary>Accessibility &amp; browser testing</summary>
   <div class="accordion-panel">
-  <strong>Passed</strong>:
+  Passed:
     <ul>
       <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
       <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
     </ul>
-  <strong>Untested</strong>:
+  Untested:
     <ul>
       <li>WCAG:AA manual</li>
       <li>Browser support &mdash; automated and manual</li>


### PR DESCRIPTION
## Description

The `strong` tag was causing problems with screenreader use of the a11y accordion.
## Additional information

Also updated 1 of the boxes to the current style, which slipped through.
## Definition of Done
- [ ] Content/documentation reviewed by Julian or someone in the Content Team
- [ ] Code reviewed by one of the core developers
- [x] Acceptance Testing
  - [x] HTML5 validation (CircleCI)
  - [X] Accessibility testing & WCAG2 compliance (`npm test`)
- [ ] Stakeholder/PO review
- [ ] CHANGELOG updated
