### PR TITLE
Change git merge strategy for CHANGELOG.md to reduce conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/CHANGELOG.md merge=union

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 
 - Added guide to [/docs/](https://github.com/AusDTO/gov-au-ui-kit/tree/develop/docs) on installing and using UI Kit via `npm`
 
+#### Bugfixes
+- Change git merge strategy for CHANGELOG.md to reduce conflicts
+
 ### 1.7.6 - 2016-09-01
 
 #### UI-Kit changes


### PR DESCRIPTION
## Description

With `merge=union` set on conflicts for `CHANGELOG.md`, both sides of the conflict will end up in the resulting file.
## Definition of Done
- [x] Code reviewed by one of the core developers
- [x] CHANGELOG updated
