### PR TITLE
Formats all component hbs markup to a max char length of 80.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 #### Styleguide
 
 - Renamed complete example page to 'all' (`/examples/all.html`).
+- Reformatted component example `.hbs` files to a max line character length of 80.
 - Update name of Slack channel from `#govau-uikit`/`#govau-guides` to `#guides-uikit`
 
 ### 1.8.0 - 2016-09-09

--- a/assets/sass/components/templates/badges.hbs
+++ b/assets/sass/components/templates/badges.hbs
@@ -1,4 +1,7 @@
-<p>A badge can appear inline with a text element <span class="badge--default">in-progress</span></p>
+<p>
+  A badge can appear inline with a text element 
+  <span class="badge--default">in-progress</span>
+</p>
 <span class="badge--alpha">alpha</span>
 <span class="badge--beta">beta</span>
 <span class="badge--error">error</span>

--- a/assets/sass/components/templates/basic-links.hbs
+++ b/assets/sass/components/templates/basic-links.hbs
@@ -1,4 +1,6 @@
 <ul>
   <li><a href="#">This is a basic link.</a></li>
-  <li><a href="https://www.dto.gov.au" rel="external">This link points to an external resource.</a></li>
+  <li><a href="https://www.dto.gov.au" rel="external">
+    This link points to an external resource.</a>
+  </li>
 </ul>

--- a/assets/sass/components/templates/calendar-callout-example.hbs
+++ b/assets/sass/components/templates/calendar-callout-example.hbs
@@ -1,4 +1,6 @@
 <section class="callout--calendar-event">
   <h3 class="next-event">The next public holiday is:</h3>
-  <p><time datetime="2016-12-25T02:30:00+00:00">Sunday 25 December</time> <span class="event-name">Christmas day</span></p>
+  <p>
+    <time datetime="2016-12-25T02:30:00+00:00">Sunday 25 December</time> 
+    <span class="event-name">Christmas day</span></p>
 </section>

--- a/assets/sass/components/templates/callouts-examples.hbs
+++ b/assets/sass/components/templates/callouts-examples.hbs
@@ -4,5 +4,7 @@
 
 <div class="callout--calendar-event">
   <span class="next-event">The next public holiday is:</span>
-  <p><time datetime="2017-01-01T00:00:00+00:00">Sunday 1 January</time> <span class="event-name">New Year's Day</span></p>
+  <p><time datetime="2017-01-01T00:00:00+00:00">Sunday 1 January</time> 
+    <span class="event-name">New Year's Day</span>
+  </p>
 </div>

--- a/assets/sass/components/templates/content-accordion.hbs
+++ b/assets/sass/components/templates/content-accordion.hbs
@@ -1,7 +1,9 @@
 <details open data-label="content-accordion-1-example" aria-expanded="true">
   <summary>1. Understand user needs</summary>
   <div class="accordion-panel">
-    <p>Understand user needs. Research to develop a deep knowledge of the users and their context for the service.</p>
+    <p>Understand user needs. Research to develop a deep knowledge of the users 
+      and their context for the service.
+    </p>
   </div>
 </details>
 
@@ -9,7 +11,9 @@
   <summary>2. Have a multi-disciplinary team</summary>
   <div class="accordion-panel">
 
-    <p>Establish a sustainable multi-disciplinary team to design, build, operate and iterate the service, led by an experienced product manager with decision-making responsibility.</p>
-
+    <p>Establish a sustainable multi-disciplinary team to design, build, 
+      operate and iterate the service, led by an experienced product manager 
+      with decision-making responsibility.
+    </p>
   </div>
 </details>

--- a/assets/sass/components/templates/content-full-width.hbs
+++ b/assets/sass/components/templates/content-full-width.hbs
@@ -1,8 +1,13 @@
 <p>
-  This paragraph will automatically wrap to a readable line length, which is usually estimated to be 65 characters (2.5 times the Roman alphabet). This can vary based on other factors, such as type face and size.
+  This paragraph will automatically wrap to a readable line length, which is 
+  usually estimated to be 65 characters (2.5 times the Roman alphabet). This 
+  can vary based on other factors, such as type face and size.
 </p>
 <p class="content-full-width">
-  This paragraph will span the full width of the main content area, which represents 12 of 16 total columns, about 900px at the maximum layout size. This can be useful when including an inline image which you'd like to appear at full-width.
+  This paragraph will span the full width of the main content area, which 
+  represents 12 of 16 total columns, about 900px at the maximum layout size. 
+  This can be useful when including an inline image which you'd like to appear 
+  at full-width.
 </p>
 <p class="content-full-width">
   <img src="http://placehold.it/900x150" alt="Demonstration image" />

--- a/assets/sass/components/templates/controls-accordion.hbs
+++ b/assets/sass/components/templates/controls-accordion.hbs
@@ -1,4 +1,5 @@
-<details class="accordion--controls" data-label="accordion-controls-example" aria-expanded="true" open>
+<details class="accordion--controls" data-label="accordion-controls-example" 
+  aria-expanded="true" open>
   <summary>What are you interested in?</summary>
   <div class="accordion-panel">
     <form>

--- a/assets/sass/components/templates/footer-navigation.hbs
+++ b/assets/sass/components/templates/footer-navigation.hbs
@@ -26,7 +26,8 @@
     </section>
     <section>
       <div class="footer-logo">
-        <img alt="Australian Government Coat of Arms" src="/latest/img/coat-of-arms.png">
+        <img alt="Australian Government Coat of Arms" 
+          src="/latest/img/coat-of-arms.png">
       </div>
       <div class="footer-links">
         <nav>
@@ -36,7 +37,8 @@
           </ul>
         </nav>
         <p>&copy; Commonwealth of Australia <br>
-        <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE.md" rel="external license">Licensed under the MIT License.</a></p>
+        <a href="https://github.com/AusDTO/gov-au-ui-kit/blob/master/LICENSE.md"
+           rel="external license">Licensed under the MIT License.</a></p>
       </div>
     </section>
     </div>

--- a/assets/sass/components/templates/global-navigation.hbs
+++ b/assets/sass/components/templates/global-navigation.hbs
@@ -1,7 +1,8 @@
 <section class="govau--header">
   <div class="wrapper">
     <div class="govau--logo">
-      <a href="/" class="logo">gov.au</a> <span class="badge--default">draft</span>
+      <a href="/" class="logo">gov.au</a> 
+      <span class="badge--default">draft</span>
     </div>
     <nav class="global-nav" aria-label="global navigation">
       <ul>

--- a/assets/sass/components/templates/inline-tab-nav.hbs
+++ b/assets/sass/components/templates/inline-tab-nav.hbs
@@ -27,7 +27,9 @@
     <li><a href="#"><span class="is-visuallyhidden">Sort by </span>Qld</a></li>
     <li><a href="#"><span class="is-visuallyhidden">Sort by </span>SA</a></li>
     <li><a href="#"><span class="is-visuallyhidden">Sort by </span>WA</a></li>
-    <li><a href="#" class="is-active"><span class="is-visuallyhidden">Sort by </span>Tas.</a></li>
+    <li><a href="#" class="is-active"><span class="is-visuallyhidden">
+      Sort by </span>Tas.</a>
+    </li>
     <li><a href="#"><span class="is-visuallyhidden">Sort by  </span>NT</a></li>
     <li><a href="#"><span class="is-visuallyhidden">Sort by  </span>ACT</a></li>
   </ul>

--- a/assets/sass/components/templates/lists-horizontal.hbs
+++ b/assets/sass/components/templates/lists-horizontal.hbs
@@ -7,7 +7,9 @@
           <a href="#">List item</a>
         </h3>
 
-        <p>The Digital Transformation Office (DTO) was established as an executive agency in July 2015. Its mission is to lead the [&hellip;]</p>
+        <p>The Digital Transformation Office (DTO) was established as an 
+          executive agency in July 2015. Its mission is to lead the [&hellip;]
+        </p>
 
       </article>
     </li>
@@ -20,10 +22,13 @@
         </h3>
 
         <div class="meta">
-          <time datetime="2016-05-08 00:00">08 May 2016</time> <a href="#" rel="author">Author</a>
+          <time datetime="2016-05-08 00:00">08 May 2016</time> 
+          <a href="#" rel="author">Author</a>
         </div>
 
-        <p>The Digital Transformation Office (DTO) was established as an executive agency in July 2015. Its mission is to lead the [&hellip;]</p>
+        <p>The Digital Transformation Office (DTO) was established as an 
+          executive agency in July 2015. Its mission is to lead the [&hellip;]
+        </p>
 
         <footer class="tags">
           <dl>
@@ -45,7 +50,9 @@
       <h3>
         <a href="#">List item &mdash; with hero image</a>
       </h3>
-      <p>The Digital Transformation Office (DTO) was established as an executive agency in July 2015. Its mission is to lead the [&hellip;]</p>
+      <p>The Digital Transformation Office (DTO) was established as an 
+        executive agency in July 2015. Its mission is to lead the [&hellip;]
+      </p>
     </article>
   </li>
 
@@ -62,7 +69,9 @@
         <time datetime="2016-05-08 00:00">08 May 2016</time>
         <a href="#" rel="author">Author</a>
       </div>
-      <p>The Digital Transformation Office (DTO) was established as an executive agency in July 2015. Its mission is to lead the [&hellip;]</p>
+      <p>The Digital Transformation Office (DTO) was established as an 
+        executive agency in July 2015. Its mission is to lead the [&hellip;]
+      </p>
 
       <footer class="tags">
         <dl>
@@ -89,7 +98,9 @@
         <a href="#" rel="author">Author</a>
       </div>
 
-      <p>The Digital Transformation Office (DTO) was established as an executive agency in July 2015. Its mission is to lead the [&hellip;]</p>
+      <p>The Digital Transformation Office (DTO) was established as an 
+        executive agency in July 2015. Its mission is to lead the [&hellip;]
+      </p>
 
       <footer class="tags">
         <dl>

--- a/assets/sass/components/templates/lists-vertical.hbs
+++ b/assets/sass/components/templates/lists-vertical.hbs
@@ -8,10 +8,13 @@
       </h3>
 
       <div class="meta">
-        <time datetime="2016-05-08 00:00">08 May 2016</time> <a href="#" rel="author">Author</a>
+        <time datetime="2016-05-08 00:00">08 May 2016</time> 
+        <a href="#" rel="author">Author</a>
       </div>
 
-      <p>The Digital Transformation Office (DTO) was established as an executive agency in July 2015. Its mission is to lead the [&hellip;]</p>
+      <p>The Digital Transformation Office (DTO) was established as an 
+        executive agency in July 2015. Its mission is to lead the [&hellip;]
+      </p>
     </article>
   </li>
 
@@ -22,10 +25,13 @@
       </h3>
 
       <div class="meta">
-        <time datetime="2016-05-08 00:00">08 May 2016</time> <a href="#" rel="author">Author</a>
+        <time datetime="2016-05-08 00:00">08 May 2016</time> 
+        <a href="#" rel="author">Author</a>
       </div>
 
-      <p>The Digital Transformation Office (DTO) was established as an executive agency in July 2015. Its mission is to lead the [&hellip;]</p>
+      <p>The Digital Transformation Office (DTO) was established as an 
+        executive agency in July 2015. Its mission is to lead the [&hellip;]
+      </p>
     </article>
     <figure>
       <img src="/kss-assets/img/img-placeholder.gif" alt="example image"/>
@@ -41,7 +47,9 @@
       <h3>
         <a href="#">List item</a>
       </h3>
-      <p>The Digital Transformation Office (DTO) was established as an executive agency in July 2015. Its mission is to lead the [&hellip;]</p>
+      <p>The Digital Transformation Office (DTO) was established as an 
+        executive agency in July 2015. Its mission is to lead the [&hellip;]
+      </p>
     </article>
   </li>
   <li>
@@ -49,7 +57,9 @@
       <h3>
         <a href="#">List item</a>
       </h3>
-      <p>The Digital Transformation Office (DTO) was established as an executive agency in July 2015. Its mission is to lead the [&hellip;]</p>
+      <p>The Digital Transformation Office (DTO) was established as an 
+        executive agency in July 2015. Its mission is to lead the [&hellip;]
+      </p>
     </article>
   </li>
   <li>
@@ -57,7 +67,9 @@
       <h3>
         <a href="#">List item</a>
       </h3>
-      <p>The Digital Transformation Office (DTO) was established as an executive agency in July 2015. Its mission is to lead the [&hellip;]</p>
+      <p>The Digital Transformation Office (DTO) was established as an 
+        executive agency in July 2015. Its mission is to lead the [&hellip;]
+      </p>
     </article>
   </li>
 </ul>
@@ -70,7 +82,9 @@
       <h3>
         <a href="#">List item</a>
       </h3>
-      <p>The Digital Transformation Office (DTO) was established as an executive agency in July 2015. Its mission is to lead the [&hellip;]</p>
+      <p>The Digital Transformation Office (DTO) was established as an 
+        executive agency in July 2015. Its mission is to lead the [&hellip;]
+      </p>
     </article>
   </li>
   <li>

--- a/assets/sass/components/templates/local-navigation.hbs
+++ b/assets/sass/components/templates/local-navigation.hbs
@@ -2,7 +2,9 @@
   <h1 class="is-visuallyhidden">Menu</h1>
   <ul>
     <li>
-      <a href="#" class="is-active">Department of Communications and the Arts</a>
+      <a href="#" class="is-active">
+        Department of Communications and the Arts
+      </a>
       <ul>
         <li>
           <a href="#" class="is-active">People and structure</a>
@@ -11,7 +13,9 @@
             <li>
               <a href="#" class="is-active">Division name</a>
               <ul>
-                <li><a href="#" class="is-active is-current">Branch name</a></li>
+                <li><a href="#" class="is-active is-current">
+                  Branch name</a>
+                </li>
                 <li><a href="#">Branch name</a></li>
               </ul>
             </li>

--- a/assets/sass/components/templates/quotation-examples.hbs
+++ b/assets/sass/components/templates/quotation-examples.hbs
@@ -1,8 +1,12 @@
 <p>An <q>in-line quote</q> using <code>q</code>.</p>
 
-<blockquote><p>A standard block quote using <code>blockquote</code>.</p></blockquote>
+<blockquote>
+  <p>A standard block quote using <code>blockquote</code>.</p>
+</blockquote>
 
-<blockquote class="pullquote"><p>An editorial block quote (pull quote)</p></blockquote>
+<blockquote class="pullquote">
+  <p>An editorial block quote (pull quote)</p>
+</blockquote>
 
 <blockquote>
   <p>A blockquote containing:</p>

--- a/assets/sass/components/templates/tab-style-nav.hbs
+++ b/assets/sass/components/templates/tab-style-nav.hbs
@@ -27,7 +27,9 @@
     <li><a href="#"><span class="is-visuallyhidden">Sort by </span>Qld</a></li>
     <li><a href="#"><span class="is-visuallyhidden">Sort by </span>SA</a></li>
     <li><a href="#"><span class="is-visuallyhidden">Sort by </span>WA</a></li>
-    <li><a href="#" class="is-current"><span class="is-visuallyhidden">Sort by </span>Tas.</a></li>
+    <li><a href="#" class="is-current"><span class="is-visuallyhidden">
+      Sort by </span>Tas.</a>
+    </li>
     <li><a href="#"><span class="is-visuallyhidden">Sort by  </span>NT</a></li>
     <li><a href="#"><span class="is-visuallyhidden">Sort by  </span>ACT</a></li>
   </ul>

--- a/assets/sass/components/templates/table-calendar.hbs
+++ b/assets/sass/components/templates/table-calendar.hbs
@@ -1,15 +1,24 @@
 <table class="calendar-table">
   <caption>New South Wales public holidays, January 2017</caption>
   <tr>
-    <th scope="row"><time datetime="2017-01-01">Sunday <span>1</span> January</time></th>
+    <th scope="row">
+      <time datetime="2017-01-01">Sunday <span>1</span> January</time>
+    </th>
     <td>New Year's Day</td>
   </tr>
   <tr>
-    <th scope="row"><time datetime="2017-01-02">Monday <span>2</span> January</time></th>
-    <td>New Year's Day holiday<span class="date-info">The Holiday Act provides for an extra public holiday to be added when New Year's Day falls on a weekend.</span></td>
+    <th scope="row">
+      <time datetime="2017-01-02">Monday <span>2</span> January</time>
+    </th>
+    <td>New Year's Day holiday<span class="date-info">The Holiday Act provides 
+      for an extra public holiday to be added when New Year's Day falls on a 
+      weekend.</span>
+    </td>
   </tr>
   <tr>
-    <th scope="row"><time datetime="2017-01-26">Thursday <span>26</span> January</time></th>
+    <th scope="row">
+      <time datetime="2017-01-26">Thursday <span>26</span> January</time>
+    </th>
     <td>Australia Day</td>
   </tr>
 </table>

--- a/assets/sass/components/templates/table-examples.hbs
+++ b/assets/sass/components/templates/table-examples.hbs
@@ -1,5 +1,7 @@
 <table class="content-table">
-  <caption>Population of Australian states and territories, December 2015</caption>
+  <caption>
+    Population of Australian states and territories, December 2015
+  </caption>
   <thead>
     <tr>
       <th scope="col">Location</th>


### PR DESCRIPTION
## Description

Formatting changes to our example markup for each component such that there’s a max of 80 chars per line. This is largely to make reading source files a bit easier, and to improve the readability of the `pre` formatted markup examples within the guide (less side scrolling, hopefully).

Only holds formatting edits; no markup itself was altered..
## Additional information
- Relevant research and support documents
- Screen shot images
- Notes
- etc.
## Definition of Done
- [x] Code reviewed by one of the core developers
- [x] Acceptance Testing
  - [x] HTML5 validation (CircleCI)
  - [x] Accessibility testing & WCAG2 compliance (`npm test`)
- [x] Stakeholder/PO review
- [x] CHANGELOG updated
