### PR TITLE
Removes 1px maroon main:after bottom-border.

### DIFF
--- a/assets/sass/utils/_mixins.scss
+++ b/assets/sass/utils/_mixins.scss
@@ -49,6 +49,5 @@ $is-ie: false !default;
     display: table;
     clear: both;
     height: 0;
-    border: 1px solid $maroon;
   }
 }


### PR DESCRIPTION
## Description

Not inc. in changelog b/c it was introduced in `develop` (iirc). 
## Definition of Done
- [x] Code reviewed by one of the core developers
- [x] Acceptance Testing
  - [x] [Cross-browser tested against standard browser matrix](https://docs.google.com/spreadsheets/d/1B8pGWSiFbWhurnDISvD2MKnI0IF_T8tU2sl1naZCw1E/edit#gid=1030964576)
  - [x] HTML5 validation (CircleCI)
  - [x] Accessibility testing & WCAG2 compliance (`npm test`)
