### PR TITLE
Feature edit: removes quote marks from blockquotes and q

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## UI Kit "Kraken"
 
+### `develop`
+
+#### Changes
+
+- We removed the quotation marks around block quotations (`blockquote`) as well as the inline quotation element (`q`). While the quote marks knew they were pretty they realised they might be in conflict with user-entered quotation marks.
+
 ### 1.11.0 - 2017-01-16
 
 UI-Kit has grown up a bit more -- we now have an official URL! Check it out at http://guides.service.gov.au/design-guide/

--- a/assets/sass/components/_typography.scss
+++ b/assets/sass/components/_typography.scss
@@ -545,10 +545,10 @@ Style guide: Typography.5 Quotations
 
 blockquote {
   margin: $medium-spacing 0;
-  padding: $small-spacing ($base-spacing + $small-spacing);
+  padding: $base-spacing ($base-spacing + $small-spacing) $tiny-spacing;
   background-color: $background-secondary-colour;
   font-family: $base-serif;
-  quotes: '\201C''\201D''\2018''\2019';
+  quotes: none;
 
   &.pullquote {
     padding: 0;
@@ -559,48 +559,19 @@ blockquote {
       line-height: $base-leading;
       text-align: center;
       font-weight: $base-font-weight;
-      margin-top: $base-spacing;
+      margin-top: $medium-spacing;
 
       @include media($tablet) {
         font-size: rem(26);
       }
     }
-
-    // Support: IE7 does not properly support pseudo elements `:before`/`:after`: http://caniuse.com/#feat=css-sel2
-
-    &::before,
-    &::after {
-      text-align: center;
-      margin: 0;
-    }
-  }
-
-  &::before,
-  &::after {
-    display: block;
-    height: 0;
-    font-family: $base-serif;
-    font-size: rem(43);
-    color: $aqua;
-  }
-
-  &::before {
-    margin-left: -($small-spacing * 0.75);
-    padding-bottom: $tiny-spacing;
-    content: open-quote;
-  }
-
-  &::after {
-    margin-right: -($small-spacing * 0.75);
-    margin-top: -($small-spacing);
-    padding-bottom: $medium-spacing;
-    text-align: right;
-    content: close-quote;
   }
 
   footer {
+    display: block;
     margin-top: $medium-spacing;
-    padding-top: $tiny-spacing;
+    padding-top: $small-spacing;
+    padding-bottom: $small-spacing;
     border-top: 1px solid $light-grey;
   }
 
@@ -627,8 +598,7 @@ blockquote {
 }
 
 q {
-  // Investigate: switching to html entities?
-  quotes: '“' '”' '‘' '’' '“' '”' '‘' '’';
+  // quotes: '“' '”' '‘' '’' '“' '”' '‘' '’';
 }
 
 cite {


### PR DESCRIPTION
## Description

Removes the quotation marks inserted via `:before`/`:after` from `blockquote` and `q`, `quotes: none`, and then re-balances the vertical and horizontal spacing. 

## Additional information

Screenshots of testing:

![screen shot 2017-03-06 at 11 51 58 am](https://cloud.githubusercontent.com/assets/52766/23593510/ffb6251c-0263-11e7-971e-3bf009deae41.png)

![screen shot 2017-03-06 at 11 52 05 am](https://cloud.githubusercontent.com/assets/52766/23593513/04e7cfa4-0264-11e7-8c6b-4c6719c4e976.png)

![screen shot 2017-03-06 at 11 52 14 am](https://cloud.githubusercontent.com/assets/52766/23593516/07aaf45a-0264-11e7-98ff-c6526a5a7ad5.png)

![screen shot 2017-03-06 at 11 52 21 am](https://cloud.githubusercontent.com/assets/52766/23593517/09caa1cc-0264-11e7-9828-71812a75c20f.png)

## Definition of Done

- [x] Content/documentation reviewed by Julian or someone in the Content Team
- [ ] UX reviewed by Gary or someone the Design team
- [x] Code reviewed by one of the core developers
- [ ] Acceptance Testing
  - [ ] [Cross-browser tested against standard browser matrix](https://docs.google.com/spreadsheets/d/1B8pGWSiFbWhurnDISvD2MKnI0IF_T8tU2sl1naZCw1E/edit#gid=1030964576)
  - [ ] Tested on multiple devices (TBD)
  - [x] HTML5 validation (CircleCI)
  - [x] Accessibility testing & WCAG2 compliance (`npm test`)
- [ ] Stakeholder/PO review
- [x] CHANGELOG updated
