### PR TITLE
Refactor Controls header to remove attribute selectors

### DIFF
--- a/assets/sass/components/_page-header.scss
+++ b/assets/sass/components/_page-header.scss
@@ -1,9 +1,7 @@
-[class^='controls'] {
+%base-controls {
   @include link-colours($link-inverted-colour, $link-inverted-colour, $controls-bg-colour);
-  @include button-colours(transparent, $body-inverted-text-colour, $body-inverted-text-colour, $controls-bg-colour);
 
   padding: $tiny-spacing 0;
-  background-color: $controls-bg-colour;
   color: $body-inverted-text-colour;
 
   section {
@@ -46,16 +44,26 @@
   [role='button'] {
     margin: 0;
   }
+}
 
-  &[class$='--contrast'] {
-    @include button-colours($controls-contrast-bg-colour, $body-inverted-text-colour, $body-inverted-text-colour, $body-inverted-text-colour, $controls-contrast-bg-colour);
+.controls {
+  @extend %base-controls;
 
-    background-color: $controls-contrast-bg-colour;
+  @include button-colours(transparent, $body-inverted-text-colour, $body-inverted-text-colour, $controls-bg-colour);
 
-    [role='button']:hover,
-    [role='button']:focus {
-      color: $controls-contrast-bg-colour;
-    }
+  background-color: $controls-bg-colour;
+}
+
+.controls--contrast {
+  @extend %base-controls;
+
+  @include button-colours($controls-contrast-bg-colour, $body-inverted-text-colour, $body-inverted-text-colour, $body-inverted-text-colour, $controls-contrast-bg-colour);
+
+  background-color: $controls-contrast-bg-colour;
+
+  [role='button']:hover,
+  [role='button']:focus {
+    color: $controls-contrast-bg-colour;
   }
 }
 

--- a/assets/sass/components/templates/controls-navigation.hbs
+++ b/assets/sass/components/templates/controls-navigation.hbs
@@ -1,0 +1,27 @@
+<div class="controls--contrast">
+  <div class="wrapper">
+    <section class="left">
+      <nav class="controls">
+        <p class="inline-links--inverted">
+          <a href="/editorial">Editorial</a>
+          <b>/</b>
+          <a href="/editorial/4">Times and dates</a>
+        </p>
+        <ul class="secondary-controls">
+          <li><a href="/editorial/4/nodes/32">View in editorial</a></li>
+          <li><a href="/editorial/4/nodes/prepare?parent_id=32">New page</a></li>
+          <li><a href="/editorial/news/new?publisher=4">New news article</a></li>
+          <li><a href="/editorial/4/submissions/new?node_id=32">Edit</a></li>
+          <li><a href="/editorial/4/nodes/32/edit">Edit metadata</a></li>
+          <li class="secondary-controls"><a href="/editorial/4/requests/new">Request membership</a></li>
+        </ul>
+      </nav>
+    </section>
+    <section class="right">
+      <ul class="inline-links--inverted">
+        <li><i class="fa-user fa"></i>Alex Sadleir</li>
+        <li><a rel="nofollow" data-method="delete" href="/users/sign_out">Sign out</a></li>
+      </ul>
+    </section>
+  </div>
+</div>

--- a/assets/sass/components/templates/controls-navigation.hbs
+++ b/assets/sass/components/templates/controls-navigation.hbs
@@ -19,7 +19,7 @@
     </section>
     <section class="right">
       <ul class="inline-links--inverted">
-        <li><i class="fa-user fa"></i>Alex Sadleir</li>
+        <li><i class="fa-user fa"></i> Willy Wonka</li>
         <li><a rel="nofollow" data-method="delete" href="/users/sign_out">Sign out</a></li>
       </ul>
     </section>

--- a/examples/zoo.hbs
+++ b/examples/zoo.hbs
@@ -95,6 +95,7 @@
     {{> local-navigation}}
     {{> table-examples}}
     {{> buttons-examples}}
+    {{> controls-navigation}}
     {{> global-navigation}}
     {{> list-examples }}
     {{> quotation-examples }}


### PR DESCRIPTION
## Description

The `contrast` variant of the `.controls` header bar was using two nested attribute selectors, making it unnecessarily specific. This PR:
- Adds a `%base-controls` placeholder for all the common `controls` styles
- Replaces attribute selectors with classnames for clarity
### Before

```
[class^=‘controls'][class$='--contrast’] { background-color: $controls-contrast-bg-colour; }
```
### After

```
.controls { @extend %base-controls... }
.controls--contrast { @extend %base-controls... }
```
## Definition of Done
- [ ] Content/documentation reviewed by Julian or someone in the Content Team
- [ ] UX reviewed by Gary or someone the Design team
- [x] Code reviewed by one of the core developers
- [x] Acceptance Testing
  - [x] [Cross-browser tested against standard browser matrix](https://docs.google.com/spreadsheets/d/1B8pGWSiFbWhurnDISvD2MKnI0IF_T8tU2sl1naZCw1E/edit#gid=1030964576)
  - [x] Tested on multiple devices (TBD)
  - [x] HTML5 validation (CircleCI)
  - [x] Accessibility testing & WCAG2 compliance (`npm test`)
- [ ] Stakeholder/PO review
- [ ] CHANGELOG updated
