### PR TITLE
refactor radio and checkbox icons to use floats rather than position …

### DIFF
--- a/assets/sass/components/_forms.scss
+++ b/assets/sass/components/_forms.scss
@@ -114,22 +114,22 @@ form {
 
       + label {
         display: inline-block;
+        float: left;
         margin-bottom: 8px;
-        padding: 15px 0 15px 60px;
-        position: relative;
+        padding: 15px 0 15px 0;
         width: 100%;
 
         @include media($tablet) {
-          padding: 12px 0 12px 60px;
+          padding: 12px 0 12px 0;
         }
 
         &::before {
           display: inline-block;
+          float: left;
           height: 27px;
-          position: absolute;
           text-align: center;
-          top: 13px;
           width: 27px;
+          margin-right: $tiny-spacing;
 
           @include media($tablet) {
             top: 9px;
@@ -181,12 +181,13 @@ form {
         border: 1px solid transparent;
         border-radius: 50%;
         content: '';
-        left: 23px;
-        top: 18px;
-        position: absolute;
+        float: left;
+        margin-left: -28px;
+        margin-top: 5px;
 
         @include media($tablet) {
           top: 14px;
+          margin-left: -29px;
         }
       }
     }
@@ -201,12 +202,8 @@ Style guide: Forms & buttons.05 Checkbox input
 */
   input[type='checkbox'] + label {
     &::before {
-      left: 20px;
       border: 2px solid $body-text-colour;
       content: '';
-      @include media($tablet) {
-        top: 9px;
-      }
     }
   }
 
@@ -225,13 +222,9 @@ Style guide: Forms & buttons.05 Checkbox input
         background-color: $body-text-colour;
         border: 1px solid transparent;
         content: '';
-        left: 25px;
-        top: 18px;
-        position: absolute;
-
-        @include media($tablet) {
-          top: 14px;
-        }
+        float: left;
+        margin-left: -29px;
+        margin-top: 5px;
       }
     }
   }

--- a/assets/sass/components/_forms.scss
+++ b/assets/sass/components/_forms.scss
@@ -53,10 +53,21 @@ form {
     border: none;
   }
 
+  legend {
+    margin-bottom: $small-spacing;
+  }
+
+  // klepas cleaned up the spacing vars a bit... just don't scroll further down.
   label {
     display: block;
-    margin-bottom: $tiny-spacing;
-    margin-top: $tiny-spacing;
+    margin-top: ($small-spacing + $tiny-spacing);
+    margin-bottom: ($small-spacing + $tiny-spacing);
+    margin-left: $small-spacing;
+
+    @include media($tablet) {
+      margin-top: $small-spacing;
+      margin-bottom: $small-spacing;
+    }
   }
 
   .hint {
@@ -94,7 +105,8 @@ form {
       @extend %base-input;
 
       height: 1px;
-      // hide the native widget but keep it in the tab order
+      // Hide the native widget but keep it in the tab order
+      // For 2.x we should burn this with fire. Lots of fire.
       left: -10000px;
       position: absolute;
       visibility: visible;
@@ -115,21 +127,16 @@ form {
       + label {
         display: inline-block;
         float: left;
-        margin-bottom: 8px;
-        padding: 15px 0 15px 0;
         width: 100%;
-
-        @include media($tablet) {
-          padding: 12px 0 12px 0;
-        }
 
         &::before {
           display: inline-block;
           float: left;
+          // These magic numbers need to be blitzed in 2.x
           height: 27px;
-          text-align: center;
           width: 27px;
-          margin-right: $tiny-spacing;
+          text-align: center;
+          margin-right: 14px;
 
           @include media($tablet) {
             top: 9px;
@@ -182,12 +189,12 @@ form {
         border-radius: 50%;
         content: '';
         float: left;
-        margin-left: -28px;
+        // More magic numbers...
+        margin-left: -36px;
         margin-top: 5px;
 
         @include media($tablet) {
           top: 14px;
-          margin-left: -29px;
         }
       }
     }
@@ -223,7 +230,7 @@ Style guide: Forms & buttons.05 Checkbox input
         border: 1px solid transparent;
         content: '';
         float: left;
-        margin-left: -29px;
+        margin-left: -36px;
         margin-top: 5px;
       }
     }


### PR DESCRIPTION
# Bugfix - Fix screen reader compatibility with radio and checkbox inputs

## Description

A DTA Identity project identified that the UI Kit checkbox/radio labels were not being read out by a screen reader. I replicated this issue using [VoiceOver on MacOSX 10.10.5](https://www.apple.com/voiceover/info/guide/) 

The screen reader currently just reads 'Checkbox checked/un-checked' so the user has no idea what the value of the input they are selecting is.

The cause of this issue was the use of `position: relative` on the `<label>` element.

## Proposal

This PR proposes replacing css `position` properties on the `<label>` element with `float: left` and negative margin. Using negative margins isn't great - is there a better way?

## Additional information

I tested the Checkbox and Radio inputs on gov.uk and they have the same issue. If we find a nice solution we could send a PR to the gov.uk style guide.

## Definition of Done

- [ ] Content/documentation reviewed by Julian or someone in the Content Team
- [x] UX reviewed by Gary or someone the Design team
- [x] Code reviewed by one of the core developers
- [x] Acceptance Testing
  - [x] [Cross-browser tested against standard browser matrix](https://docs.google.com/spreadsheets/d/1B8pGWSiFbWhurnDISvD2MKnI0IF_T8tU2sl1naZCw1E/edit#gid=1030964576)
  - [x] Tested on multiple devices (TBD)
  - [x] HTML5 validation (CircleCI)
  - [x] Accessibility testing & WCAG2 compliance (`npm test`)
- [x] Stakeholder/PO review
- [ ] CHANGELOG updated
