### PR TITLE
Site title banner rm upcase leterspacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,13 @@
 
 #### Styleguide
 
+- Renamed the design guide website to *DTO Design Guide & UI-Kit*.
 - Renamed complete example page to 'all' (`/examples/all.html`).
 - Update name of Slack channel from `#govau-uikit`/`#govau-guides` to `#guides-uikit`
+
+#### UI-Kit changes
+
+- Changes current uppercase site title topbar to be set-case and removes `letter-spacing`.
 
 ### 1.8.0 - 2016-09-09
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GOV.AU UI-Kit
+# Getting started
 
 ![CircleCI build status](https://circleci.com/gh/AusDTO/gov-au-ui-kit.svg?style=shield) ![MIT license](https://img.shields.io/badge/license-MIT-brightgreen.svg) ![Current Release](https://img.shields.io/github/release/AusDTO/gov-au-ui-kit.svg?maxAge=2592000)
 

--- a/assets/sass/components/_page-header.scss
+++ b/assets/sass/components/_page-header.scss
@@ -113,13 +113,10 @@
 
   .logo {
     font-size: rem(24);
-    font-weight: $heading-font-weight;
     padding-bottom: 2px;
     border-bottom: 0;
     color: $body-inverted-text-colour;
     font-family: $base-sans-serif;
-    text-transform: uppercase;
-    letter-spacing: 2px;
   }
 
   [class^='badge'] {
@@ -203,13 +200,10 @@
 
   .logo {
     font-size: rem(24);
-    font-weight: $heading-font-weight;
     padding-bottom: 2px;
     border-bottom: 0;
     color: $body-inverted-text-colour;
     font-family: $base-sans-serif;
-    text-transform: uppercase;
-    letter-spacing: 2px;
   }
 
   [class^='badge'] {

--- a/kss-builder/builder.js
+++ b/kss-builder/builder.js
@@ -54,8 +54,8 @@ class KssBuilderHandlebars extends KssBuilderBaseHandlebars {
                 group: 'Style guide:',
                 string: true,
                 multiple: false,
-                describe: 'Title of the style guide',
-                default: 'GOV.AU UI-Kit'
+                describe: 'Design guidance and documentation of the UI-Kit',
+                default: 'DTO Design Guide & UI-Kit'
             }
         });
     }

--- a/kss-builder/index.hbs
+++ b/kss-builder/index.hbs
@@ -62,7 +62,7 @@
   <section class="govau--header">
     <div class="wrapper">
       <div class="govau--logo">
-        <a href="/" class="logo">gov.au ui-kit</a> <span class="badge--default">draft</span>
+        <a href="/" class="logo">DTO Design Guide &amp; UI-Kit</a> <span class="badge--default">draft</span>
       </div>
       <div class="feedback">
         <a href="https://github.com/AusDTO/gov-au-ui-kit/issues/new" class="button--feedback" role="button">Give feedback</a>


### PR DESCRIPTION
## Description

Possibly controversial, but also renames the guide output title from _GOV.AU UI-KIT_ to _DTO Design Guide & UI-Kit_.

Otherwise removes the `text-transform: uppercase` and `letter-spacing` from the topbar site title logo text as suggested by Jordan: https://github.com/AusDTO/gov-au-ui-kit/pull/411
## Definition of Done
- [x] Content/documentation reviewed by Julian or someone in the Content Team
- [x] UX reviewed by Gary or someone the Design team
- [x] Code reviewed by one of the core developers
- [x] Acceptance Testing
  - [x] HTML5 validation (CircleCI)
  - [x] Accessibility testing & WCAG2 compliance (`npm test`)
- [x] Stakeholder/PO review
- [x] CHANGELOG updated
