### PR TITLE
Fix for long external links that wrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 #### Bugfixes
 
-- Poor wrapping of links going to external resources (`rel` `external`).
+- Fixes poor wrapping of links that have an icon after them (`%base-link-icon--after)`) thanks to @alecky.
 
 #### Styleguide
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - New styles for accordions used in the primary content area `details`, and when used in widgets or filters `details.accordion--controls`.
 - Added `accordion-styles` mixin for creating alternative accordion styles if required. See `_accordions.scss`.
 
+#### Bugfixes
+
+- Poor wrapping of links going to external resources (`rel` `external`).
+
 #### Styleguide
 
 - Added guide to [/docs/](https://github.com/AusDTO/gov-au-ui-kit/tree/develop/docs) on installing and using UI Kit via `npm`

--- a/assets/sass/_links.scss
+++ b/assets/sass/_links.scss
@@ -42,9 +42,7 @@ Style guide: Link styles.1 Hover links
 %base-link-icon--after {
   content: '';
   position: absolute;
-  display: block;
-  top: 0;
-  right: -($medium-spacing);
+  display: inline;
   width: $medium-spacing;
   height: $medium-spacing;
   background-repeat: no-repeat;
@@ -72,7 +70,7 @@ Style guide: Link styles.1 Hover links
     }
 
     &[rel~='external'] {
-      display: inline-block;
+      display: inline;
       position: relative;
       margin-right: $base-spacing;
 


### PR DESCRIPTION
# Currently if a link that has rel=external is long and wraps the border and icon don't wrap the text.

Set the link and text to inline to fix the problem
