### PR TITLE
Updates checkbox & radio button markup to cater for VoiceOver skipping a fieldset’s legend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ UI-Kit has grown up a bit more -- we now have an official URL! Check it out at h
 #### Bugfixes
 
 - Fixed an obscure issue in Chrome when using a screen reader where `label`s in forms were rudely not being read out. As a consequence those labels are now being positioned using floats (oh you Chrome, [you so random](https://www.youtube.com/watch?v=ggB33d0BLcY)). While at it, the radio buttons and checkboxes decided to improve their distribution of whitespace a bit too. Thanks to @simonschwartz.
-- It appears Apple’s VoiceOver has a hard time reading out the `legend` in a `form`, so after testing we updated some of the form markup snippets to explicitly demo linking a `fieldset`’s `legend` with an `input` (don’t worry: we also feel a bit disgusted that this might mean having to add extra `id`s). As ever, this is a good reminder that we need to make proper use of `aria-describedby` in either this approach or the use of [hint text](http://localhost:4000/components/forms-buttons/index.html#hint-text).
+- It appears Apple’s VoiceOver has a hard time reading out the `legend` in a `form`, so after testing we updated some of the form markup snippets to explicitly demo linking a `fieldset`’s `legend` with an `input` (don’t worry: we also feel a bit disgusted that this might mean having to add extra `id`s). As ever, this is a good reminder that we need to make proper use of `aria-describedby` in either this approach or the use of [hint text](http://guides.service.gov.au/design-guide/components/forms-buttons/index.html#hint-text).
 
 #### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ UI-Kit has grown up a bit more -- we now have an official URL! Check it out at h
 #### Bugfixes
 
 - Fixed an obscure issue in Chrome when using a screen reader where `label`s in forms were rudely not being read out. As a consequence those labels are now being positioned using floats (oh you Chrome, [you so random](https://www.youtube.com/watch?v=ggB33d0BLcY)). While at it, the radio buttons and checkboxes decided to improve their distribution of whitespace a bit too. Thanks to @simonschwartz.
+- It appears Apple’s VoiceOver has a hard time reading out the `legend` in a `form`, so after testing we updated some of the form markup snippets to explicitly demo linking a `fieldset`’s `legend` with an `input` (don’t worry: we also feel a bit disgusted that this might mean having to add extra `id`s). As ever, this is a good reminder that we need to make proper use of `aria-describedby` in either this approach or the use of [hint text](http://localhost:4000/components/forms-buttons/index.html#hint-text).
 
 #### Breaking changes
 

--- a/assets/sass/components/_forms.scss
+++ b/assets/sass/components/_forms.scss
@@ -62,7 +62,6 @@ form {
     display: block;
     margin-top: ($small-spacing + $tiny-spacing);
     margin-bottom: ($small-spacing + $tiny-spacing);
-    margin-left: $small-spacing;
 
     @include media($tablet) {
       margin-top: $small-spacing;
@@ -128,6 +127,7 @@ form {
         display: inline-block;
         float: left;
         width: 100%;
+        margin-left: $small-spacing;
 
         &::before {
           display: inline-block;

--- a/assets/sass/components/templates/checkbox-input.html
+++ b/assets/sass/components/templates/checkbox-input.html
@@ -1,13 +1,13 @@
 <form>
   <fieldset>
-    <legend>Which electronic devices do you own?</legend>
-    <input id="phone" name="reply" type="checkbox" value="phone"/>
+    <legend id="q-devices-owned">Which electronic devices do you own?</legend>
+    <input id="phone" name="reply" type="checkbox" aria-describedby="q-devices-owned" value="phone"/>
     <label for="phone">Phone</label>
-    <input id="tablet" name="reply" type="checkbox" value="tablet"/>
+    <input id="tablet" name="reply" type="checkbox" aria-describedby="q-devices-owned" value="tablet"/>
     <label for="tablet">Tablet</label>
-    <input id="laptop" name="reply" type="checkbox" value="laptop"/>
+    <input id="laptop" name="reply" type="checkbox" aria-describedby="q-devices-owned" value="laptop"/>
     <label for="laptop">Laptop</label>
-    <input id="desktop" name="reply" type="checkbox" value="desktop"/>
+    <input id="desktop" name="reply" type="checkbox" aria-describedby="q-devices-owned" value="desktop"/>
     <label for="desktop">Desktop computer</label>
   </fieldset>
 </form>

--- a/assets/sass/components/templates/radio-button-input.html
+++ b/assets/sass/components/templates/radio-button-input.html
@@ -1,9 +1,9 @@
 <form>
   <fieldset>
-    <legend>Would you like us to phone you?</legend>
-    <input id="yes" name="reply" type="radio" value="Yes"/>
+    <legend id="q-phone-you">Would you like us to phone you?</legend>
+    <input id="yes" name="reply" type="radio" aria-describedby="q-phone-you" value="Yes"/>
     <label for="yes">Yes</label>
-    <input id="no" name="reply" type="radio" value="No"/>
+    <input id="no" name="reply" type="radio" aria-describedby="q-phone-you" value="No"/>
     <label for="no">No</label>
   </fieldset>
 </form>


### PR DESCRIPTION
## Description

During testing of https://github.com/AusDTO/gov-au-ui-kit/pull/456 we discovered that [VoiceOver historically seems have poor support for `legend`](http://pauljadam.com/demos/voiceover-ios-html-aria-support.html), and while it now seems to handle them in Safari, it fails in other browsers tested on Mac OS X (latest Firefox and Chrome).

After some discussion I propose we make these edits to the example markup. They don’t break anything, and it’s a bit icky that we’re adding extra `id`s just to do this, but the value we add to VoiceOver users is immense (well, providing back basic functionality that this VoiceOver bug otherwise robs).

## Additional information

This PR also fixes a minor `margin-left` bug on the `label`s that was introduced in the last merge.

I’ve added [a PR to the design guide that just adds a small note to the guidance section for radios and checkboxes respectively](https://github.com/AusDTO/dto-design-guide/pull/123), reminding implementers to use ARIA tags, just like we issue in the [hint text](http://guides.service.gov.au/design-guide/components/forms-buttons/index.html#hint-text) section at the bottom of the *Forms & buttons* page.

I did have the idea of maybe uniting the guidance on ARIA tags in some capacity, thinking there’d be value in an implementer having all the ARIA info somewhere, so that we minimise the chances of them missing one of these two sections when intending to implement a form `fieldset`, but I guess it’s impossible to try to anticipate all the various browser–screen reader combinations and how they handle whatever implementation is made…

… case in point: https://www.powermapper.com/tests/screen-readers/labelling/ (look at the various combos and their support for `fieldset`).

## Definition of Done

- [ ] Code reviewed by one of the core developers
- [x] Acceptance Testing
  - [x] [Cross-browser tested against standard browser matrix](https://docs.google.com/spreadsheets/d/1B8pGWSiFbWhurnDISvD2MKnI0IF_T8tU2sl1naZCw1E/edit#gid=1030964576)
  - [x] Tested on multiple devices (TBD)
  - [x] HTML5 validation (CircleCI)
  - [x] Accessibility testing & WCAG2 compliance (`npm test`)
- [ ] Stakeholder/PO review
- [x] CHANGELOG updated
