### PR TITLE
Updates to the browser support md doc.

### DIFF
--- a/BROWSER-SUPPORT.md
+++ b/BROWSER-SUPPORT.md
@@ -35,7 +35,7 @@ All browsers listed are latest stable release, except Internet Explorer.
 
 ## Unsupported browsers
 
-We list commonly used browsers and devices and their rough test status. We don’t list unsupported devices and browsers.
+We list commonly used browsers and devices and their rough test status. Other combinations may be supported but have not been extensively tested.
 
 We are aiming for a solid HTML mobile-first foundation that provides functional support for the browsers and devices of all of our users.
 

--- a/BROWSER-SUPPORT.md
+++ b/BROWSER-SUPPORT.md
@@ -4,9 +4,7 @@ The UI-Kit team needs to support all of our users, regardless of their device, w
 
 Equal access to information about laws and government programs is a legal requirement under the <a href="https://www.legislation.gov.au/Latest/C2016C00763" rel="external">Disability Discrimination Act (1992)</a>.
 
-The support levels will be revised when needed to better meet user needs.
-
-We initially defined these levels using analytics data from various major \*.gov.au sites.
+This document has drawn on analytics data from various major \*.gov.au sites.
 
 ## Mobile browsers
 
@@ -26,18 +24,18 @@ Minimum version based on [support for CSS Flexible Box layout modules](http://ca
 |-------------------|---------------|-------------|
 | Chrome            | Windows, OS X | Tested      |
 | Firefox           | Windows, OS X | Tested      |
-| Safari            | OS X          | Untested    |
+| Safari            | OS X          | Tested      |
 | Opera             | Windows, OS X | Untested    |
 | Yandex            | Windows, OS X | Untested    |
-| Edge              | Windows       | Untested    |
-| IE 10 & newer            | Windows       | Tested      |
+| Edge              | Windows       | Tested      |
+| IE 10 & newer     | Windows       | Tested      |
 | IE 9 & older      | Windows       | Tested &mdash; functional support only  |
 
 All browsers listed are latest stable release, except Internet Explorer.
 
 ## Unsupported browsers
 
-We don’t list unsupported devices and browsers.
+We list commonly used browsers and devices and their rough test status. We don’t list unsupported devices and browsers.
 
 We are aiming for a solid HTML mobile-first foundation that provides functional support for the browsers and devices of all of our users.
 
@@ -67,8 +65,3 @@ We define ‘support’ as:
 
 - making things usable before they go live
 - improving and fixing issues found in production environments.
-
-We didn’t use a decision tree because:
-
-- we can identify fully supported browsers and devices
-- all other browsers and devices need graduated support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ UI-Kit has grown up a bit more -- we now have an official URL! Check it out at h
 - Most of the guidance previously sitting in the SASS partials have gracefully uprooted and migrated themselves into the new [Design Guide repository](https://github.com/AusDTO/dto-design-guide/), stored now in Markdown. They like their new home.
 - The images loaded as content in the guide have also joined their friends in the new Design Guide repository.
 - The English text in some of the markup examples have received some further tlc.
+- Our [browser support document](https://github.com/AusDTO/gov-au-ui-kit/blob/develop/BROWSER-SUPPORT.md) was out of date. It’s been simplified a bit more, and updated to reflect testing conducted end-2016.
 
 #### New goodies
 


### PR DESCRIPTION
## Description

Updates the browser doc page:

- Removes line re. updating when user needs change (because we should be doing that anyway)
- Changes the line that the browser support levels were drawn from the analytics data (not quite right) to note that this doc has drawn on that data generally.
- Updates the test status of mobile and desktop browser tables
- Adds a line that we list common browsers/devices and their test status, but not *unsupported devices* (there was some prev. confusion over the tablets being the ‘supported’ ones, and then saying we don’t list the supported/unsupported seemed confusing).
- Removes the snippet at the end re. the decision for us not to pursue a browser decision tree (something the BBC came up with). This has caused confusion (what is a browser decision tree?), esp. since we don’t link to one; removing. 

This PR seeks to address https://github.com/AusDTO/gov-au-ui-kit/issues/431, at least in part.

## Question…

I think it’s important to move some of this data over into the design guide website. Thoughts?

## Definition of Done

- [x] Content/documentation reviewed by Julian or someone in the Content Team
- [x] Reviewed by one of the core developers
- [x] CHANGELOG updated
