### PR TITLE
Applies font-size 1em to complex content items within table tds.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@
 
 ### `develop` - (unreleased)
 
+#### Large changes
+
+- Moved font sizing declarations to `body`, rather than applying them to `ul`, `ol`, `p`, `dt`, `dd`, etc. directly. This should avoid the need to apply `font-size: 1em` resets for nested content, eg a `p` or `ul` > `li` inside a `table` > `td`.
+
 #### Bugfixes
 
-- Fixes font sizing when placing content elements inside a `table`’s `td`.
 - Changes `.inline-nav` to `.inline-tab-nav` as actually documented.
 - Fixed Vertical lists not displaying correctly in IE7-8.
 - Fixes global menu not opening completely on iOS 9 [#365](https://github.com/AusDTO/gov-au-ui-kit/issues/365).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Bugfixes
 
+- Fixes font sizing when placing content elements inside a `table`’s `td`.
 - Changes `.inline-nav` to `.inline-tab-nav` as actually documented.
 - Fixed Vertical lists not displaying correctly in IE7-8.
 - Fixes global menu not opening completely on iOS 9 [#365](https://github.com/AusDTO/gov-au-ui-kit/issues/365).

--- a/assets/sass/components/_navigation.scss
+++ b/assets/sass/components/_navigation.scss
@@ -376,6 +376,7 @@ Style guide: Navigation.6 Footer navigation
         ul {
           a {
             @extend %icon-arrow-right;
+            
             padding-left: $base-spacing + $small-spacing;
             background-repeat: no-repeat;
             background-position: $base-spacing center;
@@ -445,6 +446,7 @@ Style guide: Navigation.6 Footer navigation
     ul {
       margin: 0;
       display: none;
+      
       @include media($tablet) {
         margin: inherit;
         display: block;
@@ -471,6 +473,7 @@ Style guide: Navigation.6 Footer navigation
 
 [class^='breadcrumbs'] {
   @include link-colours($link-colour, $link-colour--hover);
+  
   display: none;
   width: 100%;
   margin: 0;
@@ -495,6 +498,7 @@ Style guide: Navigation.6 Footer navigation
 
       &:not(:last-child) {
         @extend %icon-arrow-right;
+        
         margin-right: $small-spacing;
         padding-right: $medium-spacing;
         background-repeat: no-repeat;
@@ -506,12 +510,14 @@ Style guide: Navigation.6 Footer navigation
 
   &[class$='--inverted'] {
     @include link-colours($link-inverted-colour, $link-inverted-colour--hover, $link-colour);
+    
     background-color: transparent;
     color: $body-inverted-text-colour;
 
     ul {
       li:not(:last-child) {
         @extend %icon-arrow-right--white;
+        
         color: $body-inverted-text-colour;
       }
     }
@@ -561,6 +567,7 @@ Style guide: Navigation.7 Skip links
 
 .skip-to {
   @include link-colours($link-colour, $link-colour--hover);
+  
   position: relative;
   z-index: 99;
 
@@ -687,6 +694,7 @@ Style guide: Navigation.8 Group of links
 
     li {
       @include span-columns(4);
+      
       float: left;
       margin-top: 0.5em;
 

--- a/assets/sass/components/_tables.scss
+++ b/assets/sass/components/_tables.scss
@@ -68,22 +68,6 @@ table {
   thead {
     border-bottom: solid 2px $grey;
   }
-
-  ul,
-  ol,
-  li,
-  dl,
-  p,
-  dt,
-  dd {
-    font-size: 1em;
-  }
-
-  ul,
-  ol,
-  dl {
-    margin-top: $small-spacing;
-  }
 }
 
 /*

--- a/assets/sass/components/_tables.scss
+++ b/assets/sass/components/_tables.scss
@@ -57,7 +57,6 @@ table {
   th {
     border-bottom: solid 1px $light-grey;
     padding: $tiny-spacing;
-    font-size: $small-font-size;
     text-align: left;
 
     @include media($tablet) {
@@ -68,6 +67,22 @@ table {
 
   thead {
     border-bottom: solid 2px $grey;
+  }
+
+  ul,
+  ol,
+  li,
+  dl,
+  p,
+  dt,
+  dd {
+    font-size: 1em;
+  }
+
+  ul,
+  ol,
+  dl {
+    margin-top: $small-spacing;
   }
 }
 

--- a/assets/sass/components/_typography.scss
+++ b/assets/sass/components/_typography.scss
@@ -101,6 +101,14 @@ html {
   font-weight: $base-font-weight;
 }
 
+body {
+  font-size: rem(16);
+
+  @include media($tablet) {
+    font-size: rem(17);
+  }
+}
+
 /*
 Headings & body copy
 
@@ -550,14 +558,9 @@ dl,
 p,
 dt,
 dd {
-  font-size: rem(16);
   margin-top: 0; // Check up on where margin-top is coming from...
   margin-bottom: $medium-spacing;
   line-height: $base-spacing;
-
-  @include media($tablet) {
-    font-size: rem(17);
-  }
 }
 
 li {


### PR DESCRIPTION
## Description

Applies @TrebBrennan’s fix from #417. I played around with the font sizing — applying font-sizing via the Bourbon `rem()` does not override the specificity set, so using `1em`.

Should fix for #417.
## Definition of Done
- [x] Code reviewed by one of the core developers
- [x] Acceptance Testing
  - [x] HTML5 validation (CircleCI)
- [x] Stakeholder/PO review
- [x] CHANGELOG updated
