### PR TITLE
Global nav on  iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Bugfixes
 
 - Fixed Vertical lists not displaying correctly in IE7-8
+- Fixes global menu not opening completely on iOS 9 [#365](https://github.com/AusDTO/gov-au-ui-kit/issues/365)
 
 ### 1.8.0 - 2016-09-09
 

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -43,7 +43,7 @@ var paths = {
 
 var options = {
     autoprefixer: {
-        browsers: ['last 2 versions', 'ie 8-10']
+        browsers: ['last 2 versions', 'ie 7-10', 'iOS >= 4']
     },
     sass: {
         functions: {

--- a/assets/sass/components/_lists.scss
+++ b/assets/sass/components/_lists.scss
@@ -83,11 +83,11 @@ Markup: templates/lists-small.hbs
     <ul>
       <li>HTML5 validation (<a href="http://validator.github.io/validator/" rel="external">Nu Html Checker</a>)</li>
       <li>WCAG:AA automated (<a href="http://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/" rel="external">HTML_CodeSniffer</a>)</li>
-      <li>Browser support: Modern browsers and IE7+
     </ul>
   <strong>Untested</strong>:
     <ul>
       <li>WCAG:AA manual</li>
+      <li>Browser support &mdash; automated and manual</li>
     </ul>
   </div>
 </details>

--- a/assets/sass/components/_navigation.scss
+++ b/assets/sass/components/_navigation.scss
@@ -228,13 +228,12 @@ Style guide: Navigation.6 Footer navigation
 
 .global-nav {
   clear: both;
-  padding: $tiny-spacing 0 $small-spacing;
   overflow: hidden;
 
   ul {
     list-style-type: none;
-    margin: $base-spacing 0;
-    padding: 0;
+    margin: 0;
+    padding: $base-spacing 0;
 
     @include media($tablet) {
       @include outer-container;


### PR DESCRIPTION
## Description

Fixes https://github.com/AusDTO/gov-au-ui-kit/issues/365, https://github.com/AusDTO/gov-au-ui-kit/issues/362 & https://github.com/AusDTO/gov-au-ui-kit/issues/351

This PR fixes the layout & behaviour of the Global nav in iOS 4 and above by:
- Adding `box-sizing` support via prefixing
- Removing doubled-up `margin` & `padding` on the `nav` and `ul` elements
### Before (iPhone 4, iOS 4)

![image](https://i.gyazo.com/a22b397372521f234e30ecbffb7340e2.gif)
### After (iPhone 4, iOS 4)

![image](https://i.gyazo.com/757fe8bcaca71f60bd8740c12b6ba294.gif)
### Before (iPhone 6, iOS 9)

![image](https://i.gyazo.com/1309d0fd3372c3da6d39a9be6ed652ae.gif)
### After (iPhone 6, iOS 9)

![image](https://i.gyazo.com/04a47f8059073ae7c604a4640e8559ae.gif)
## Definition of Done
- [x] Content/documentation reviewed by Julian or someone in the Content Team
- [x] UX reviewed by Gary or someone the Design team
- [x] Code reviewed by one of the core developers
- [x] Acceptance Testing
  - [x] [Cross-browser tested against standard browser matrix](https://docs.google.com/spreadsheets/d/1B8pGWSiFbWhurnDISvD2MKnI0IF_T8tU2sl1naZCw1E/edit#gid=1030964576)
  - [x] Tested on multiple devices (TBD)
  - [x] HTML5 validation (CircleCI)
  - [x] Accessibility testing & WCAG2 compliance (`npm test`)
- [x] Stakeholder/PO review
- [x] CHANGELOG updated
