### PR TITLE
Fix paths to Guide images

### DIFF
--- a/assets/sass/_grid-layout.scss
+++ b/assets/sass/_grid-layout.scss
@@ -46,7 +46,7 @@ For each new element you will need to set column properties for the breakpoints,
 
 The following diagram shows how the main content area takes up 12 of 16 columns at `$desktop` and above:
 
-![Diagram of the layout across 16 columns](kss-assets/img/img_grid_layout.png)
+![Diagram of the layout across 16 columns](/kss-assets/img/img_grid_layout.png)
 
 For iOS users ensure you set the `viewport` to the `device-width` in your `<head>` to ensure your site is responsive:
 
@@ -100,7 +100,7 @@ main {
 
   Primary content is always contained in 12 columns. This allows for seamless introduction of a sidebar/side navigation.
 
-  ![Diagram of the layout with optional aside nav](kss-assets/img/img_grid_layout_nav.png)
+  ![Diagram of the layout with optional aside nav](/kss-assets/img/img_grid_layout_nav.png)
 
   By default the sidebar sits to the right of the main content. When the sidebar contains content controls (eg filters), instead of navigation, it can sit on the left side. Use the class `.sidebar-has-controls` on the parent `main` element:
 

--- a/assets/sass/templates/lists-horizontal.hbs
+++ b/assets/sass/templates/lists-horizontal.hbs
@@ -39,7 +39,7 @@
   <!-- Hero list item -->
   <li class="hero-item">
     <figure>
-      <img src="kss-assets/img/img-placeholder.gif" alt="example image"/>
+      <img src="/kss-assets/img/img-placeholder.gif" alt="example image"/>
     </figure>
     <article>
       <h3>
@@ -52,7 +52,7 @@
   <!-- List item with an image -->
   <li>
     <figure>
-      <img src="kss-assets/img/img-placeholder.gif" alt="example image" />
+      <img src="/kss-assets/img/img-placeholder.gif" alt="example image" />
     </figure>
     <article>
       <h3>

--- a/assets/sass/templates/lists-vertical.hbs
+++ b/assets/sass/templates/lists-vertical.hbs
@@ -28,7 +28,7 @@
       <p>The Digital Transformation Office (DTO) was established as an executive agency in July 2015. Its mission is to lead the [&hellip;]</p>
     </article>
     <figure>
-      <img src="kss-assets/img/img-placeholder.gif" alt="example image"/>
+      <img src="/kss-assets/img/img-placeholder.gif" alt="example image"/>
     </figure>
   </li>
 </ul>


### PR DESCRIPTION
## Description

Fixes paths to guide images inside `/kss-assets/img` so that they'll load from any example or guide page.

> miles [4:49 PM] @here quick check - broken placeholder images src on the zoo pages http://gov-au-ui-kit-staging.apps.staging.digital.gov.au/examples/zoo.html
## Definition of Done
- [x] Code reviewed by one of the core developers
- [x] Acceptance Testing
  - [x] HTML5 validation (CircleCI)
  - [x] Accessibility testing & WCAG2 compliance (`npm test`)
