### PR TITLE
Changes unofficial docs to call the repo via https instead of ssh.

### DIFF
--- a/docs/how-dashboards-include-the-uikit.md
+++ b/docs/how-dashboards-include-the-uikit.md
@@ -6,13 +6,13 @@ We did this by installing the module as an npm and including parts as granularly
 
 ## Installation steps
 
-Install GOV.AU UI-Kit as an npm from the tag release:
+Install GOV.AU UI-Kit as an npm from the tag release (substitute `1.8` for latest release tag):
 
 `package.json`:
 
 ```json
 deps: {
-  "gov-au-ui-kit": "git@github.com:AusDTO/gov-au-ui-kit.git#1.7.4",
+  "gov-au-ui-kit": "https://github.com/AusDTO/gov-au-ui-kit.git#1.8",
 }
 ```
 

--- a/docs/including-uikit-via-npm.md
+++ b/docs/including-uikit-via-npm.md
@@ -6,13 +6,12 @@ Simple guide for installing UI-Kit via npm for use with `webpack` or any build p
 
 Find the latest release at: [gov-au-ui-kit/releases](https://github.com/AusDTO/gov-au-ui-kit/releases)
 
-Install via npm (substitute `1.7.6` for latest release tag):
+Install via npm (substitute `1.8` for latest release tag):
 ```bash
-$ npm install https://github.com/AusDTO/gov-au-ui-kit.git#1.7.6
+$ npm install https://github.com/AusDTO/gov-au-ui-kit.git#1.8
 ```
 
 #### Configuring `node-sass`:
-
 
 `node-sass` exposes an option for [includePaths](https://github.com/sass/node-sass#includepaths), you want to provide the absolute path to `node_modules` to `node-sass`.
 


### PR DESCRIPTION
## Description

Docs on consuming UI-Kit should be cloning the repo via HTTPS, not via ssh (`git@`…).

Thanks to @dlm78.

Should fix #416.
## Definition of Done
- [x] Code reviewed by one of the core developers
- [x] Stakeholder/PO review
