### PR TITLE
Adds site nav item active styling, colour change, and fixes wrong colour docs hex value

### DIFF
--- a/assets/sass/components/_site-nav.scss
+++ b/assets/sass/components/_site-nav.scss
@@ -105,13 +105,10 @@ $site-nav-toggle-width: 40%;
       font-weight: $bold-font-weight;
       font-size: $site-nav-type-size;
 
+      &:hover,
       &.is-active {
-        border-color: $site-nav-border-colour--hover;
-        color: $link-colour;
-      }
-
-      &:hover {
         background-color: $site-nav-item-colour--hover;
+        color: $link-colour;
       }
 
       @include media($tablet) {

--- a/assets/sass/components/_site-nav.scss
+++ b/assets/sass/components/_site-nav.scss
@@ -16,7 +16,7 @@ $site-nav-type-size: rem(16);
 $site-nav-border-width: 2px;
 $site-nav-border-colour: $border-colour;
 $site-nav-border-colour--hover: $border-highlight-colour;
-$site-nav-item-colour--hover: $lighter-aqua;
+$site-nav-item-colour--hover: $aqua;
 $site-nav-toggle-width: 40%;
 
 .site-nav {
@@ -104,6 +104,11 @@ $site-nav-toggle-width: 40%;
       padding: $medium-spacing 0;
       font-weight: $bold-font-weight;
       font-size: $site-nav-type-size;
+
+      &.is-active {
+        border-color: $site-nav-border-colour--hover;
+        color: $link-colour;
+      }
 
       &:hover {
         background-color: $site-nav-item-colour--hover;

--- a/assets/sass/utils/_colours.scss
+++ b/assets/sass/utils/_colours.scss
@@ -65,7 +65,7 @@ Lighter and darker versions are percentage variations of the original colours (S
   <div class="guide-colour">
     <div class="swatch bg-lighter-aqua"></div>
     <p class="text"><strong>Lighter-aqua</strong><br/>
-      <small>$lighter-aqua<br/> #5BCBE3</small></p>
+      <small>$lighter-aqua<br/> #DEF4F9</small></p>
   </div>
 
   <div class="guide-colour">


### PR DESCRIPTION
## Description

Changes colour for the site-nav item hovers to `$aqua` and adds an `.active` state (same as hover).

Also fixes the hex colour value for `$lighter-aqua` in the in-line documentation for the colours — may need to replicate in the design guide repo (ew).

## Definition of Done

- [ ] Content/documentation reviewed by Julian or someone in the Content Team
- [ ] UX reviewed by Gary or someone the Design team
- [ ] Code reviewed by one of the core developers
- [ ] Acceptance Testing
  - [ ] [Cross-browser tested against standard browser matrix](https://docs.google.com/spreadsheets/d/1B8pGWSiFbWhurnDISvD2MKnI0IF_T8tU2sl1naZCw1E/edit#gid=1030964576)
  - [ ] Tested on multiple devices (TBD)
  - [x] HTML5 validation (CircleCI)
  - [x] Accessibility testing & WCAG2 compliance (`npm test`)
- [ ] Stakeholder/PO review
- [ ] CHANGELOG updated
