### PR TITLE
Bugfix/main padding top mbl fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Adds a new gulp task (`styleguide.data`) which outputs a JSON file of all the SA
 
 #### Bugfixes
 
+- `main` now receives the same `padding-top` at mobile sizes that it received at tablet+ sizes (fix for content hugging the top of `main`/the page `header`).
 - Changes `.inline-nav` to `.inline-tab-nav` as actually documented.
 - Fixed Vertical lists not displaying correctly in IE7-8.
 - Fixes global menu not opening completely on iOS 9 [#365](https://github.com/AusDTO/gov-au-ui-kit/issues/365).

--- a/assets/sass/components/_grid-layout.scss
+++ b/assets/sass/components/_grid-layout.scss
@@ -1,5 +1,6 @@
 @mixin wrapper-padding {
   @include pad(0 $gutter);
+
   width: 100%;
   box-sizing: border-box;
 
@@ -92,9 +93,7 @@ main {
   @include wrapper-padding;
   @include outer-container;
 
-  @include media($tablet) {
-    padding-top: $base-spacing * 2;
-  }
+  padding-top: $base-spacing * 2;
 
   @include ie-lte(8) {
     @include ie-clearfix;
@@ -167,9 +166,7 @@ main {
       }
 
       &:first-child {
-
         @include reset-layout-direction;
-
         @include fill-parent;
         @include shift(0);
 
@@ -194,6 +191,7 @@ main {
 
       @include media($tablet) {
         @include span-columns(4 of 12);
+
         margin-left: 0;
       }
 
@@ -237,6 +235,7 @@ footer {
   &[role='contentinfo'] {
     @include outer-container(100%);
     @include pad(0 default);
+
     margin-top: ($base-spacing * 2);
     min-width: 100%;
   }


### PR DESCRIPTION
## Description

`main` now receives the same `padding-top` at mobile sizes that it received at tablet+ sizes (fix for content hugging the top of `main`/the page `header`).

I first spotted this affecting the mygov alpha, and again just in implementing the uikit again for another site.
## Additional information

Before:
![screen shot 2016-10-20 at 5 09 05 pm](https://cloud.githubusercontent.com/assets/52766/19548090/0a31e9e6-96e8-11e6-959b-d3865b174b78.png)

After:
![screen shot 2016-10-20 at 5 08 50 pm](https://cloud.githubusercontent.com/assets/52766/19548096/10670a80-96e8-11e6-97f9-445b4aa8bb61.png)
## Definition of Done
- [x] UX reviewed by Gary or someone the Design team
- [x] Code reviewed by one of the core developers
- [x] Acceptance Testing
  - [x] HTML5 validation (CircleCI)
- [x] Stakeholder/PO review
- [x] CHANGELOG updated
