### PR TITLE
Adds to footer: ie-clearfix, spacing, center of items in mbl view.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### `develop` - (unreleased)
 
+#### UI-Kit changes
+
+- Footer improvements:
+  - adds `ie-clearfix` mixin
+  - improves margins when footer link `ul`s collapse in mobile–tablet views and footer crest margins
+  - centers image and copyright footer content in mobile view.
+- `.lede` has been added, synonymous with `.abstract`, accessible on block elements (not `p` tags).
+
+### 1.9 - 2016-11-07
+
 #### Large changes
 
 - Moved font sizing declarations to `body`, rather than applying them to `ul`, `ol`, `p`, `dt`, `dd`, etc. directly. This should avoid the need to apply `font-size: 1em` resets for nested content, eg a `p` or `ul` > `li` inside a `table` > `td`.

--- a/assets/sass/components/_page-footer.scss
+++ b/assets/sass/components/_page-footer.scss
@@ -1,5 +1,6 @@
 footer[role='contentinfo'] {
-  @include pad(( $base-spacing * 2 ) 0);
+  @include pad($base-spacing 0);
+  @include ie-clearfix;
 
   background-color: $non-white;
   border-top: 6px solid $border-contrast-colour;
@@ -35,14 +36,28 @@ footer[role='contentinfo'] {
       @include span-columns(3 of 12);
     }
 
+    margin-bottom: $base-spacing * 2;
+
     img {
       max-height: 7em; //was $base-spacing * 4;
+      display: block;
+      margin: 0 auto;
+
+      @include media($tablet) {
+        margin: 0;
+      }
     }
   }
 
   .footer-links {
+    text-align: center;
+    margin: 0 auto;
+
     @include media($tablet) {
       @include span-columns(9 of 12);
+
+      margin: 0;
+      text-align: left;
     }
 
     ul {


### PR DESCRIPTION
## Description

[These are fixes made in the dta website repo, brought over into uikit]

Adds:

- calls `ie-clearfix` mixin in the footer
- improves margins and paddings, predominately for mbl <-> tablet views, mainly for the `ul`s and the footer crest image.
- centers items in mbl view; align left in tablet and above

## Definition of Done

- [x] Code reviewed by one of the core developers
- [x] Acceptance Testing
  - [x] [Cross-browser tested against standard browser matrix](https://docs.google.com/spreadsheets/d/1B8pGWSiFbWhurnDISvD2MKnI0IF_T8tU2sl1naZCw1E/edit#gid=1030964576)
- [x] Stakeholder/PO review
- [x] CHANGELOG updated

