### PR TITLE
Remove letter spacing from the header

### DIFF
--- a/assets/sass/components/_page-header.scss
+++ b/assets/sass/components/_page-header.scss
@@ -119,7 +119,6 @@
     color: $body-inverted-text-colour;
     font-family: $base-sans-serif;
     text-transform: uppercase;
-    letter-spacing: 2px;
   }
 
   [class^='badge'] {
@@ -209,7 +208,6 @@
     color: $body-inverted-text-colour;
     font-family: $base-sans-serif;
     text-transform: uppercase;
-    letter-spacing: 2px;
   }
 
   [class^='badge'] {


### PR DESCRIPTION
# Remove letter spacing from the header
## Description

This branch removes letter spacing from the title in the page header.
Currently, the 2px spacing between each letter makes page titles a bit odd, and harder to read.
## Additional information

Before:
<img width="309" alt="before" src="https://cloud.githubusercontent.com/assets/71922/19421699/db830e1e-9452-11e6-9348-845bca269f5a.png">

After:
<img width="305" alt="after" src="https://cloud.githubusercontent.com/assets/71922/19421701/dd59b7c4-9452-11e6-81d5-2fb34b63a446.png">
## Definition of Done
- [ ] Content/documentation reviewed by Julian or someone in the Content Team
- [ ] UX reviewed by Gary or someone the Design team
- [ ] Code reviewed by one of the core developers
- [ ] Acceptance Testing
  - [ ] [Cross-browser tested against standard browser matrix](https://docs.google.com/spreadsheets/d/1B8pGWSiFbWhurnDISvD2MKnI0IF_T8tU2sl1naZCw1E/edit#gid=1030964576)
  - [ ] Tested on multiple devices (TBD)
  - [ ] HTML5 validation (CircleCI)
  - [ ] Accessibility testing & WCAG2 compliance (`npm test`)
- [ ] Stakeholder/PO review
- [ ] CHANGELOG updated
