### PR TITLE
Add some heading helper classes

### DIFF
--- a/assets/sass/components/_typography.scss
+++ b/assets/sass/components/_typography.scss
@@ -81,16 +81,21 @@ Style guide: Typography.3 Body copy
 // Note that we style h5 and h6 are identical to h4.
 
 h1,
+.h1,
 h2,
+.h2,
 h3,
-h4 {
+.h3,
+h4,
+.h4 {
   line-height: $base-heading-leading;
   font-weight: $base-font-weight;
   margin-bottom: $tiny-spacing;
   margin-top: $base-spacing;
 }
 
-h1 {
+h1,
+.h1 {
   font-size: rem(24);
   font-weight: $bold-font-weight;
   margin-bottom: $small-spacing;
@@ -127,11 +132,13 @@ h1 {
   }
 }
 
-h2 {
+h2,
+.h2 {
   @include h2;
 }
 
-h3 {
+h3,
+.h3 {
   font-size: rem(24);
   font-weight: $heading-font-weight;
   margin-top: $medium-spacing + ($small-spacing / 3); // 38.133px; was 34.4px from Alz.
@@ -147,8 +154,11 @@ h3 {
 }
 
 h4,
+.h4,
 h5,
-h6 {
+.h5,
+h6,
+.h6 {
   font-size: rem(18);
   font-weight: $heading-font-weight;
 


### PR DESCRIPTION
## Description

This adds some helper functionality to headings. Don't you hate when someone says 'make that heading a h4', but to be semantic and accessible, it has to stay a `<h3>`. Well, these helpers let you have the best of both worlds. It can be a h3, but *look* like a h4.


## Additional information

- It may be more useful in non-application uses, such as authors entering content into a CMS. However, it can be useful within a web application too.
- It breaks the guideline of 'don't name things based on appearance', and could probably be done using alternative class names. However, it is useful to keep consistency within your site.
- It could easily be abused. `<p class="h2">My heading</p>` could be a nasty result of using this badly. Some clear guidance will need to be included in the Design Guide.
- It is useful in circumstances where the space available to headings is narrow and the default headings look to big. Here's a prominent [example](https://www.humanservices.gov.au/customer/contact-us) where we use it in the wild.
- I was initially unconvinced this was a good idea, but it is something we use only when needed with great success.

## Definition of Done

- [ ] Content/documentation reviewed by Julian or someone in the Content Team
- [ ] UX reviewed by Gary or someone the Design team
- [ ] Code reviewed by one of the core developers
- [ ] Acceptance Testing
  - [ ] [Cross-browser tested against standard browser matrix](https://docs.google.com/spreadsheets/d/1B8pGWSiFbWhurnDISvD2MKnI0IF_T8tU2sl1naZCw1E/edit#gid=1030964576)
  - [ ] Tested on multiple devices (TBD)
  - [ ] HTML5 validation (CircleCI)
  - [ ] Accessibility testing & WCAG2 compliance (`npm test`)
- [ ] Stakeholder/PO review
- [ ] CHANGELOG updated
