### PR TITLE
Input group style and examples

### DIFF
--- a/assets/sass/components/_buttons.scss
+++ b/assets/sass/components/_buttons.scss
@@ -91,3 +91,60 @@ button,
     }
   }
 }
+
+/*
+
+input groups
+
+HTML EXAMPLES
+
+Standard input group using button element
+
+ <div class="input-group">
+   <input  maxlength="128"  placeholder="Type search term here" title="Search" type="text" value="" />
+   <button>Search</button>
+ </div>
+
+Standard input group using input[type='button']
+
+<div class="input-group">
+  <input maxlength="128" placeholder="Type search term here" title="Search" type="text" value="" />
+  <input class="form-submit" type="submit" value="Search" />
+</div>
+
+Reverse input group using button element
+
+<div class="input-group reverse">
+   <input  maxlength="128"  placeholder="Type search term here" title="Search" type="text" value="" />
+   <button>Search</button>
+</div>
+
+Reverse input group using input[type='button']
+
+<div class="input-group reverse">
+  <input maxlength="128" placeholder="Type search term here" title="Search" type="text" value="" />
+  <input class="form-submit" type="submit" value="Search" />
+</div>
+
+*/
+
+.input-group {
+  display: flex;
+
+  %base-button {
+    margin: 0;
+  }
+
+  // The default HTML structure is button or [type='button'] element to the right
+  > :nth-child(1) {
+    border-right: 0;
+  }
+}
+
+// button or [type='button'] to the left (reverse HTML structure)
+.input-group.reverse  {
+
+  > :nth-child(2) {
+    border-left: 0;
+  }
+}


### PR DESCRIPTION
## Description

a pattern which makes it easy for designers, developers and publishers to construct input / button combination structures across their site. 

## Additional information

* single class in surrounding container
* default button to the right
* reverse class for button to the left
* removes margining and appropriate border

Seeks to address - https://github.com/AusDTO/gov-au-ui-kit/issues/460

<img width="421" alt="screen shot 2017-01-11 at 3 03 38 pm" src="https://cloud.githubusercontent.com/assets/14192426/21835494/8f2b4b28-d811-11e6-873d-6c96a20130ed.png">

## Definition of Done

- [ ] Content/documentation reviewed by Julian or someone in the Content Team
- [ ] UX reviewed by Gary or someone the Design team
- [ ] Code reviewed by on(https://docs.google.com/spreadsheets/d/1B8pGWSiFbWhurnDISvD2MKnI0IF_T8tU2sl1naZCw1E/edit#gid=1030964576)e of the core developers
- [ ] Acceptance Testing
  - [ ] [Cross-browser tested against standard browser matrix]
  - [ ] Tested on multiple devices (TBD)
  - [ ] HTML5 validation (CircleCI)
  - [ ] Accessibility testing & WCAG2 compliance (`npm test`)
- [ ] Stakeholder/PO review
- [ ] CHANGELOG updated
